### PR TITLE
feat: optimize Schema runtime, modernize VL 2025.7 builds, and improve ArtNet output

### DIFF
--- a/Main/gamma/Schema_Lite.props
+++ b/Main/gamma/Schema_Lite.props
@@ -11,6 +11,6 @@
     <ApplicationIcon>$(MsBuildThisFileDirectory)Assets\Logos\scenic-tools-schema.ico</ApplicationIcon>
     <VLIgnoreCompileErrors>False</VLIgnoreCompileErrors>
     <VLIgnoreUnhandledExceptions>False</VLIgnoreUnhandledExceptions>
-    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/Main/gamma/Schema_Lite.props
+++ b/Main/gamma/Schema_Lite.props
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VLAssetBehavior>PointToOutput</VLAssetBehavior>
+    <VLAssetBehavior>RelativeToOutput</VLAssetBehavior>
     <VLCleanBuildDirectory>True</VLCleanBuildDirectory>
-    <VLExportPath>$(MsBuildThisFileDirectory)..\Exports</VLExportPath>
+    <VLExportPath>$(MsBuildThisFileDirectory)..\Exports\Schema</VLExportPath>
     <VLTargetOS>Linux</VLTargetOS>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>$(MsBuildThisFileDirectory)Assets\Logos\scenic-tools-schema.ico</ApplicationIcon>
+    <VLIgnoreCompileErrors>False</VLIgnoreCompileErrors>
+    <VLIgnoreUnhandledExceptions>False</VLIgnoreUnhandledExceptions>
+    <RuntimeIdentifier>linux-arm</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/Main/gamma/Schema_Lite.vl
+++ b/Main/gamma/Schema_Lite.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="M1TGnrU41z8PVVlccSWS3R" LanguageVersion="2024.6.2" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="M1TGnrU41z8PVVlccSWS3R" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory" />
     <!--
@@ -14,7 +14,7 @@
       </p:NodeReference>
       <Patch Id="OjCe3WTRNvMMfpypOYLR2Y">
         <Canvas Id="JGR4jnQZJpfOS7Q1TqLU1P" CanvasType="Group">
-          <Node Bounds="376,553,223,212" Id="NT0ByjyjEjYMGYbOo2ti9m">
+          <Node Bounds="376,553,268,306" Id="NT0ByjyjEjYMGYbOo2ti9m">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -68,7 +68,9 @@
                     <Pin Id="FXUElVn23U1NaSrs0KtzF6" Name="Input" Kind="InputPin" />
                     <Pin Id="JBtDMXBDrQkM64koBH1QN2" Name="Output" Kind="OutputPin" />
                   </Node>
+                  <Patch Id="VvtoCait07yM9w6O0JlCr0" Name="Dispose" />
                 </Patch>
+                <Pin Id="ScG7JqqKVdhOCU1ROU1I1L" Name="Warn" Kind="InputPin" />
               </Node>
               <Node Bounds="470,726,55,19" Id="GACsbksMduWN1ie9fGnuBn">
                 <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
@@ -77,6 +79,44 @@
                 </p:NodeReference>
                 <Pin Id="PngurFqwGQQNharJGl40qv" Name="Message" Kind="InputPin" />
                 <Pin Id="DJXvBEZdkPnOhVMEANLSND" Name="Apply" Kind="InputPin" />
+              </Node>
+              <Node Bounds="547,731,85,19" Id="AWgtSB2XSSYLIJlCC30BFl">
+                <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Counter" />
+                </p:NodeReference>
+                <Pin Id="L2GH4UMbicQOGd9aPvfnN3" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="ArXo4K2y21KQLpgoWB8YR7" Name="Increment" Kind="InputPin" />
+                <Pin Id="N8X38M7fjpTL83zzIrmhcd" Name="Default" Kind="InputPin" />
+                <Pin Id="HVdMEZP0cTVMqm9a2RVGyA" Name="Up" Kind="ApplyPin" />
+                <Pin Id="ScF7j0bOBRpMxyGeKmn3Fs" Name="Down" Kind="ApplyPin" />
+                <Pin Id="IHfbLIJc1zvP7kAge2bL6s" Name="Reset" Kind="ApplyPin" />
+                <Pin Id="EGLGKndem6gMg6DmXHK1tW" Name="Value" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="547,760,25,19" Id="H22gIspJFOPPbAkiHKKVm3">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="&gt;" />
+                </p:NodeReference>
+                <Pin Id="BkqkOBPhZXENg6WWjMiDNg" Name="Input" Kind="InputPin" />
+                <Pin Id="O0dHaVIeGJOQHP4Jo38AIU" Name="Input 2" Kind="InputPin" DefaultValue="5" />
+                <Pin Id="TEZ4WQwVF3GPoXDpp9ss8U" Name="Result" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="546,820,79,19" Id="IYEC68qThTiO9fBmwSc8jJ">
+                <p:NodeReference LastCategoryFullName="System" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="KeepAppAlive" />
+                </p:NodeReference>
+                <Pin Id="U0Y6hgyn0mYO6m9tl2iDNj" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="LJf0a5blKRYL2S7kAgubQQ" Name="Is Alive" Kind="InputPin" />
+              </Node>
+              <Node Bounds="547,790,37,19" Id="OLH37231S4lNreYRBBKkjI">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="NOT" />
+                </p:NodeReference>
+                <Pin Id="LdlOEiHZ0U1LVvoca1098k" Name="Input" Kind="StateInputPin" />
+                <Pin Id="Dex9OJ0LYdZLx4I28jhqjn" Name="Output" Kind="StateOutputPin" />
               </Node>
             </Patch>
           </Node>
@@ -188,14 +228,6 @@
             <Pin Id="Dauck83uB4sL3UQgH381eH" Name="Input 2" Kind="InputPin" />
             <Pin Id="VueunSFlNvCOAKvJKJ7fe4" Name="Output" Kind="StateOutputPin" />
           </Node>
-          <Node Bounds="126,36,79,19" Id="Jkaq1oratWnQF1ejc53Y8f">
-            <p:NodeReference LastCategoryFullName="System" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="KeepAppAlive" />
-            </p:NodeReference>
-            <Pin Id="TuiIpC4OcoeMlm5cV7WJSw" Name="Node Context" Kind="InputPin" IsHidden="true" />
-            <Pin Id="KgcXhEfZIgAOczSLI0I02o" Name="Is Alive" Kind="InputPin" />
-          </Node>
           <Pad Id="C0j7RqBFXGIPCBgjRJSDKk" Comment="Condition" Bounds="166,286,35,35" ShowValueBox="true" isIOBox="true" Value="True">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
@@ -229,6 +261,11 @@
         <Link Id="F6xExOqPECXK955te6D3Rb" Ids="C0j7RqBFXGIPCBgjRJSDKk,TJkJNq6VXzYPNHYd4w8ppj" />
         <Link Id="H9Ok27s3dTUQNywpnxk7Pn" Ids="NQ0Dxyq4cnFN1PPerLAhDt,HYGgFEzuwIXN6sNUo1QE84" />
         <Link Id="DjMA2eLz8zlPGLpxOIN0AU" Ids="DAxf7wCbWaUMtCk7JHv6ZI,FXUElVn23U1NaSrs0KtzF6" />
+        <Link Id="RouBEtl6JXqLPGiJiG8JDx" Ids="EMwNwZkfdRINCyG7PBoBIn,HVdMEZP0cTVMqm9a2RVGyA" />
+        <Link Id="T3U4vL530dyPBbXn9ywtaC" Ids="DKYeQNA6TadL2siDsRIlMc,IHfbLIJc1zvP7kAge2bL6s" />
+        <Link Id="DZWgcXwEHyMP8Qy94yyl5J" Ids="EGLGKndem6gMg6DmXHK1tW,BkqkOBPhZXENg6WWjMiDNg" />
+        <Link Id="OWegDqDc8jKK9jOIWdNgs5" Ids="TEZ4WQwVF3GPoXDpp9ss8U,LdlOEiHZ0U1LVvoca1098k" />
+        <Link Id="EZchZGhgjCzNcbjKQySt77" Ids="Dex9OJ0LYdZLx4I28jhqjn,LJf0a5blKRYL2S7kAgubQQ" />
       </Patch>
     </Node>
   </Patch>
@@ -237,5 +274,5 @@
   <DocumentDependency Id="HlgJvz6QKM0L3s3wIVbbl1" Location="../vl/App/Schema.App.Runtime.vl" />
   <DocumentDependency Id="ChYaOYCalxFQCJcyKNRhg4" Location="../vl/App/Schema.App.Plugins.Common.vl" />
   <DocumentDependency Id="GyzuZ3Mn7i9PgnEbdIBbT9" Location="../vl/Blocks/Schema.Blocks.vl" />
-  <NugetDependency Id="OGu8NpbOjJoNwMs43Xoqk9" Location="VL.CoreLib" Version="2024.6.2" />
+  <NugetDependency Id="HgrhD75vIJDO4hMdfq9xzg" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/gamma/Schema_Studio.props
+++ b/Main/gamma/Schema_Studio.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VLAssetBehavior>PointToOutput</VLAssetBehavior>
+    <VLAssetBehavior>RelativeToOutput</VLAssetBehavior>
     <VLCleanBuildDirectory>True</VLCleanBuildDirectory>
     <VLExportPath>$(MsBuildThisFileDirectory)..\Exports</VLExportPath>
     <VLTargetOS>Windows</VLTargetOS>
@@ -9,5 +9,8 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetFramework>net8.0-windows</TargetFramework>
     <ApplicationIcon>$(MsBuildThisFileDirectory)Assets\Logos\scenic-tools-schema.ico</ApplicationIcon>
+    <VLIgnoreCompileErrors>False</VLIgnoreCompileErrors>
+    <VLIgnoreUnhandledExceptions>False</VLIgnoreUnhandledExceptions>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/Main/gamma/Schema_Studio.vl
+++ b/Main/gamma/Schema_Studio.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="VizwSUhvb2zNmfvP4bIm10" LanguageVersion="2024.6.7" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="VizwSUhvb2zNmfvP4bIm10" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory" />
     <!--
@@ -15,77 +15,13 @@
       </p:NodeReference>
       <Patch Id="OjCe3WTRNvMMfpypOYLR2Y">
         <Canvas Id="JGR4jnQZJpfOS7Q1TqLU1P" CanvasType="Group">
-          <Node Bounds="49,133,148,183" Id="NT0ByjyjEjYMGYbOo2ti9m">
-            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-              <Choice Kind="ApplicationStatefulRegion" Name="If" />
-              <FullNameCategoryReference ID="Primitive" />
-            </p:NodeReference>
-            <Pin Id="P5RliCwwTkIOUclxZyuKPw" Name="Condition" Kind="InputPin" />
-            <Patch Id="RB9U3NvThNeNio41QdlQGD" ManuallySortedPins="true">
-              <Patch Id="GE4U5vAZIW4P1Rd7YtQtO7" Name="Create" ManuallySortedPins="true" />
-              <Patch Id="AgijohnPJX6K939dN7G2RH" Name="Then" ManuallySortedPins="true" />
-              <Node Bounds="80,153,105,95" Id="I7EsLj95GPlO0ZvqHIYLnU">
-                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                  <Choice Kind="ProcessAppFlag" Name="Try" />
-                </p:NodeReference>
-                <Pin Id="VH0o20Fh5ZHLF3ZAY2v5Ts" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                <Pin Id="JIt6F02rDGDOLpQoAJF4ue" Name="User Exceptions Channel" Kind="InputPin" IsHidden="true" />
-                <Pin Id="MbcY6bIP4ypMlq71EFso4B" Name="Stick To Last Valid Outputs" Kind="InputPin" />
-                <Pin Id="RCCu2YlL1YtPlBaYml0JJZ" Name="Reset Region On Failure" Kind="InputPin" />
-                <Pin Id="DKYeQNA6TadL2siDsRIlMc" Name="Success" Kind="OutputPin" />
-                <Pin Id="EMwNwZkfdRINCyG7PBoBIn" Name="Failure" Kind="OutputPin" />
-                <Pin Id="RtpWKaoayrkPug3m2oh1At" Name="Error Message" Kind="OutputPin" />
-                <Pin Id="GNVZ28DqUz5PiYh47eH6Xx" Name="Exceptions" Kind="OutputPin" />
-                <Patch Id="AeeG168VVorNfw9BM59HVq" ManuallySortedPins="true">
-                  <Node Bounds="92,176,81,19" Id="P8bk1VJui51PBpBTDTapcm">
-                    <p:NodeReference LastCategoryFullName="Schema.App" LastDependency="Schema.App.RuntimeEditor.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="RuntimeEditor" />
-                    </p:NodeReference>
-                    <Pin Id="U35dKPdPD9FQbHXU2Z6jxs" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                    <Pin Id="ALXwzfSpSFQNASMKGhzbFK" Name="Reload Modules" Kind="InputPin" />
-                    <Pin Id="JoaIXP3Hh0UNTfvVozXPtI" Name="Output" Kind="OutputPin" />
-                    <Pin Id="G6X9mhYZHrkOrP5V5OAxpX" Name="EditorState" Kind="OutputPin" />
-                  </Node>
-                  <Patch Id="Vxp17jOflgrLO4QQNsV2AM" Name="Create" ManuallySortedPins="true" />
-                  <Patch Id="MFaRAFM8ukSNWBhA0hcgSB" Name="Update" ParticipatingElements="CCWtPvmlG8NPI4Tq6y3pnt" />
-                  <Node Bounds="92,209,45,19" Id="ML0w9A4USw4Ppt9LhiJDdk">
-                    <p:NodeReference LastCategoryFullName="Schema" LastDependency="Schema.Blocks.vl">
-                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <Choice Kind="ProcessAppFlag" Name="Blocks" />
-                    </p:NodeReference>
-                    <Pin Id="FvQwpwrLtxkMiE6BGPe4HG" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                    <Pin Id="SobUFMmLm1NLgnWDDk0eYO" Name="Input" Kind="InputPin" />
-                    <Pin Id="P9KetpyYAkKO6dYdW1ki3l" Name="Output" Kind="OutputPin" />
-                  </Node>
-                  <Patch Id="BuhysyfyEMqPWGCKMQ5ZDt" Name="Dispose" />
-                </Patch>
-              </Node>
-              <Node Bounds="106,277,55,19" Id="GACsbksMduWN1ie9fGnuBn">
-                <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                  <Choice Kind="OperationCallFlag" Name="LogError (String)" />
-                </p:NodeReference>
-                <Pin Id="PngurFqwGQQNharJGl40qv" Name="Message" Kind="InputPin" />
-                <Pin Id="DJXvBEZdkPnOhVMEANLSND" Name="Apply" Kind="InputPin" />
-              </Node>
-            </Patch>
-          </Node>
-          <Pad Id="RO37yIr3bcZLUjIFtfgcJq" Comment="Start Runtime" Bounds="48,82,35,35" ShowValueBox="true" isIOBox="true" Value="True">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="TypeFlag" Name="Boolean" />
-              <FullNameCategoryReference ID="Primitive" />
-            </p:TypeAnnotation>
-          </Pad>
-          <Node Bounds="46,35,95,19" Id="VkxEZ3fTB8IO95cM7MetIW">
-            <p:NodeReference LastCategoryFullName="Schema.App" LastDependency="Schema.App.ProjectSelector.vl">
+          <Node Bounds="28,30,80,19" Id="OYaSlF0cXQHQd3khPRyOVX">
+            <p:NodeReference LastCategoryFullName="Schema.App.Studio" LastDependency="Schema.App.Studio.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <Choice Kind="ProcessAppFlag" Name="SelectProjectFlow" />
+              <Choice Kind="ProcessAppFlag" Name="SchemaStudio" />
             </p:NodeReference>
-            <Pin Id="JPqi99x0x7rMCCSV0T8ZJX" Name="Node Context" Kind="InputPin" IsHidden="true" />
-            <Pin Id="Tt7SP2y0iugPBaZM2sifig" Name="Selected" Kind="OutputPin" />
+            <Pin Id="NG2aWC93EszMz4fzTlBqk8" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Qqo1Lggk8E5LsOi2hTSgaP" Name="State" Kind="OutputPin" />
           </Node>
         </Canvas>
         <Patch Id="VZ1PY486ObVNlm7Bqp7y2d" Name="Create" />
@@ -94,18 +30,10 @@
           <Fragment Id="CAcGOZN57MFL6c5RBvpWb6" Patch="VZ1PY486ObVNlm7Bqp7y2d" Enabled="true" />
           <Fragment Id="Mf7RnfFTCVRPqhy6mz5bgJ" Patch="Vd6kBLH2EfQMqNSuVo0Cbr" Enabled="true" />
         </ProcessDefinition>
-        <Link Id="GgK1lCe3YNXPHzKpJpiTLl" Ids="RO37yIr3bcZLUjIFtfgcJq,P5RliCwwTkIOUclxZyuKPw" />
-        <Link Id="JMZg5AYOtZ1PHQlW6MExEh" Ids="EMwNwZkfdRINCyG7PBoBIn,DJXvBEZdkPnOhVMEANLSND" />
-        <Link Id="TdM3DIVtc4gNYHdywHPjDt" Ids="RtpWKaoayrkPug3m2oh1At,PngurFqwGQQNharJGl40qv" />
-        <Link Id="CCWtPvmlG8NPI4Tq6y3pnt" Ids="JoaIXP3Hh0UNTfvVozXPtI,SobUFMmLm1NLgnWDDk0eYO" />
-        <Link Id="IcVz7WnWhOcMVqej5dF5Qb" Ids="Tt7SP2y0iugPBaZM2sifig,RO37yIr3bcZLUjIFtfgcJq" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.7" />
-  <DocumentDependency Id="COO6uM87138P1Ucx1xfn8l" Location="../vl/App/Schema.App.RuntimeEditor.vl" />
+  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2025.7.0" />
   <NugetDependency Id="Mv1PkBfOXpZN3ZUAecBtl5" Location="VL.WinFormsUtils" Version="1.0.11" />
-  <DocumentDependency Id="J25F41yfGl4P04HLrkQ5Kj" Location="../vl/App/Schema.App.ProjectSelector.vl" />
-  <DocumentDependency Id="DcyytHaD0W5OhD5pPxTncb" Location="../vl/VVVV.Schema.Core.vl" />
-  <DocumentDependency Id="RyPHtxH3BUONxwaiEirCa6" Location="../vl/Blocks/Schema.Blocks.vl" />
+  <DocumentDependency Id="Ccch3BmascjLgdxoionYog" Location="../vl/App/Schema.App.Studio.vl" />
 </Document>

--- a/Main/gamma/Schema_Studio.vl
+++ b/Main/gamma/Schema_Studio.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="VizwSUhvb2zNmfvP4bIm10" LanguageVersion="2024.6.6" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.6" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="VizwSUhvb2zNmfvP4bIm10" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory" />
     <!--
@@ -102,9 +102,9 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.6" />
+  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.7" />
   <DocumentDependency Id="COO6uM87138P1Ucx1xfn8l" Location="../vl/App/Schema.App.RuntimeEditor.vl" />
-  <NugetDependency Id="Mv1PkBfOXpZN3ZUAecBtl5" Location="VL.WinFormsUtils" Version="1.0.9" />
+  <NugetDependency Id="Mv1PkBfOXpZN3ZUAecBtl5" Location="VL.WinFormsUtils" Version="1.0.11" />
   <DocumentDependency Id="J25F41yfGl4P04HLrkQ5Kj" Location="../vl/App/Schema.App.ProjectSelector.vl" />
   <DocumentDependency Id="DcyytHaD0W5OhD5pPxTncb" Location="../vl/VVVV.Schema.Core.vl" />
   <DocumentDependency Id="RyPHtxH3BUONxwaiEirCa6" Location="../vl/Blocks/Schema.Blocks.vl" />

--- a/Main/gamma/sketches/ImguiWidget/Schema.Embed.ImGui.vl
+++ b/Main/gamma/sketches/ImguiWidget/Schema.Embed.ImGui.vl
@@ -1,0 +1,592 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="AOpohWuGI1cNdM0SKrGGfD" LanguageVersion="2025.7.0-0086-gcaebf60212" Version="0.128">
+  <NugetDependency Id="CN7Z0xDfB4WNi3DTXLkwsA" Location="VL.CoreLib" Version="2025.7.0-0086-gcaebf60212" />
+  <Patch Id="HJ00EfMiio9NUFlZ23OVaH">
+    <Canvas Id="AYelhJsb0D8NYYvaz5b1YY" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory">
+      <!--
+
+    ************************ Node ************************
+
+-->
+      <Node Name="Node" Bounds="197,91" Id="R2mpNPRC4a2On7R9sGTwDC">
+        <p:NodeReference>
+          <Choice Kind="ContainerDefinition" Name="Process" />
+          <CategoryReference Kind="Category" Name="Primitive" />
+        </p:NodeReference>
+        <Patch Id="SaGMOLaU9NMMcK2lifUDvG">
+          <Canvas Id="OWhyx01bO5NQUb2KTP8BuE" BordersChecked="false" CanvasType="Group" />
+          <Patch Id="CTxvyOT6Li6LHRwvTtxX7L" Name="Create" />
+          <Patch Id="GiSeePQvijiMRrAGnN0fwl" Name="Update" />
+          <!--
+
+    ************************  ************************
+
+-->
+          <ProcessDefinition Id="V1xDJcGWznWPlEL64u0DLb">
+            <Fragment Id="GNLxyPu0EsuLqUNegYXdPp" Patch="CTxvyOT6Li6LHRwvTtxX7L" Enabled="true" />
+            <Fragment Id="SSJlMtp5ErqLbCuExCf97K" Patch="GiSeePQvijiMRrAGnN0fwl" Enabled="true" />
+          </ProcessDefinition>
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="DW072Xd1V4WM2BjZz2T18r">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <CategoryReference Kind="Category" Name="Primitive" />
+      </p:NodeReference>
+      <Patch Id="Lrroh6QpCjINZ4uvRVccjb">
+        <Canvas Id="ENlaJ58D9fIOGvvhwBC0gj" CanvasType="Group">
+          <Node Bounds="87,256,105,19" Id="G7N4RjeK3c0OzY19NDOrjL">
+            <p:NodeReference LastCategoryFullName="Schema.UI" LastDependency="Schema.UI.vl">
+              <Choice Kind="ProcessAppFlag" Name="TreeViewEditor" />
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+            </p:NodeReference>
+            <Pin Id="AA3R6RuYNMmNONgqRkGAOH" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MMDUP85eNVkOSLH2i8Tken" Name="Editable" Kind="InputPin" />
+            <Pin Id="VyQxIFIlzqZM0Y7ww1tV66" Name="Create Node" Kind="InputPin" />
+            <Pin Id="NBlnbXCNn8TN6auaMrDanA" Name="EditorState" Kind="InputPin" />
+            <Pin Id="AEzi5XWJ6cYP4D2RW29zoB" Name="State" Kind="InputPin" />
+            <Pin Id="DYZXxre6QnsOXmFhFZkDLV" Name="Block Blacklist" Kind="InputPin" />
+            <Pin Id="BQJE9mcxlQUQYUtuc6pSaB" Name="Stack Blacklist" Kind="InputPin" />
+            <Pin Id="KzgbRm5IjFxNUvCp6GRkeo" Name="Layer" Kind="OutputPin" />
+            <Pin Id="GQZbttAvyolPmygHk9IIJT" Name="Map" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="87,98,85,26" Id="JTuLR0cTPfhN9WgBLEO6YZ">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="Fixture" />
+              <Choice Kind="OperationCallFlag" Name="Create" />
+              <CategoryReference Kind="ClassType" Name="Fixture" NeedsToBeDirectParent="true">
+                <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true" />
+              </CategoryReference>
+            </p:NodeReference>
+            <Pin Id="IDKr9SKpYdDPSClKfTMIhG" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SvcgSraNYrkNTcpMEXgp1w" Name="Name" Kind="InputPin" DefaultValue="Fixture">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="RvkTF9SkHMlLpQFcwbhvUZ" Name="Setup" Kind="InputPin" />
+            <Pin Id="Ked06kK6A3nP4gRzkTqT2B" Name="State" Kind="InputPin" />
+            <Pin Id="PxJkufdJpSYNk4lWXbt4O0" Name="Layers" Kind="InputPin" DefaultValue="1">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="I9he1Mw8A3XPlM0bKTbjpU" Name="Root Node" Kind="InputPin" />
+            <Pin Id="Kl4Kvt4PfG3PKjhpNU1Xs3" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Node Bounds="35,529,165,19" Id="C84f8s2ZbmOMFn7jMkhCHJ">
+            <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Renderer" />
+            </p:NodeReference>
+            <Pin Id="Gik8YT7tVtmMask54TalWF" Name="Bounds" Kind="InputPin" DefaultValue="552, 256, 614, 436">
+              <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastDependency="System.Drawing.dll">
+                <Choice Kind="TypeFlag" Name="Rectangle" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="CKHr4gAUbUiM1GU5eAAxKJ" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SBIgyrlb8TsPFKqLyz9Xe9" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MvuON6HgRKqPdU76FwYY7C" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Jk1co7l8wObM73zzOzsTOg" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+            <Pin Id="AuiXhOmS2ffOcx9kNd5lCj" Name="Input" Kind="InputPin" />
+            <Pin Id="CiZyaXKDWwnQZZvpG5vxni" Name="Title" Kind="InputPin" />
+            <Pin Id="H0fPXNBG5owLJAdh6Ysx60" Name="Color" Kind="InputPin" />
+            <Pin Id="PtP75GfpYmJNTDzi9p9Ptb" Name="Clear" Kind="InputPin" />
+            <Pin Id="Im8WvG3EliqPmsn0ZUkFQj" Name="Space" Kind="InputPin" />
+            <Pin Id="TvqapO0Uv7eObCPYS5SqvO" Name="Show Cursor" Kind="InputPin" />
+            <Pin Id="LQGlJPKVuPRNDiLtsQakzq" Name="VSync" Kind="InputPin" />
+            <Pin Id="O9uAKc3vl4wM6aQUPJ87Rh" Name="Commands" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JTrFOGr2jjDNI0yOJihpol" Name="Enable Keyboard Shortcuts" Kind="InputPin" IsHidden="true" />
+            <Pin Id="CtPnW1ozxVsQJ3ISH23tB8" Name="Enabled" Kind="InputPin" />
+            <Pin Id="ONNjmqVkqCwMd2l0yw5UcE" Name="Form Bounds Notifications" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="Hh1K7WSSJrsOVDMzkA5QUz" Name="Form" Kind="OutputPin" />
+            <Pin Id="Jf8IkU5Zx6oP8WNtd59vlM" Name="ClientBounds" Kind="OutputPin" />
+            <Pin Id="U89k1qjM7SyLj1JOBImPz7" Name="Render Time" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="37,557,92,19" Id="Tq4oEiswOMqPRU0mTMYsj3">
+            <p:NodeReference LastCategoryFullName="VL.WinFormsUtils" LastDependency="VL.WinFormsUtils.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetAlwaysOnTop" />
+            </p:NodeReference>
+            <Pin Id="NyjS3ofY9WMPIVd9yuLOtS" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Gmzvu1HtsA0MbAzJnutjzF" Name="Input" Kind="InputPin" />
+            <Pin Id="BksJU8NBV2UMc16bBlaGnv" Name="On Top" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="Cnoa5NaAULINxB2zeCrYDX" Name="Input" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="87,181,49,26" Id="Moa4p5TsOyHP4fClh5Kua7">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="Update" />
+              <CategoryReference Kind="ClassType" Name="Fixture" NeedsToBeDirectParent="true">
+                <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true" />
+              </CategoryReference>
+            </p:NodeReference>
+            <Pin Id="DwsE1SqSRYrPdkCMfa4ua8" Name="Input" Kind="StateInputPin" />
+            <Pin Id="Qm1fcRj8cJBMdOl0DUEnO1" Name="Global" Kind="InputPin" />
+            <Pin Id="QKd58ln3vxcLNXItDhOJS4" Name="Output" Kind="StateOutputPin" />
+            <Pin Id="QPlJ48lKfPoP4Xah9lYGMR" Name="State" Kind="OutputPin" />
+          </Node>
+          <Pad Id="Uk6URINgkwENgoS8GbNlB0" SlotId="MwBa6IkB28sQO8Zf1G6azI" Bounds="89,154" />
+          <Node Bounds="55,356,169,114" Id="JMfgFD8W4rSLYRseRuRm0T">
+            <p:NodeReference LastCategoryFullName="Graphics.Skia.Layer" LastDependency="VL.ImGui.Skia.vl">
+              <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Skia" />
+              <Choice Kind="ProcessAppFlag" Name="ImGui" />
+            </p:NodeReference>
+            <Pin Id="Jw4lDEPT1FlLteOR3pPmBu" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KGYsgaJ5LXHO4gqUbGb0n4" Name="Docking Enabled" Kind="InputPin" />
+            <Pin Id="IvnGRksHXXPLW3QCgY3Q9J" Name="Fonts" Kind="InputPin" />
+            <Pin Id="A0XvMRNJtXdMa4NZmEMcxV" Name="Add Fullscreen Window" Kind="InputPin" />
+            <Pin Id="VH9ScyPXIybOVVXzcOBO9k" Name="Style" Kind="InputPin" />
+            <Pin Id="RiOVa00nnyGQAhoneArrn9" Name="Use Skia Space" Kind="InputPin" />
+            <Pin Id="HcTIK1x8JQ2OJ35b0StN3x" Name="Output" Kind="OutputPin" />
+            <Patch Id="LgEsfgmLNaCOBeqK7Avksp" ManuallySortedPins="true">
+              <Patch Id="H5w8uj6UX40MrJbiJZeIdy" Name="Create" ManuallySortedPins="true" />
+              <Patch Id="TltvZzmDPOAOBsNcYiShCj" Name="Update" ParticipatingElements="TeD0wxIgoRjOIOvJBd56Uo" ManuallySortedPins="true" />
+              <Patch Id="BVVDcv5s3v7OKTbILcpq75" Name="Dispose" ManuallySortedPins="true" />
+              <Node Bounds="67,379,105,19" Id="Op8iy0CYOsONz6bbdp6Ltx">
+                <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.Skia.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="ImGui" />
+                  <CategoryReference Kind="Category" Name="Widgets" />
+                  <Choice Kind="ProcessAppFlag" Name="LayerWidget" />
+                </p:NodeReference>
+                <Pin Id="BWAfJxoLMeTPmuKC6AMUrP" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="RTzXo9pZXiLPzalt03KcKE" Name="Context" Kind="InputPin" />
+                <Pin Id="FC5ZW1XyfGbOUEmCNKj9nT" Name="Layer" Kind="InputPin" />
+                <Pin Id="QjurNTjI7hTPG6x2Ki2WUj" Name="Size" Kind="InputPin" />
+                <Pin Id="DHkFUKzBROyQN1frRlIInY" Name="Space" Kind="InputPin" DefaultValue="DIP" />
+                <Pin Id="Tc3YGEpBiuTNOTxnqwLXQT" Name="Show Helper" Kind="InputPin" />
+                <Pin Id="LooGIFksQwnOvThd8sM22y" Name="Event Filter" Kind="InputPin" />
+                <Pin Id="S2fq1BAAa4zO3OUuLA0Gmu" Name="Context" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="67,431,145,19" Id="CqqmRlE1VLOOJYHsppfSX7">
+                <p:NodeReference LastCategoryFullName="ImGui.Widgets" LastDependency="VL.ImGui.Skia.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessNode" Name="Slider (Float)" />
+                </p:NodeReference>
+                <Pin Id="BA52lsrslwILmefwb3KsFn" Name="Context" Kind="InputPin" />
+                <Pin Id="PV1EZw3CICNNRfplBR5i6T" Name="Channel" Kind="InputPin" />
+                <Pin Id="IAjNclT79ltQOXqf5L5NPg" Name="Label" Kind="InputPin" />
+                <Pin Id="EI7Bkl1qxTPK9fX1npXCmb" Name="Min" Kind="InputPin" />
+                <Pin Id="UQHdARKv0D1LeCM47LtbGJ" Name="Max" Kind="InputPin" />
+                <Pin Id="Pzbg8pSABA9LGMqCQRhVap" Name="Format" Kind="InputPin" />
+                <Pin Id="SBYlzrA81zfOPcH60wBNIP" Name="Flags" Kind="InputPin" />
+                <Pin Id="OrdRFYrvV1kM4tDh4ulvFH" Name="Style" Kind="InputPin" />
+                <Pin Id="SSvJpabDJlVONGDqyFtRNS" Name="Context" Kind="OutputPin" />
+                <Pin Id="LGexTeKyoAcLMRPCOfioip" Name="Bang" Kind="OutputPin" />
+                <Pin Id="M5GGfWg6dK8NC6yUHcyrxY" Name="Value" Kind="OutputPin" />
+              </Node>
+            </Patch>
+          </Node>
+          <Pad Id="AmRB86FQaX2QOs1Tn4hCoe" Comment="Size" Bounds="109,315,35,28" ShowValueBox="true" isIOBox="true" Value="4, 2">
+            <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Vector2" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="167,12,62,26" Id="Kphz0iA0Z22MBFSDiouKwP">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.ValueLFOBee" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="ValueLFOBee" />
+              <Choice Kind="OperationCallFlag" Name="Create" />
+            </p:NodeReference>
+            <Pin Id="HnODbLEZ2AXLg5XYwzi0y2" Name="Output" Kind="StateOutputPin" />
+            <Pin Id="BxIhNwyytRpOTp132QeD0z" Name="Node Context" Kind="InputPin" IsHidden="true" />
+          </Node>
+          <Node Bounds="167,51,105,26" Id="DEv8TMUgNCWNWQTECAgFnS">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Node" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="Node" />
+              <Choice Kind="OperationCallFlag" Name="Create" />
+            </p:NodeReference>
+            <Pin Id="GyKHEKdQZR2Pei4PM1nSii" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="QxWXcKJkKB2MtoZCflMHu9" Name="Bee" Kind="InputPin" />
+            <Pin Id="C1ZgXSYkNh9LeRdK8XXJBL" Name="Properties" Kind="InputPin" />
+            <Pin Id="Hlow6hOR0seP2kTG2MVnhI" Name="Name" Kind="InputPin" DefaultValue="LFO" />
+            <Pin Id="MXrgUB9cBByOx80sab7CN0" Name="Children" Kind="InputPin" />
+            <Pin Id="RCMc41gS1XPLFjsaz88lxA" Name="Drivers" Kind="InputPin" />
+            <Pin Id="I3v5YwgGgm9OLHKdMRyIcv" Name="Fold" Kind="InputPin" />
+            <Pin Id="Ai6UySz3CCNOQwFhir4Gji" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Node Bounds="131,226,57,19" Id="UYXZmz4FecSOnB52Dn7u62">
+            <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                  </p:OuterCategoryReference>
+                </p:OuterCategoryReference>
+              </CategoryReference>
+              <Choice Kind="OperationCallFlag" Name="GetValue" />
+            </p:NodeReference>
+            <Pin Id="NYgNaTtXnILPTJNj6isgf7" Name="Input" Kind="InputPin" />
+            <Pin Id="SgBgP0vSuQWMvQEctBL7Wb" Name="Default Value" Kind="InputPin" />
+            <Pin Id="PKC1kzNmH7nMxaijfHZCB4" Name="Output" Kind="OutputPin" />
+            <Pin Id="C6e5bpIflhVPmYkVimmGmH" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Pad Id="L7PPwJCzxGkQG5KSvRI26l" Bounds="251,171,214,82" ShowValueBox="true" isIOBox="true" Value="TODO simplify view&#xD;&#xA;- no or minimal menu&#xD;&#xA;- no or minimal layer view&#xD;&#xA;- no or minimal fixture out view">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="MAs2O1N5lcHLATf0JEi7AM" Bounds="252,258,336,19" ShowValueBox="true" isIOBox="true" Value="TODO persistence within document or own file autosave">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="FsXVjgccsjFLFE4gO9GGIg" Bounds="253,389,371,19" ShowValueBox="true" isIOBox="true" Value="Block stack could be saved within/next to channel to animate.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="Ty9zqYzFwGPOuJN70hI31d" Bounds="255,421,371,72" ShowValueBox="true" isIOBox="true" Value="Allowing quick embedding in imgui and seamless integration with channels in order to animate any UI parameter could be quite powerful and useful.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="Inz71omOKOJLq3gHEK8iEP" Bounds="256,500,371,72" ShowValueBox="true" isIOBox="true" Value="Current Hydropolis app would be made into a performance machine in this way.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="DPgwkzmWVr5PB3PTXWtWHg" Bounds="254,286,338,84" ShowValueBox="true" isIOBox="true" Value="TODO decouple full state/ui dependency&#xD;&#xA;- block registration&#xD;&#xA;- creation&#xD;&#xA;- add view">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="LpgOl2IOGbQLnhbOlNRJe4" Bounds="255,565,442,156" ShowValueBox="true" isIOBox="true" Value="API Ideas&#xD;&#xA;- Wrapped widgets with available Driver (How to ensure bg evaluation? Update must happen in global space. Would be possible if we can get stable Channel reference. Of course easiest with global channel + path)&#xD;&#xA;  - There are Channel attributes. Potentially useful&#xD;&#xA;- How much limitation on imgui patching freedom is acceptable?&#xD;&#xA;  - Asking users to assign unique ID is ok I think">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Node Bounds="137,641,53,19" Id="FmKdM9NaJ21P72NY28JhVu">
+            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="Channel" />
+            </p:NodeReference>
+            <Pin Id="PaUMQ5oFtWIQOwoKLpvYre" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="IiEN842BvC3OcXb0lSDDHm" Name="Initial Value" Kind="InputPin" IsHidden="true" />
+            <Pin Id="LualHr7B6syPUboLG15oTj" Name="Value" Kind="InputPin" />
+            <Pin Id="RuWVCFDHiOCN4C16ihJMaM" Name="Output" Kind="OutputPin" />
+            <Pin Id="Jmxo6Av5rEBPQFEmpIBAhH" Name="Value" Kind="OutputPin" />
+          </Node>
+          <Pad Id="N66jZtpMrNsNKOmuh7vqh0" Comment="" Bounds="139,618,35,15" ShowValueBox="true" isIOBox="true">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="635,809,61,19" Id="U4LYcIMDGSpLCPvcsYrCNM">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Primitive" />
+              <Choice Kind="ProcessAppFlag" Name="Reference" />
+            </p:NodeReference>
+            <Pin Id="HMVmSFMVhX5N5WqteK5waz" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KWdMJJEZdZzO6FWoPZuB2V" Name="Data" Kind="InputPin" />
+            <Pin Id="M6Q6kvOqd6RNAPz3lfuRcs" Name="Data" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="706,633,88,26" Id="KuTjoBEZipANzJT1AIRR0P">
+            <p:NodeReference LastCategoryFullName="Reactive.Channel (Ungeneric)" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <FullNameCategoryReference ID="Reactive.Channel (Ungeneric)" />
+              <Choice Kind="OperationCallFlag" Name="Attributes" />
+            </p:NodeReference>
+            <Pin Id="Q2idhqm6hC1PdUNFUNZ056" Name="Input" Kind="StateInputPin" />
+            <Pin Id="E9qVyN8h8iHPnCIxxYdMqC" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="268,801,75,19" Id="KthMmC5Bm5XN4LFhhVJTXL">
+            <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="MutableInterfaceType" Name="Channel" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetAttributes" />
+            </p:NodeReference>
+            <Pin Id="LbtWvMwM333OxVniPUVzvF" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="BYZSLCXODwcP7eXdx1Kuxy" Name="Input" Kind="InputPin" />
+            <Pin Id="PiIG5lVvAHiO9IZvWo1ZTs" Name="Attributes" Kind="InputPin" />
+            <Pin Id="Suno9c0jqC0PUvkxom4OoW" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="338,761,39,19" Id="QQUh5WY8iEvLvEcjLy39V3">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+              <Choice Kind="OperationCallFlag" Name="Cons" />
+            </p:NodeReference>
+            <Pin Id="UVGOSXsbaebLEkiARk3R8C" Name="Result" Kind="OutputPin" />
+            <Pin Id="Ouehm0Gnj17OAScv2P6v90" Name="Input" Kind="InputPin" />
+          </Node>
+          <Node Bounds="338,723,67,26" Id="MGba3NONOB3O2pNtaaJs5x">
+            <p:NodeReference LastCategoryFullName="System.EditorAttributes.LabelAttribute" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="System" />
+              <CategoryReference Kind="ClassType" Name="LabelAttribute" />
+              <Choice Kind="OperationCallFlag" Name="Create" />
+            </p:NodeReference>
+            <Pin Id="HqDshqhCA26O4ZfKObQE2p" Name="Label" Kind="InputPin" DefaultValue="ID:1234" />
+            <Pin Id="MmsOD82tnB6Lx3haI22bGu" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Node Bounds="268,841,88,26" Id="EDpHBmvehLcO35iTCuFwx9">
+            <p:NodeReference LastCategoryFullName="Reactive.Channel (Ungeneric)" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <FullNameCategoryReference ID="Reactive.Channel (Ungeneric)" />
+              <Choice Kind="OperationCallFlag" Name="Attributes" />
+            </p:NodeReference>
+            <Pin Id="Fmr9VClxzyXQLTYBjbqzvR" Name="Input" Kind="StateInputPin" />
+            <Pin Id="Pbo5oQ8pnf2MjcE5QcRPh8" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Pad Id="Rr4enAgpMbPObzXN7T8heF" Comment="" Bounds="270,892,266,103" ShowValueBox="true" isIOBox="true" />
+          <Node Bounds="60,787,82,19" Id="SL7b91I0VtTMj33qChv8yw">
+            <p:NodeReference LastCategoryFullName="Reactive.ChannelHub" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="GlobalChannel" />
+            </p:NodeReference>
+            <Pin Id="ICGVDCWhIslMheI3PZNp9K" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Ugco8ARu80YPAT6i2kbb2v" Name="Path" Kind="InputPin" />
+            <Pin Id="CfiCzbzwsW4Mt5irK4vWVf" Name="Value" Kind="InputPin" />
+            <Pin Id="CQSS7HzlzCfPp1x1EFm3pl" Name="Channel" Kind="OutputPin" />
+            <Pin Id="H1zXNpVwdzMMxNOjw5A2EA" Name="Value" Kind="OutputPin" />
+            <Pin Id="QLmuUWdUOrvLaqD4fbmx0r" Name="Author" Kind="InputPin" IsHidden="true" />
+            <Pin Id="AWvf88JDHwWPxSi78RvJDC" Name="Path" Kind="OutputPin" IsHidden="true" />
+          </Node>
+          <Pad Id="DrFHrfIspyBOTdk92z6oNo" Comment="Path" Bounds="30,738,35,15" ShowValueBox="true" isIOBox="true" Value="Path">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="62,1090,82,19" Id="N3eJYig2rMiLX5ZfC2uG6C">
+            <p:NodeReference LastCategoryFullName="Reactive.ChannelHub" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="GlobalChannel" />
+            </p:NodeReference>
+            <Pin Id="EgmMHZCfJJuMigBBa3qJ9E" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="LghO1PJ7t3lP7q2IcyNEA6" Name="Path" Kind="InputPin" />
+            <Pin Id="HfBiUVftThdMdK4tOpglJb" Name="Value" Kind="InputPin" />
+            <Pin Id="BHf7zpz9yVJPp0oQq0UjAa" Name="Channel" Kind="OutputPin" />
+            <Pin Id="Mp78ALGTe7jOoPYTm67rdE" Name="Value" Kind="OutputPin" />
+            <Pin Id="KPefdAzkiUZNPLWYELKi6z" Name="Author" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JtimaIQxmDFPGkIjZaz2Gt" Name="Path" Kind="OutputPin" IsHidden="true" />
+          </Node>
+          <Node Bounds="62,1136,88,26" Id="QHVHx133hQEMHhZFGJOzqz">
+            <p:NodeReference LastCategoryFullName="Reactive.Channel (Ungeneric)" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <FullNameCategoryReference ID="Reactive.Channel (Ungeneric)" />
+              <Choice Kind="OperationCallFlag" Name="Attributes" />
+            </p:NodeReference>
+            <Pin Id="Q4ZWCfTxeGXNnLWpf7Nv3U" Name="Input" Kind="StateInputPin" />
+            <Pin Id="Iw773DFHDJcPkiBfbbOO7j" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Pad Id="S9MqS9g17p9PHyqSHpkRY0" Comment="" Bounds="64,1187,266,103" ShowValueBox="true" isIOBox="true" />
+          <Node Bounds="60,886,75,19" Id="QfQJjLblbWlNFU67gs6pHM">
+            <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="MutableInterfaceType" Name="Channel" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="SetAttributes" />
+            </p:NodeReference>
+            <Pin Id="IRaR9OwxVSgLtGFwv1F1FV" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="O3ybBNYGCDOOgXVloeYHsN" Name="Input" Kind="InputPin" />
+            <Pin Id="TMrGoNBoyeTOWQjVWVulrn" Name="Attributes" Kind="InputPin" />
+            <Pin Id="IZ63F7xrc83P26oXONWqLv" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="160,852,39,19" Id="U1D64JykgMFMSAnkO5pcAl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+              <Choice Kind="OperationCallFlag" Name="Cons" />
+            </p:NodeReference>
+            <Pin Id="SEiGK78sHfjMWmz81rbENr" Name="Result" Kind="OutputPin" />
+            <Pin Id="BRoPiK1wphXNreRKmh5IZb" Name="Input" Kind="InputPin" />
+          </Node>
+          <Node Bounds="160,814,67,26" Id="UdpmTzoQhvBORi9W5DxlkP">
+            <p:NodeReference LastCategoryFullName="System.EditorAttributes.LabelAttribute" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="System" />
+              <CategoryReference Kind="ClassType" Name="LabelAttribute" />
+              <Choice Kind="OperationCallFlag" Name="Create" />
+            </p:NodeReference>
+            <Pin Id="PFTnayONUPWLXhl1MDvHAy" Name="Label" Kind="InputPin" />
+            <Pin Id="KhX8dHrATUSNwEUwNBpL5b" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Pad Id="Nq5uRuwXVI9LD0WkYUq6Aw" Comment="" Bounds="173,1126,35,15" ShowValueBox="true" isIOBox="true">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="635,763,53,19" Id="UfIksmUX4bTP9dWJtwJsZE">
+            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="Channel" />
+            </p:NodeReference>
+            <Pin Id="K4NJY92uJmkM8RbpxWQdPy" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SlSWxGRUaH5QX3ku2MbYJc" Name="Initial Value" Kind="InputPin" IsHidden="true" />
+            <Pin Id="T4ZTbYeT0xTOxLq1XwRKNQ" Name="Value" Kind="InputPin" />
+            <Pin Id="UyQqNWLiLUeNB2MlTdRPzK" Name="Output" Kind="OutputPin" />
+            <Pin Id="FO9ZZwtzKlwPiotgqkUpyL" Name="Value" Kind="OutputPin" />
+          </Node>
+          <Pad Id="DDHDfPB2htbP2G23M9xDTv" Comment="" Bounds="637,740,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="750,901,51,26" Id="TveBBNPioXcMkbqc9Dp6Ww">
+            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="Reference" />
+              <Choice Kind="OperationCallFlag" Name="Data" />
+            </p:NodeReference>
+            <Pin Id="G1jTaW0UPEzOOH8Xl2LWix" Name="Input" Kind="StateInputPin" />
+            <Pin Id="Sa3BkNFJ6azPTHiwNT0Mzn" Name="Output" Kind="StateOutputPin" />
+            <Pin Id="LtxVPTVvONsLvZM05jNLDA" Name="Data" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="750,815,51,26" Id="Daww4c2tCwhMqJIvkRXISi">
+            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="Reference" />
+              <Choice Kind="OperationCallFlag" Name="Create" />
+            </p:NodeReference>
+            <Pin Id="KkMHMi4gbZLQcq9kk1tpJM" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JNSy2q1VnoPMaBjkdAUofc" Name="Data" Kind="InputPin" />
+            <Pin Id="ER9FUz3tODtM2EdTQkz0FN" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Pad Id="Q3YQz91QYk6LA6o7LUZNMX" SlotId="EE0QW2zzp7CM19TqtixiMb" Bounds="752,872" />
+          <Pad Id="Iib055mBemkPRXHqAANAvw" Comment="Data" Bounds="798,952,157,51" ShowValueBox="true" isIOBox="true" />
+          <Node Bounds="559,909,51,26" Id="IrYMeIusqwALXjRTnDTv3e">
+            <p:NodeReference LastCategoryFullName="Primitive.Reference" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="Reference" />
+              <Choice Kind="OperationCallFlag" Name="Data" />
+            </p:NodeReference>
+            <Pin Id="IqP57W1Z6WLOD30Uf1nioA" Name="Input" Kind="StateInputPin" />
+            <Pin Id="LUJO2RVojuoP6EpuLtuvv3" Name="Output" Kind="StateOutputPin" />
+            <Pin Id="V1OmmYnON4BLfxwiOcKKC8" Name="Data" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="605,968,55,26" Id="SM4QPaVKA86LFqgo5GMuJG">
+            <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="MutableInterfaceType" Name="Channel" NeedsToBeDirectParent="true" />
+              <Choice Kind="OperationCallFlag" Name="SetValue" />
+            </p:NodeReference>
+            <Pin Id="BMMN6XByUBfMKzj01QDhXZ" Name="Input" Kind="StateInputPin" />
+            <Pin Id="JVPRoVdWWUfMvzQ7HRl1pF" Name="Value" Kind="InputPin" />
+            <Pin Id="Ho2oANz0Id5LDthkt5ECkN" Name="Author" Kind="InputPin" IsHidden="true" />
+            <Pin Id="HcxltZPF6UeMc5naZgbSep" Name="Apply" Kind="InputPin" DefaultValue="True" />
+            <Pin Id="IPu3S9DIR0cNo671WfHu24" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Pad Id="NqdGEJpiWW7OplmJOUfX3M" Comment="" Bounds="632,942,35,15" ShowValueBox="true" isIOBox="true" Value="0.42">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="BvGqVftto9gPnduFQuAtFL" Bounds="19,708,146,19" ShowValueBox="true" isIOBox="true" Value="Pass by global channel">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="HUVQQlmPA96LOjTZ2oBebq" Bounds="708,739,283,64" ShowValueBox="true" isIOBox="true" Value="Pass by reference, could be used to push any channel passed into widget to global evaluator part">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+        </Canvas>
+        <Patch Id="Hdvk18sZWJQLNVJOAcLr9F" Name="Create" ParticipatingElements="JTuLR0cTPfhN9WgBLEO6YZ,JawGjv5UaQxOBEuhiNx5Va" />
+        <Patch Id="NeXIASIAmSRLG3L1a1x8nz" Name="Update" />
+        <ProcessDefinition Id="JGIXZS9lNL9OCuUKCvXLQi">
+          <Fragment Id="I4BgdtfpQX0Plxov4lY91p" Patch="Hdvk18sZWJQLNVJOAcLr9F" Enabled="true" />
+          <Fragment Id="KiVXcLeyUjGPUyrwLZaEYC" Patch="NeXIASIAmSRLG3L1a1x8nz" Enabled="true" />
+        </ProcessDefinition>
+        <Slot Id="MwBa6IkB28sQO8Zf1G6azI" Name="Fixture" />
+        <Link Id="J2i5s2Cy0p7PVPlL3S22ka" Ids="Hh1K7WSSJrsOVDMzkA5QUz,Gmzvu1HtsA0MbAzJnutjzF" />
+        <Link Id="Smp6GzJq3hPMWLMrmRD379" Ids="QKd58ln3vxcLNXItDhOJS4,MMDUP85eNVkOSLH2i8Tken" />
+        <Link Id="SiUji2Y7FV5OOq2uoe3LnD" Ids="Kl4Kvt4PfG3PKjhpNU1Xs3,Uk6URINgkwENgoS8GbNlB0" />
+        <Link Id="NesFUQ1hYZONer9wW04KPl" Ids="Uk6URINgkwENgoS8GbNlB0,DwsE1SqSRYrPdkCMfa4ua8" />
+        <Link Id="J6xrK85G7nJLU52an42iz8" Ids="HcTIK1x8JQ2OJ35b0StN3x,AuiXhOmS2ffOcx9kNd5lCj" />
+        <Link Id="TeD0wxIgoRjOIOvJBd56Uo" Ids="S2fq1BAAa4zO3OUuLA0Gmu,BA52lsrslwILmefwb3KsFn" />
+        <Link Id="B65geBOySNlOBBn48kCAaG" Ids="KzgbRm5IjFxNUvCp6GRkeo,FC5ZW1XyfGbOUEmCNKj9nT" />
+        <Link Id="QN6dGU9px3mMNeUoe5i8Zj" Ids="AmRB86FQaX2QOs1Tn4hCoe,QjurNTjI7hTPG6x2Ki2WUj" />
+        <Link Id="JFgOOwWQK0mPsLr2d1zbvK" Ids="HnODbLEZ2AXLg5XYwzi0y2,QxWXcKJkKB2MtoZCflMHu9" />
+        <Link Id="BJL8UmvBtKBPdu7gZJ3Urp" Ids="Ai6UySz3CCNOQwFhir4Gji,I9he1Mw8A3XPlM0bKTbjpU" />
+        <Link Id="FxNdhaQW08cMwd2npfDhHN" Ids="QPlJ48lKfPoP4Xah9lYGMR,NYgNaTtXnILPTJNj6isgf7" />
+        <Link Id="GXgzoZ1qQ4ROBpmQOtdvu6" Ids="C6e5bpIflhVPmYkVimmGmH,PV1EZw3CICNNRfplBR5i6T" />
+        <Link Id="KPB4TxLonbOOZhAXcbSHth" Ids="N66jZtpMrNsNKOmuh7vqh0,LualHr7B6syPUboLG15oTj" />
+        <Link Id="HiIOiQzGBkQPkxgJ3H3veH" Ids="RuWVCFDHiOCN4C16ihJMaM,BYZSLCXODwcP7eXdx1Kuxy" />
+        <Link Id="PRPvZVwY0laLHFPAvtj5wp" Ids="UVGOSXsbaebLEkiARk3R8C,PiIG5lVvAHiO9IZvWo1ZTs" />
+        <Link Id="DWlrfJwMONqNkTqQk2MzVL" Ids="Suno9c0jqC0PUvkxom4OoW,Fmr9VClxzyXQLTYBjbqzvR" />
+        <Link Id="EFIqSUGdarEOrcBHTcqVMr" Ids="Pbo5oQ8pnf2MjcE5QcRPh8,Rr4enAgpMbPObzXN7T8heF" />
+        <Link Id="NX5twW3gaTTMShq1p61j7i" Ids="N66jZtpMrNsNKOmuh7vqh0,CfiCzbzwsW4Mt5irK4vWVf" />
+        <Link Id="E8e4rq8F4ulPyOEMpoZubg" Ids="DrFHrfIspyBOTdk92z6oNo,Ugco8ARu80YPAT6i2kbb2v" />
+        <Link Id="OcN3unMOSCYL7A7WWSfpic" Ids="Iw773DFHDJcPkiBfbbOO7j,S9MqS9g17p9PHyqSHpkRY0" />
+        <Link Id="EO2xeXUiWrwM5mQLTlT5p5" Ids="BHf7zpz9yVJPp0oQq0UjAa,Q4ZWCfTxeGXNnLWpf7Nv3U" />
+        <Link Id="LCx6OhNVqtqOXORRaLkeie" Ids="CQSS7HzlzCfPp1x1EFm3pl,O3ybBNYGCDOOgXVloeYHsN" />
+        <Link Id="Fo6Sq4iZt0dN2nGhPTUtJY" Ids="MmsOD82tnB6Lx3haI22bGu,Ouehm0Gnj17OAScv2P6v90" />
+        <Link Id="CMfYDxnCZUHL8SYQ1dYIy6" Ids="KhX8dHrATUSNwEUwNBpL5b,BRoPiK1wphXNreRKmh5IZb" />
+        <Link Id="GC82FcsowiJLKpb3213kIZ" Ids="SEiGK78sHfjMWmz81rbENr,TMrGoNBoyeTOWQjVWVulrn" />
+        <Link Id="OBQmNdvYmDsOzYjH2XFjE3" Ids="DrFHrfIspyBOTdk92z6oNo,PFTnayONUPWLXhl1MDvHAy" />
+        <Link Id="PDmM8o4wkC5Pik2TVuviiY" Ids="DrFHrfIspyBOTdk92z6oNo,LghO1PJ7t3lP7q2IcyNEA6" />
+        <Link Id="PsEFGUjJci6LfTNSCZnKFo" Ids="Mp78ALGTe7jOoPYTm67rdE,Nq5uRuwXVI9LD0WkYUq6Aw" />
+        <Link Id="JawGjv5UaQxOBEuhiNx5Va" Ids="DDHDfPB2htbP2G23M9xDTv,T4ZTbYeT0xTOxLq1XwRKNQ" />
+        <Link Id="STCgiq8y55iPWVA9giXEYw" Ids="UyQqNWLiLUeNB2MlTdRPzK,KWdMJJEZdZzO6FWoPZuB2V" />
+        <Link Id="ToTBc9CvA4rQOP7WqTTuVz" Ids="UyQqNWLiLUeNB2MlTdRPzK,JNSy2q1VnoPMaBjkdAUofc" />
+        <Slot Id="EE0QW2zzp7CM19TqtixiMb" Name="Output" />
+        <Link Id="KDEAiD0YcmLLEx2PPwrI7y" Ids="ER9FUz3tODtM2EdTQkz0FN,Q3YQz91QYk6LA6o7LUZNMX" />
+        <Link Id="JVoOLSG1OsyMSoJaiRMHN0" Ids="Q3YQz91QYk6LA6o7LUZNMX,G1jTaW0UPEzOOH8Xl2LWix" />
+        <Link Id="Nt2txXvV5JUNMt1exS8KWt" Ids="LtxVPTVvONsLvZM05jNLDA,Iib055mBemkPRXHqAANAvw" />
+        <Link Id="UXykuAHShBqPkKWvBepoNh" Ids="Q3YQz91QYk6LA6o7LUZNMX,IqP57W1Z6WLOD30Uf1nioA" />
+        <Link Id="LZtAEsRst3NPhheeGwf4WN" Ids="V1OmmYnON4BLfxwiOcKKC8,BMMN6XByUBfMKzj01QDhXZ" />
+        <Link Id="OZMj0DKekDsPCwsD2gnIpO" Ids="NqdGEJpiWW7OplmJOUfX3M,JVPRoVdWWUfMvzQ7HRl1pF" />
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="NX7NHqLUE2PMSDB652jh0z" Location="VL.ImGui.Skia" Version="2025.7.0-0086-gcaebf60212" />
+  <NugetDependency Id="SHoTBAKidObOA5U33cTHBg" Location="VL.Skia" Version="2025.7.0-0086-gcaebf60212" />
+  <NugetDependency Id="Lk5kS5EFIsBOUJgl2h36Xe" Location="VL.WinFormsUtils" Version="1.0.11" />
+  <DocumentDependency Id="OHFiRIxa1D4NP5aXWbttpz" Location="../../../vl/UI/Schema.UI.vl" />
+  <DocumentDependency Id="DDbh3vuZXvOL3sGkYOa5kS" Location="../../../vl/VVVV.Schema.Core.vl" />
+</Document>

--- a/Main/installDependencies.ps1
+++ b/Main/installDependencies.ps1
@@ -23,7 +23,7 @@ $ignoreList = @(
 $nugetDirectory = Join-Path -Path $env:USERPROFILE -ChildPath "AppData\Local\vvvv\gamma\nugets"
 
 # NuGet executable path
-$nugetPath = "C:\Program Files\vvvv\vvvv_gamma_6.6\tools\NuGet.exe"
+$nugetPath = "C:\Program Files\vvvv\vvvv_gamma_6.7\tools\NuGet.exe"
 
 # Ensure NuGet executable exists
 if (-not (Test-Path -Path $nugetPath)) {

--- a/Main/vl/App/Schema.App.ProjectSelector.vl
+++ b/Main/vl/App/Schema.App.ProjectSelector.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="KWbcETv5tocLZLwFW8YcsS" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="KWbcETv5tocLZLwFW8YcsS" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory">
       <!--
@@ -780,7 +780,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.7" />
   <DocumentDependency Id="AIZZPl56EDgLMbYWA5MQcV" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="LxWQRtP0OlsOmBcYssV78H" Location="../Blocks/Schema.Blocks.vl" />
   <DocumentDependency Id="EQvzUt9U4aQL4pH4TLv5MM" Location="../UI/Schema.UI.vl" />
@@ -792,7 +792,7 @@
   <DocumentDependency Id="Iz4bAuXSdZmQXHQZDkGMmd" Location="../Plugins/ArtNetOutput/Schema.Plugins.ArtNetOutput.UI.vl" />
   <DocumentDependency Id="Ks8snV0hiirP8WFIViK81S" Location="../UI/Schema.UI.ExtrasMenu.vl" />
   <DocumentDependency Id="HlqnWNp3Ls2Nchsu2ZKuTY" Location="../Plugins/Controllers/Schema.Plugins.Controllers.UI.vl" />
-  <NugetDependency Id="PTdF95wHZSgNNf448FkzFt" Location="VL.WinFormsUtils" Version="1.0.9" />
+  <NugetDependency Id="PTdF95wHZSgNNf448FkzFt" Location="VL.WinFormsUtils" Version="1.0.11" />
   <DocumentDependency Id="FXGObGgkz8TNMWeWuN047x" Location="../UI/Logo/Schema.UI.Logo.vl" />
   <DocumentDependency Id="M7nUXZWRNniMSPxc7uLROs" Location="../Utilities/Schema.Utilities.FileSystem.vl" />
 </Document>

--- a/Main/vl/App/Schema.App.ProjectSelector.vl
+++ b/Main/vl/App/Schema.App.ProjectSelector.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="KWbcETv5tocLZLwFW8YcsS" LanguageVersion="2024.6.7" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="KWbcETv5tocLZLwFW8YcsS" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory">
       <!--
@@ -95,16 +95,19 @@
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Renderer" />
               </p:NodeReference>
-              <Pin Id="P3T00ap0aROLW0appyfA8D" Name="Bounds" Kind="InputPin" DefaultValue="818, 384, 600, 400">
+              <Pin Id="QiP9yw2a1owM9Qj1ncu96u" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="P3T00ap0aROLW0appyfA8D" Name="Bounds" Kind="InputPin" DefaultValue="816, 384, 600, 400">
                 <p:TypeAnnotation LastCategoryFullName="System.Drawing" LastDependency="System.Drawing.dll">
                   <Choice Kind="TypeFlag" Name="Rectangle" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="Csgp6rbzOJqNTex21ZrwnH" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
               <Pin Id="U8B1YlCfMVAPzmqNrMiqRQ" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
-              <Pin Id="QiP9yw2a1owM9Qj1ncu96u" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="IdwDMiDIC16OrrHkDZvydu" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+              <Pin Id="COyADCqCZcFNcxp7l4BByM" Name="Always On Top" Kind="InputPin" IsHidden="true" />
+              <Pin Id="EM0vvDFSoMiMll218AX5ic" Name="Extend Into Title Bar" Kind="InputPin" IsHidden="true" />
               <Pin Id="NaKdqtBhwM5OnkbTgJj50O" Name="Input" Kind="InputPin" />
+              <Pin Id="KMzaWk5AVmoLy8j4KH39Ll" Name="Title" Kind="InputPin" />
               <Pin Id="RdtlG5B5mvtPMHwUUh4Qm5" Name="Color" Kind="InputPin" />
               <Pin Id="HbG2nS46yy6LLv75MPBZwr" Name="Clear" Kind="InputPin" />
               <Pin Id="R6AP6FZSjifNgzCwcDCVlb" Name="Space" Kind="InputPin" />
@@ -164,6 +167,7 @@
               <Pin Id="J1aUFf4JHnlPcoZ86UiJoa" Name="Initial Result" Kind="InputPin" IsHidden="true" />
               <Pin Id="DnfJa3x1bFaNci8PjQIgzO" Name="Async Notifications" Kind="InputPin" />
               <Pin Id="QNa7quy6SisMDxxwsevrXD" Name="Reset" Kind="InputPin" />
+              <Pin Id="F1G28rjeVdHNmeaU4MwS0u" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="RqMLv3IrKv1Mofe8lRmHyt" Name="Value" Kind="OutputPin" />
               <Pin Id="AL2rVKelPkWMF49NqWKTZE" Name="On Data" Kind="OutputPin" />
             </Node>
@@ -176,6 +180,7 @@
               <Pin Id="A8xvVZ4K0TQODQYz8On34f" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="BHZOEwtk8n5MwCmk9o2ENK" Name="Messages" Kind="InputPin" />
               <Pin Id="AchA78daKgeNDEJ36TloA6" Name="Reset" Kind="InputPin" />
+              <Pin Id="VtwIVaAAofoQQiXqsuNQBL" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="MBX9EEYMbDDODBot0ZUb9w" Name="Result" Kind="OutputPin" />
               <Patch Id="RzjU9DqtuzkMcRWCj7S80i" ManuallySortedPins="true">
                 <Patch Id="KUSioOw9E1DOEwnZuBYhct" Name="Create" ManuallySortedPins="true" />
@@ -780,7 +785,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.7" />
+  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="AIZZPl56EDgLMbYWA5MQcV" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="LxWQRtP0OlsOmBcYssV78H" Location="../Blocks/Schema.Blocks.vl" />
   <DocumentDependency Id="EQvzUt9U4aQL4pH4TLv5MM" Location="../UI/Schema.UI.vl" />

--- a/Main/vl/App/Schema.App.Runtime.vl
+++ b/Main/vl/App/Schema.App.Runtime.vl
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Mmgay0mO1rbNSsziqlUXER" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="LFIvC2gUISuN02MaMYoU22" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="Mmgay0mO1rbNSsziqlUXER" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="LTmiVQs3DQaLQ3oxpbquDm">
     <Canvas Id="KwIr1K3CwwHOHsmEikSaLl" DefaultCategory="Schema.App.Runtime" CanvasType="FullCategory">
       <!--
@@ -111,14 +110,6 @@
             <ControlPoint Id="Fs8lyz9rdwWNKlLsl7EGov" Bounds="399,732" />
             <ControlPoint Id="Lc7FD3lyw3YQTaMo4q4yWe" Bounds="654,733" />
             <ControlPoint Id="R5ap9WV4Iz4M0h9PfiqqPd" Bounds="463,299" />
-            <Node Bounds="315,379,58,26" Id="HRpLgwLjyJ5L0PY0k5nwdR">
-              <p:NodeReference LastCategoryFullName="System.Console" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="WriteLine" />
-              </p:NodeReference>
-              <Pin Id="MwHjHagTmqZLfhS7QR5499" Name="Value" Kind="InputPin" />
-              <Pin Id="F29pVdaey0dN6p39Am5eWP" Name="Apply" Kind="InputPin" DefaultValue="True" />
-            </Node>
             <Pad Id="DRbtVa6WeqxMn1jOpvonmp" Comment="" Bounds="318,219,134,15" ShowValueBox="true" isIOBox="true" Value="Starting Schema Runtime&#xD;&#xA;Version ">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ImmutableTypeFlag" Name="String" />
@@ -236,8 +227,16 @@
               <Pin Id="Ria981Eb5EgL5SvYPPkWMA" Name="Wait Accuracy" Kind="OutputPin" IsHidden="true" />
             </Node>
             <Overlay Id="Gigo9DukothOCVn6FRA0UP" Name="FPS Throttling" Bounds="85,605,235,258" />
+            <Node Bounds="319,321,51,19" Id="L7Vf1WTqYpcQcGnXSJuhzR">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+              </p:NodeReference>
+              <Pin Id="CwD86SoZtCeLDEUl8NA4D9" Name="Message" Kind="InputPin" />
+            </Node>
+            <Pad Id="GnzXxQLHbO7P3RAD4sXcG3" Bounds="441,470,35,15" ShowValueBox="true" isIOBox="true" />
           </Canvas>
-          <Patch Id="IpL2RecCCxzMq336umRJzj" Name="Create" ParticipatingElements="HRpLgwLjyJ5L0PY0k5nwdR" />
+          <Patch Id="IpL2RecCCxzMq336umRJzj" Name="Create" ParticipatingElements="TF12tW6KD7eOgYA8dC7htY,L7Vf1WTqYpcQcGnXSJuhzR" />
           <Patch Id="NHWP2F00gX1O0tu3NVkwaK" Name="Update" ParticipatingElements="TiEmaQfO5FyNknBQlSs1e5">
             <Pin Id="Obck08dzQJjLorRQMfiakc" Name="Output" Kind="OutputPin" Bounds="397,734" />
             <Pin Id="NxuyLFtYmWrMeHmKxXs5oq" Name="Project Name" Kind="OutputPin" />
@@ -250,7 +249,7 @@
           <Slot Id="Jpq6tKxgnjfME0aUXsfv82" Name="Project Name" />
           <Link Id="NitZlXCBcHyMDHGj5Zi3wf" Ids="CYDkl8I7tI7NdJSsrcnAe4,GayBQuhmddrOreruHbgij8" />
           <Link Id="BtaikbvBRrPLoOrxPTsvcw" Ids="I3Yh8RPYYSAM4vVhum5zuS,KrPBy22I3hOQHv6wIbBraP" />
-          <Link Id="RQLrMlQ5KlWLKm5Sww4bgx" Ids="RWxIQ8P2VZsPBQJWKUrUra,IHCR7Fv6ZluNHlTK52UgKs" />
+          <Link Id="RQLrMlQ5KlWLKm5Sww4bgx" Ids="RWxIQ8P2VZsPBQJWKUrUra,GnzXxQLHbO7P3RAD4sXcG3" />
           <Link Id="Db6v5CAxn8oN2DvcS0X5lC" Ids="SR3LRYfTlCmMLkQjaTcBVh,DMFoKrHbbyANIhBOoMgZXT" />
           <Link Id="LCF6VccfQjBLkosI9SKYbC" Ids="A0UzoVOifVLLZzmN6tmpqP,TYRAZa2RcMVOcyTjXqfThB" />
           <Link Id="DLf1xTmVmntPul8t9NG05R" Ids="A0UzoVOifVLLZzmN6tmpqP,OHs6vuFEPs3PrJuN7whUCx" />
@@ -263,7 +262,7 @@
           <Link Id="DxB6dY0Tk0zOKbYOUd2SVr" Ids="Daa0jDanJeXQR9C9SXgClf,R5ap9WV4Iz4M0h9PfiqqPd" IsHidden="true" />
           <Link Id="RmuLFdsOAoiM2YXl5IP9Mw" Ids="DRbtVa6WeqxMn1jOpvonmp,FPUdwLsr4cdL3fbufBU01F" />
           <Link Id="F3G0avVPiqVMvNdygTqHuK" Ids="F5OWUcAvxvSQPH2pLcDJo8,IdYsrHu6CRuMrZsxlZgFi4" />
-          <Link Id="HX3EaKvkTQHLUyPgdqS7P1" Ids="ED1o10NILodLwKAcf9kSTX,MwHjHagTmqZLfhS7QR5499" />
+          <Link Id="HX3EaKvkTQHLUyPgdqS7P1" Ids="ED1o10NILodLwKAcf9kSTX,CwD86SoZtCeLDEUl8NA4D9" />
           <Link Id="B4kzVnxiThePIRABL40Oko" Ids="JKjv2FdWT7sO8AzbJK8sq5,OqFoSw8AJ5VLNhN9yAG7rq" />
           <Link Id="KeKRF82LdbJOgVSw9bjc0f" Ids="TILQW9jMUFOMLe5Ql7MKmp,BNkuh71oC29OQoRy2auo3v" />
           <Link Id="EjoZ03ptf1nQKOrR3FE049" Ids="AKorKKAliI0PRPCCFaQKFF,DS6JqQzj1efMCDhirW9d7C" />
@@ -273,6 +272,7 @@
           <Link Id="TXmwV3Q5ihqOBNoKcH1oFh" Ids="EtAE10FN2LiMJusA4kQBQi,A0fKH8M4y64OwlHmKPFwhW" />
           <Link Id="MeU9AjijRDeObIBhkILLQw" Ids="RBvH2hZTTddNb1bD3nrURG,RhjvD7CPwxkMZDHkTmhoPK" />
           <Link Id="AE2tUlaeil4OmUcpcZpiwV" Ids="F5OWUcAvxvSQPH2pLcDJo8,Ibur0Q7OKJzQTzku6snq8q" />
+          <Link Id="AcINCnh7JDOMBvzk8Amizl" Ids="GnzXxQLHbO7P3RAD4sXcG3,IHCR7Fv6ZluNHlTK52UgKs" />
         </Patch>
       </Node>
       <Canvas Id="KFGlshPsdQKM83BKof9Ekv" Name="Utilities" Position="188,81">
@@ -580,4 +580,5 @@
   <DocumentDependency Id="EE6nHiC4UCbQD3qw5Cwa9L" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="OFy1m5svP1PMck6JxllgK5" Location="../Schema.Projects.vl" />
   <DocumentDependency Id="U4uZf3cEA63QSx1uLyoitp" Location="../Schema.Version.vl" />
+  <NugetDependency Id="GWxYMgPyypzNpnQXh5r0n5" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/vl/App/Schema.App.RuntimeEditor.vl
+++ b/Main/vl/App/Schema.App.RuntimeEditor.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="SEZp2QoOKtvQYCy8GcjOBZ" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="SEZp2QoOKtvQYCy8GcjOBZ" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory">
       <!--
@@ -66,7 +66,7 @@
               <Pin Id="RWzFtVrviBpOUypvdI3UUk" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="RjWgFV5FmPJPEHcarss4E7" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="47,264,65,19" Id="Q2c93nFkvMVP0IVkOdCRPM">
+            <Node Bounds="41,264,65,19" Id="Q2c93nFkvMVP0IVkOdCRPM">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromValue" />
@@ -524,7 +524,7 @@
             <ControlPoint Id="SEDs0l0kH4iOZd4FunfbfH" Bounds="340,747" />
             <ControlPoint Id="HrcV911vYIHNL4pY8oeOIL" Bounds="406,746" />
             <ControlPoint Id="HvZs1pR5LG8PyTbblP4MTo" Bounds="403,287" />
-            <Node Bounds="343,384,103,19" Id="FoG3ZKaojUDM33PWyTy5zp">
+            <Node Bounds="341,384,103,19" Id="FoG3ZKaojUDM33PWyTy5zp">
               <p:NodeReference LastCategoryFullName="Main" LastDependency="Schema.UI.ExtrasMenu.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ExtrasMenuOverlay" />
@@ -534,7 +534,7 @@
               <Pin Id="HQ1OKWQNbzuLYY88R2g436" Name="Output" Kind="OutputPin" />
               <Pin Id="BMg3VlcIFjZPeyhWoFsQaJ" Name="Layer" Kind="OutputPin" />
             </Node>
-            <Node Bounds="343,418,137,19" Id="Vq9UGlHxFWWPNN8vd7yM8f">
+            <Node Bounds="341,418,137,19" Id="Vq9UGlHxFWWPNN8vd7yM8f">
               <p:NodeReference LastCategoryFullName="Schema.Controllers2.UI" LastDependency="Schema.Plugins.Controllers.UI.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ControllerOverviewOverlay" />
@@ -599,7 +599,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.7" />
   <DocumentDependency Id="AIZZPl56EDgLMbYWA5MQcV" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="LxWQRtP0OlsOmBcYssV78H" Location="../Blocks/Schema.Blocks.vl" />
   <DocumentDependency Id="EQvzUt9U4aQL4pH4TLv5MM" Location="../UI/Schema.UI.vl" />

--- a/Main/vl/App/Schema.App.RuntimeEditor.vl
+++ b/Main/vl/App/Schema.App.RuntimeEditor.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="SEZp2QoOKtvQYCy8GcjOBZ" LanguageVersion="2024.6.7" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="SEZp2QoOKtvQYCy8GcjOBZ" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory">
       <!--
@@ -143,6 +143,247 @@
               <Pin Id="SDzgQzqd9QhOSqMw4BtEkC" Name="Output" Kind="StateOutputPin" />
             </Node>
             <ControlPoint Id="LLGUjQH1wtTL1uyWz5cVh4" Bounds="223,413" />
+            <Node Bounds="-165,10,68,19" Id="Q4oPLccfzMRLwUXNQscCEd">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetFixtures (State)" />
+              </p:NodeReference>
+              <Pin Id="SwhfXT1GIM4NX5Oidh6bUd" Name="Input" Kind="InputPin" />
+              <Pin Id="OJHAYvmpZ8kOa2Ee5cAucn" Name="Output" Kind="OutputPin" />
+              <Pin Id="Dt8tCbv1IVrN2DB0NknQVc" Name="Fixtures" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-197,50,100,26" Id="ERjzwUGSVVVNN1zfbodDLr">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixtures" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetFixtureByName" />
+              </p:NodeReference>
+              <Pin Id="KHwgHRFHoIFLBdjzUPUgGN" Name="Input" Kind="StateInputPin" />
+              <Pin Id="TIX4DKXUoaIOFN3SRrbTZR" Name="Name" Kind="InputPin" DefaultValue="Virtual" />
+              <Pin Id="JB2YKdVpcxKPnnHhl0uHgD" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="V1QGyy41AuRMTHIesolhm1" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-191,90,57,26" Id="GRgAm01ysT6LErqVkVDfHp">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Fixture" />
+                <Choice Kind="OperationCallFlag" Name="GetSetup" />
+              </p:NodeReference>
+              <Pin Id="C6PvcmVb2ubPL0dAMWzdMo" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Q1VUkidF1ENNv2sC8JwHFA" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="ASi7dPElVYzL8WUqpOwgp4" Name="Setup" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-37,47,58,70" Id="RvrXtq9LhDUNx5FBqR9teE">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+              </p:NodeReference>
+              <Pin Id="FXhibMo8MA0OFVQlaiICiy" Name="Break" Kind="OutputPin" />
+              <Patch Id="SZjVFpDUR5AQHPtRLJREhU" ManuallySortedPins="true">
+                <Patch Id="Rq1sStC8AEsNtkd1fU44Qy" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="U2ru6Bs0bJyOIyJeewzWtv" Name="Update" ManuallySortedPins="true" />
+                <Patch Id="MEqKWRIA4rjLsGWDZNE5Xz" Name="Dispose" ManuallySortedPins="true" />
+                <Node Bounds="-25,70,34,19" Id="EV7pPjlN1n1MMkceI8Zn0g">
+                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="XYz" />
+                  </p:NodeReference>
+                  <Pin Id="SflMwzVSkeUMhPGAstSJcg" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="T2Msd3SoWjvPyCJiKiENnZ" Name="Z" Kind="InputPin" />
+                  <Pin Id="Kplkbn2LCN2NHgRvQbLez4" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="UIN4aaruYJ5P0JKdg0eujC" Bounds="-23,53" Alignment="Top" />
+              <ControlPoint Id="FU0Qxlclan9N5eA7G2xf2g" Bounds="-23,111" Alignment="Bottom" />
+            </Node>
+            <Node Bounds="-25,10,85,19" Id="DPrhNfubUQuMSWF4KANVf3">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="CircleSpread" />
+              </p:NodeReference>
+              <Pin Id="AstJtnh52Z9PkT8LsjkgKf" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="MplqIsJYa8FLhxDnIMBVAd" Name="Center" Kind="InputPin" />
+              <Pin Id="EfT5CIcEAbeNHvlHZdi0Wx" Name="Width" Kind="InputPin" DefaultValue="4.6, 4.6" />
+              <Pin Id="ML8zKjnY4dSMLzEnREfrSZ" Name="Factor" Kind="InputPin" />
+              <Pin Id="LGPMOxrjiX3OSKJl9GULSc" Name="Phase" Kind="InputPin" DefaultValue="-0.25" />
+              <Pin Id="R9uz2Ay1uhaMcNFIfrSjAJ" Name="Count" Kind="InputPin" DefaultValue="240" />
+              <Pin Id="GP5ZGAhSYWNP7GZ3aJcjvf" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-100,340,44,26" Id="H1tTFsrz12BOI8bxlBzdPK">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="Count" />
+              </p:NodeReference>
+              <Pin Id="GNVlNdjR1baMtecWCQkHZd" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Kio2t7k5LLhQGQ9sYIHT7n" Name="Count" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-93,108,201,148" Id="Q7YO7cHVW9bNvfMxRG7nsi">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+              </p:NodeReference>
+              <Pin Id="VPsQZ0nSmY5MpftjF2eQ6q" Name="Break" Kind="OutputPin" />
+              <Patch Id="JhqZ9ZdAE47QdMc62yKM46" ManuallySortedPins="true">
+                <Patch Id="S04c9gyEMspL4hntsn5sfB" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="P4ateiitGsWNA92G1RLQxo" Name="Update" ManuallySortedPins="true" />
+                <Patch Id="EokyTivwcgnNSGh3CGY5DP" Name="Dispose" ManuallySortedPins="true" />
+                <Node Bounds="-42,150,88,86" Id="HB4uKvqA1ybMi2tuTNHwu0">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                  </p:NodeReference>
+                  <Pin Id="DWIFzyu10BBQdb3UtdwMZL" Name="Break" Kind="OutputPin" />
+                  <Patch Id="DS2LF9Rp7vXNfQBfWAfnN5" ManuallySortedPins="true">
+                    <Patch Id="IsdJKNSBu6IPpBjjS20Lpr" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="JPHWBlZsHzCNy9NqEI4UbY" Name="Update" ManuallySortedPins="true" />
+                    <Patch Id="ErRxugBvXqqOq1wQRUezGC" Name="Dispose" ManuallySortedPins="true" />
+                    <Node Bounds="-30,182,64,19" Id="RQCOrSZIE3aMFrpsBu5x9O">
+                      <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="Transform" />
+                      </p:NodeReference>
+                      <Pin Id="R0KhQFMtPw5M8U4scuoaPl" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="JqrSmkec0KHMYakPlQyOz8" Name="Transform" Kind="InputPin" />
+                      <Pin Id="KVBw5xOUJgCPlFDl3RtmJZ" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                  </Patch>
+                  <ControlPoint Id="QbDeEyECqwLMBmUo6ZJMGv" Bounds="-22,156" Alignment="Top" />
+                  <ControlPoint Id="MybtP3zOwaZQS5M57UbPjG" Bounds="-27,230" Alignment="Bottom" />
+                </Node>
+                <Node Bounds="51,140,45,19" Id="FDDcg0K9kjANRog0QPyuLa">
+                  <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Rotate (Axis)" />
+                  </p:NodeReference>
+                  <Pin Id="SiEi9zTAkPIOF19FxXWOfI" Name="Input" Kind="InputPin" />
+                  <Pin Id="Qsh5UnhP7VLLxhKUd57GVk" Name="Axis" Kind="InputPin" />
+                  <Pin Id="V2Ew5ufQecVP7K74enzHf0" Name="Angle" Kind="InputPin" />
+                  <Pin Id="H75aS2vilATP6SMe5Cy8yX" Name="Output" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="LwjEqTdraJaOG6mW9At1pI" Bounds="16,114" Alignment="Top" />
+              <ControlPoint Id="TeyxyjdbmQ1NNZfBczZR8R" Bounds="-26,250" Alignment="Bottom" />
+            </Node>
+            <Node Bounds="56,60,85,19" Id="Me9mKFFbW8UQG2eK6uUeu4">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
+              </p:NodeReference>
+              <Pin Id="Evw5TGlsgN3OPSRNnGR44K" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="IcRbBIBOb3kNp5kkw14Y8w" Name="Center" Kind="InputPin" />
+              <Pin Id="GsiJ5v2P7GfO9OzPQrZ4mL" Name="Width" Kind="InputPin" DefaultValue="0.5" />
+              <Pin Id="OoJtOhFmEqHMkw7h6RgOsn" Name="Alignment" Kind="InputPin" />
+              <Pin Id="NPbKHH8hVBXOjKlAX1W8fO" Name="Phase" Kind="InputPin" />
+              <Pin Id="Pa8oHTyeATbQHMj6iOqGoz" Name="Count" Kind="InputPin" DefaultValue="4" />
+              <Pin Id="B315N7wed3XNqdziuNlH2r" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-38,260,47,19" Id="Sd6camx5GuCNRPHkUigIny">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="Flatten" />
+              </p:NodeReference>
+              <Pin Id="NZPQUScIfW7L4uVoYdFvfa" Name="Input" Kind="StateInputPin" />
+              <Pin Id="UEeB6LG6Z8qMysxs2XEIfa" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Pad Id="A8onKCrk2Q5LpIJbRanUDx" Comment="Axis" Bounds="116,150,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1, 0">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Vector3" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Pad Id="GIvRPUHSwkzQdKYKgTJXpj" Comment="" Bounds="-58,310" isIOBox="true" />
+            <Node Bounds="-42,290,63,26" Id="D218DLY1ZG5MCNwFhi6KtF">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetSpread" />
+              </p:NodeReference>
+              <Pin Id="I2Ycgt0NcbYODgUnSDUW6p" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Qvy2o8dzVqPOhndVvCFEmE" Name="Index" Kind="InputPin" />
+              <Pin Id="Oe30GwDugztQD5zdXCTTgO" Name="Count" Kind="InputPin" />
+              <Pin Id="KRQ0istynBzQEj784X4VeA" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="-122,280,44,26" Id="VV3vzU4FxKCLtNFSJJSOrX">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="Count" />
+              </p:NodeReference>
+              <Pin Id="ELVLe5V14s3LmGGyN9Lvti" Name="Input" Kind="StateInputPin" />
+              <Pin Id="NaGftX3mJAGO9RyEL5KNxG" Name="Count" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-77,301,25,19" Id="DuuCgwzkJdUPKdBC9PSwNM">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="-" />
+              </p:NodeReference>
+              <Pin Id="TqZO3KcqCRvMfgl3xJjyxl" Name="Input" Kind="InputPin" />
+              <Pin Id="Cx0GGVYlAIgNjhlfAaLLeS" Name="Input 2" Kind="InputPin" />
+              <Pin Id="TfA74nwEO8PPlWxWo1LtGo" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-176,200,25,19" Id="NvB1Zs5BMFeOzdmuq0vUTj">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="/" />
+              </p:NodeReference>
+              <Pin Id="O4YLmm0g9LnL6GI3pnpXTP" Name="Input" Kind="InputPin" />
+              <Pin Id="SAjcTchDXPLLDpTYGdvEUT" Name="Input 2" Kind="InputPin" DefaultValue="2" />
+              <Pin Id="TkVkDgFg6BNLLZu44nQBGo" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Pad Id="AjaoVJ35BKVM1ekoqjJ9gT" Comment="Count" Bounds="57,-20,35,15" ShowValueBox="true" isIOBox="true" Value="240">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Integer32" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="-176,180,62,19" Id="Qj0ffu5VSvyPOL5DyKAeLG">
+              <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToFloat32" />
+              </p:NodeReference>
+              <Pin Id="HxUcathdvSgQaUiEmgJbxX" Name="Input" Kind="InputPin" />
+              <Pin Id="Tf4H3hpobBsNZnx6sx8uAm" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-176,230,46,19" Id="DNxW8MDdSE9MPCByJOGQTr">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Round" />
+              </p:NodeReference>
+              <Pin Id="CNjBMPgVu8TNSEIWnKHp5L" Name="Input" Kind="InputPin" />
+              <Pin Id="UVNmzuBdr7uLX1yLIWLQGy" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="-353,296,117,92" Id="D2ri3fwihcyP8k1RfIvxth">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+              </p:NodeReference>
+              <Pin Id="OdmEow5eTqoNGmKQ7FzNlm" Name="Condition" Kind="InputPin" DefaultValue="False" />
+              <Patch Id="Jp7pgBkYPyTPizWcs1fu6Z" ManuallySortedPins="true">
+                <Patch Id="R61NdBKhumjMQtFzQMX1Rf" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="NIjqovj7zQfOPC8i0BbZ9t" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="-341,319,93,19" Id="GXNMDBJih0TNHjDwqA2PLo">
+                  <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetPixelPositions" />
+                  </p:NodeReference>
+                  <Pin Id="NnmbfN2eg83OfQ30MuZ5d1" Name="Input" Kind="InputPin" />
+                  <Pin Id="JKY04rWUM0fNWOXczYzJJm" Name="Value" Kind="InputPin" />
+                  <Pin Id="OD7IryFOr6yMDIqf8mxOdr" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="-341,349,79,19" Id="FysygFnyruwPeP88DmtVsK">
+                  <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetPixelCount" />
+                  </p:NodeReference>
+                  <Pin Id="EYXxbtvEUrdOjO7JDRK62g" Name="Input" Kind="InputPin" />
+                  <Pin Id="LkwDOYkdVKpMVoRQDmpE6N" Name="Value" Kind="InputPin" />
+                  <Pin Id="RU88nYVoJV7PawBQcBYs4W" Name="Output" Kind="OutputPin" />
+                </Node>
+              </Patch>
+            </Node>
           </Canvas>
           <Patch Id="DFJlyutS9LkOSOKZeb1JnV" Name="Create" />
           <Patch Id="JxTG77arUFeLdi8WjlFKS6" Name="Update">
@@ -175,6 +416,36 @@
           <Link Id="SxMRb1ruwjrMP91MyU86P4" Ids="BSDYBUmOaEyLq4savgFbNw,DzKB3492sNMM9Sd2FAC3IA" />
           <Link Id="P1aTVkLa6FMPVDvrwpeb82" Ids="SuIPb7voOOiMFTOaAwYYIB,LLGUjQH1wtTL1uyWz5cVh4" />
           <Link Id="KICc7C4jFZ3P3CBwEnBAA9" Ids="LLGUjQH1wtTL1uyWz5cVh4,GEgH5CrTL3rOWeeeRrFNZK" IsHidden="true" />
+          <Link Id="PoD84lovUfGPOMs9UYfTU4" Ids="IpXneshOsvQNkvG8tm6Gzk,SwhfXT1GIM4NX5Oidh6bUd" />
+          <Link Id="RtxLO6OdlQdP9AzmG2mp7y" Ids="Dt8tCbv1IVrN2DB0NknQVc,KHwgHRFHoIFLBdjzUPUgGN" />
+          <Link Id="HclXEiL1RbqLqLfMKBUNGc" Ids="V1QGyy41AuRMTHIesolhm1,C6PvcmVb2ubPL0dAMWzdMo" />
+          <Link Id="Bjwapo92JDRLVUVb9YJw3r" Ids="ASi7dPElVYzL8WUqpOwgp4,NnmbfN2eg83OfQ30MuZ5d1" />
+          <Link Id="Gw74Q0TKXvpLRVfdNDIKmN" Ids="GP5ZGAhSYWNP7GZ3aJcjvf,UIN4aaruYJ5P0JKdg0eujC" />
+          <Link Id="K9yX5iLH8eYOffSVjaRG7g" Ids="UIN4aaruYJ5P0JKdg0eujC,SflMwzVSkeUMhPGAstSJcg" />
+          <Link Id="VLgCGMsdDivP4qYAUwGtWT" Ids="Kplkbn2LCN2NHgRvQbLez4,FU0Qxlclan9N5eA7G2xf2g" />
+          <Link Id="DNd1zzqYZp8QModznEhMMA" Ids="Kio2t7k5LLhQGQ9sYIHT7n,LkwDOYkdVKpMVoRQDmpE6N" />
+          <Link Id="KjbLeIDnTAINe3PgTDojKh" Ids="B315N7wed3XNqdziuNlH2r,LwjEqTdraJaOG6mW9At1pI" />
+          <Link Id="QRlXicwwB2wOtX6MHJWSv6" Ids="FU0Qxlclan9N5eA7G2xf2g,QbDeEyECqwLMBmUo6ZJMGv" />
+          <Link Id="B3ZCvAmX0hQP0P5WCiAExT" Ids="H75aS2vilATP6SMe5Cy8yX,JqrSmkec0KHMYakPlQyOz8" />
+          <Link Id="MiR9GcYDtC1PE07QtJaBXn" Ids="LwjEqTdraJaOG6mW9At1pI,V2Ew5ufQecVP7K74enzHf0" />
+          <Link Id="Fd8ArbzargiMQV5vQKph4Y" Ids="QbDeEyECqwLMBmUo6ZJMGv,R0KhQFMtPw5M8U4scuoaPl" />
+          <Link Id="Nkeut0YdNkIMipHYszJe5m" Ids="KVBw5xOUJgCPlFDl3RtmJZ,MybtP3zOwaZQS5M57UbPjG" />
+          <Link Id="Lfr3vbIOXYkOJooW1ZhcCq" Ids="MybtP3zOwaZQS5M57UbPjG,TeyxyjdbmQ1NNZfBczZR8R" />
+          <Link Id="UM99ftfymC4OCDd7UFrEOa" Ids="TeyxyjdbmQ1NNZfBczZR8R,NZPQUScIfW7L4uVoYdFvfa" />
+          <Link Id="LsuoWol443JN70bzMqSdRd" Ids="UEeB6LG6Z8qMysxs2XEIfa,I2Ycgt0NcbYODgUnSDUW6p" />
+          <Link Id="KQDHDclozjzQF9xszTLyAs" Ids="A8onKCrk2Q5LpIJbRanUDx,Qsh5UnhP7VLLxhKUd57GVk" />
+          <Link Id="E9Yb8klwyXjNU7b5Bmfd0U" Ids="GIvRPUHSwkzQdKYKgTJXpj,GNVlNdjR1baMtecWCQkHZd" />
+          <Link Id="KRxTppY3ZnKLJOtm1B0dm7" Ids="GIvRPUHSwkzQdKYKgTJXpj,JKY04rWUM0fNWOXczYzJJm" />
+          <Link Id="EldHtyemmvhLWrC70keyFQ" Ids="KRQ0istynBzQEj784X4VeA,GIvRPUHSwkzQdKYKgTJXpj" />
+          <Link Id="TNabDKvspIlLsHh832uQSz" Ids="UEeB6LG6Z8qMysxs2XEIfa,ELVLe5V14s3LmGGyN9Lvti" />
+          <Link Id="Ki1q1ZJ4NAkNdCvDlCXcHi" Ids="NaGftX3mJAGO9RyEL5KNxG,TqZO3KcqCRvMfgl3xJjyxl" />
+          <Link Id="FEK1AXI5pqZNibeY2WFsJB" Ids="TfA74nwEO8PPlWxWo1LtGo,Oe30GwDugztQD5zdXCTTgO" />
+          <Link Id="PUtqz4P1tbEPTIs5RKXIDY" Ids="AjaoVJ35BKVM1ekoqjJ9gT,R9uz2Ay1uhaMcNFIfrSjAJ" />
+          <Link Id="ImK5KX4qIonNuaCdf2uziJ" Ids="AjaoVJ35BKVM1ekoqjJ9gT,HxUcathdvSgQaUiEmgJbxX" />
+          <Link Id="DRzBN46WhU3N6BseYreOZu" Ids="Tf4H3hpobBsNZnx6sx8uAm,O4YLmm0g9LnL6GI3pnpXTP" />
+          <Link Id="Dya2oGUPKZNOzWcU6WR6uU" Ids="TkVkDgFg6BNLLZu44nQBGo,CNjBMPgVu8TNSEIWnKHp5L" />
+          <Link Id="E4lyMgLdgYrQAZPdY3A87D" Ids="UVNmzuBdr7uLX1yLIWLQGy,Cx0GGVYlAIgNjhlfAaLLeS" />
+          <Link Id="LnG83LHs1tZLop290i8bpj" Ids="OD7IryFOr6yMDIqf8mxOdr,EYXxbtvEUrdOjO7JDRK62g" />
         </Patch>
       </Node>
       <!--
@@ -599,7 +870,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2024.6.7" />
+  <NugetDependency Id="QLtFNGbqxEpNp5tg50c80H" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="AIZZPl56EDgLMbYWA5MQcV" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="LxWQRtP0OlsOmBcYssV78H" Location="../Blocks/Schema.Blocks.vl" />
   <DocumentDependency Id="EQvzUt9U4aQL4pH4TLv5MM" Location="../UI/Schema.UI.vl" />

--- a/Main/vl/App/Schema.App.Studio.vl
+++ b/Main/vl/App/Schema.App.Studio.vl
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="T7mbL0jScB9PFhnLhBQhL9" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="HPmJL4Ai165QK8hvzcayVN" Location="VL.CoreLib" Version="2025.7.0" />
+  <Patch Id="AitlDO4vc7AOJ9qzrVbBsj">
+    <Canvas Id="QgzQptbW09QLXR57KeYym2" DefaultCategory="Schema.App.Studio" CanvasType="FullCategory">
+      <!--
+
+    ************************ SchemaStudio ************************
+
+-->
+      <Node Name="SchemaStudio" Bounds="46,70" Id="JqAqjPeXQc7N9hbgbwN0Hm">
+        <p:NodeReference>
+          <Choice Kind="ContainerDefinition" />
+        </p:NodeReference>
+        <Patch Id="Q5ix6LmxxUyO7H5ruKlL9n">
+          <Canvas Id="A1Dtblk8PQoPaJCCYJAXz0" CanvasType="Group">
+            <Node Bounds="48,138,148,183" Id="G06I30JuP0SLRundS4SQMO">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:NodeReference>
+              <Pin Id="PhyBpSAWBi7PWgRFq8Uldi" Name="Condition" Kind="InputPin" />
+              <Patch Id="R0YEbI7HqvALOHXcx9WA9E" ManuallySortedPins="true">
+                <Patch Id="RQ9FbqpPFlsMqpZq8jE9Eo" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="Uag9jxmIy2yPJQvnosVnGN" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="79,158,105,95" Id="PObTG8JJHJ4QJFeyUOxPZk">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Try" />
+                  </p:NodeReference>
+                  <Pin Id="QB2hvYGIuVgL2jdHbs5r4C" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="LMQH5rRrL92PzRJ9CSoQNp" Name="User Exceptions Channel" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="JCSHXGILwYRMTjsLJXI6JP" Name="Stick To Last Valid Outputs" Kind="InputPin" />
+                  <Pin Id="TCRTm5sg2wrPyIKZJy7gvS" Name="Reset Region On Failure" Kind="InputPin" />
+                  <Pin Id="QfOUcxFUkEzPivynezOqtC" Name="Success" Kind="OutputPin" />
+                  <Pin Id="GMd8drSRi69PlWL3nDocca" Name="Failure" Kind="OutputPin" />
+                  <Pin Id="UTMe2AxQxi1NbHq58R6bAl" Name="Error Message" Kind="OutputPin" />
+                  <Pin Id="Cyvx6WopyMlQEf3Jt61PUe" Name="Exceptions" Kind="OutputPin" />
+                  <Patch Id="Oe9iwrOk1MvMqn3JcPiPVz" ManuallySortedPins="true">
+                    <Node Bounds="91,181,81,19" Id="PxNNMIQwFNTPBTNYEeKz0q">
+                      <p:NodeReference LastCategoryFullName="Schema.App" LastDependency="Schema.App.RuntimeEditor.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="ProcessAppFlag" Name="RuntimeEditor" />
+                      </p:NodeReference>
+                      <Pin Id="O1gMNhd1ZXLQK84LO4L2dO" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="JrS0gu0P5eSN3srawC1h7W" Name="Reload Modules" Kind="InputPin" />
+                      <Pin Id="RQhCmvHbuy7PuKHO2JVjUA" Name="Output" Kind="OutputPin" />
+                      <Pin Id="C2eWKLQmao8NeczYZh0ajN" Name="EditorState" Kind="OutputPin" />
+                    </Node>
+                    <Patch Id="AHwOeKfwuHmQE2Gjs6udzn" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="IBewXhXuK30O7kQ89UWlm4" Name="Update" ParticipatingElements="E4CasosMtVeNVZ7gfMB3O1" />
+                    <Node Bounds="91,214,45,19" Id="S2eGP5GsUNvMo56xsTGPpN">
+                      <p:NodeReference LastCategoryFullName="Schema" LastDependency="Schema.Blocks.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="ProcessAppFlag" Name="Blocks" />
+                      </p:NodeReference>
+                      <Pin Id="RB3BodspRfqM67lLHCFx1A" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="V29gQyGGVIbLrD3EzVML5i" Name="Input" Kind="InputPin" />
+                      <Pin Id="TKDjYfnTeeXOX32JucWWcr" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Patch Id="PXH78t494cqN9qoA7n2d1n" Name="Dispose" />
+                  </Patch>
+                  <Pin Id="RklK1WoumIsK9mt3fsJ4K1" Name="Warn" Kind="InputPin" />
+                  <ControlPoint Id="M4jmmwtohLQNT5v47SXxou" Bounds="93,247" Alignment="Bottom" />
+                </Node>
+                <Node Bounds="105,282,55,19" Id="OfMZtNNkQ2pNh2iLQesDNL">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="LogError (String)" />
+                  </p:NodeReference>
+                  <Pin Id="CuLgMZWua1yOn6CTtOZ1j3" Name="Message" Kind="InputPin" />
+                  <Pin Id="VvjNmKOKG5PMZlUMJ6f1Pg" Name="Apply" Kind="InputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="Dxm9KWnUKUyPWrEsLXRIBW" Bounds="93,315" Alignment="Bottom" />
+              <ControlPoint Id="DfEBNTrLwYDOyrYiC3JXOw" Bounds="93,144" Alignment="Top" />
+            </Node>
+            <Pad Id="Q6XnaO5MZB7QA0eaGSh6mX" Comment="Start Runtime" Bounds="47,87,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+                <FullNameCategoryReference ID="Primitive" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="45,40,95,19" Id="LSlnuIHUwoMPI131SgdLmO">
+              <p:NodeReference LastCategoryFullName="Schema.App" LastDependency="Schema.App.ProjectSelector.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="SelectProjectFlow" />
+              </p:NodeReference>
+              <Pin Id="PU16ReOcduvO3NPgwl4xSE" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="A1JsV3TdSaRPqZltHOaS2e" Name="Selected" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="Tjj3Fz9Imb9MM5Bzhb3Va7" Bounds="93,360" />
+            <Node Bounds="99,100,40,19" Id="QTfqfGvtLbENhdKbOhm5Fl">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="NULL" />
+              </p:NodeReference>
+              <Pin Id="RDLNpHOsCs5Mif7rSgWolX" Name="Result" Kind="OutputPin" />
+            </Node>
+          </Canvas>
+          <Patch Id="MeFduzyyfKtLEGYPpWwjPX" Name="Create" />
+          <Patch Id="SvBJVPwEi1pM068wv86ENa" Name="Update">
+            <Pin Id="PStwzgGnLRQM8YIA9Cyd7d" Name="State" Kind="OutputPin" />
+          </Patch>
+          <!--
+
+    ************************  ************************
+
+-->
+          <ProcessDefinition Id="DmQg9SL1n8eNetBcxVf4Xv">
+            <Fragment Id="DfKtpBZOWdrOx5eePLLUoE" Patch="MeFduzyyfKtLEGYPpWwjPX" Enabled="true" />
+            <Fragment Id="Rv10jROOwatPkK2utVzgga" Patch="SvBJVPwEi1pM068wv86ENa" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="OFbsSgfj1ZKPx0JvXLLKGO" Ids="Q6XnaO5MZB7QA0eaGSh6mX,PhyBpSAWBi7PWgRFq8Uldi" />
+          <Link Id="SlGkOsBwMKdP4yURqfZgyT" Ids="GMd8drSRi69PlWL3nDocca,VvjNmKOKG5PMZlUMJ6f1Pg" />
+          <Link Id="LqZpRhit9csLrAcaULe9Xh" Ids="UTMe2AxQxi1NbHq58R6bAl,CuLgMZWua1yOn6CTtOZ1j3" />
+          <Link Id="E4CasosMtVeNVZ7gfMB3O1" Ids="RQhCmvHbuy7PuKHO2JVjUA,V29gQyGGVIbLrD3EzVML5i" />
+          <Link Id="GLh03bVzpCNOcSO4fBQj3x" Ids="A1JsV3TdSaRPqZltHOaS2e,Q6XnaO5MZB7QA0eaGSh6mX" />
+          <Link Id="OkY5iwr687zPVWK8Mdt3Ks" Ids="TKDjYfnTeeXOX32JucWWcr,M4jmmwtohLQNT5v47SXxou" />
+          <Link Id="FnNXAKSNKRNNl6PXoYDMTS" Ids="DfEBNTrLwYDOyrYiC3JXOw,Dxm9KWnUKUyPWrEsLXRIBW" IsFeedback="true" />
+          <Link Id="Cy55AP1BBefOg2f57wFSGK" Ids="M4jmmwtohLQNT5v47SXxou,Dxm9KWnUKUyPWrEsLXRIBW" />
+          <Link Id="ILeola4PKyBPIYUxXHOYxV" Ids="Dxm9KWnUKUyPWrEsLXRIBW,Tjj3Fz9Imb9MM5Bzhb3Va7" />
+          <Link Id="NJug0ncufaKOEdL7H1EGH7" Ids="Tjj3Fz9Imb9MM5Bzhb3Va7,PStwzgGnLRQM8YIA9Cyd7d" IsHidden="true" />
+          <Link Id="NS2YEEUR5ROQVKvadSYzCD" Ids="RDLNpHOsCs5Mif7rSgWolX,DfEBNTrLwYDOyrYiC3JXOw" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="HgWA26BDwBQLmaT7WL3vF8">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <CategoryReference Kind="Category" Name="Primitive" />
+      </p:NodeReference>
+      <Patch Id="UC95A4tb6UOMXwWsMdQHYZ">
+        <Canvas Id="V3jH1AREwP9OemxrCzWJvN" CanvasType="Group" />
+        <Patch Id="K5GIkd9vt5MN05fJtZZIjf" Name="Create" />
+        <Patch Id="OEVvV9zb5tNN2eUPYvLI41" Name="Update" />
+        <ProcessDefinition Id="HL3030O6AtQLV5ifutKddh">
+          <Fragment Id="T8SBAtDCr4TM1k5A3l7FrI" Patch="K5GIkd9vt5MN05fJtZZIjf" Enabled="true" />
+          <Fragment Id="Nv7CwoMVPcyMpbSRbgXcH6" Patch="OEVvV9zb5tNN2eUPYvLI41" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="CcL7UBBRNl6PeVGf9JBL1A" Location="./Schema.App.ProjectSelector.vl" />
+  <DocumentDependency Id="SlSMam9XsDMMAXsupmHqAR" Location="./Schema.App.RuntimeEditor.vl" />
+  <DocumentDependency Id="F9o01pwbQsWMxzZHxP0dk7" Location="../Blocks/Schema.Blocks.vl" />
+  <DocumentDependency Id="CF1cue434gYORCAlf1g47L" Location="../Utilities/Schema.Utilities.Logging.vl" />
+</Document>

--- a/Main/vl/Blocks/Schema.Blocks.vl
+++ b/Main/vl/Blocks/Schema.Blocks.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="L7Vo8ZPUrq9Mv9n0E4gDS5" LanguageVersion="2024.6.2" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="L7Vo8ZPUrq9Mv9n0E4gDS5" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="PLXooxhceXrLbo2i3C2kIL">
     <Canvas Id="AdAzzIseIAWMpkZQxkK0Vb" DefaultCategory="Schema" CanvasType="FullCategory">
       <!--
@@ -7,7 +7,7 @@
     ************************ Blocks ************************
 
 -->
-      <Node Name="Blocks" Bounds="419,260" Id="QOQD5oz3UPjLA1fDoeQGQx">
+      <Node Name="Blocks" Bounds="85,100" Id="QOQD5oz3UPjLA1fDoeQGQx">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
@@ -140,5 +140,5 @@
   <DocumentDependency Id="EClgGmUd5mbQbSObwKXsy4" Location="./Operator/Schema.Blocks.Operator.vl" />
   <DocumentDependency Id="EWWcVO3nXZkMTVYoX0LIDk" Location="./Setup/Schema.Blocks.Setup.vl" />
   <DocumentDependency Id="ESv6YZTLk1lN79UMwRNqs5" Location="./Assign/Schema.Blocks.Assign.vl" />
-  <NugetDependency Id="SpSlbQKNXOTQZV0bDGeKHy" Location="VL.CoreLib" Version="2024.6.2" />
+  <NugetDependency Id="SpSlbQKNXOTQZV0bDGeKHy" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/vl/Blocks/Source/Color/Pixel/Schema.Blocks.Source.Color.Pixel.Rainbow.vl
+++ b/Main/vl/Blocks/Source/Color/Pixel/Schema.Blocks.Source.Color.Pixel.Rainbow.vl
@@ -1,0 +1,439 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="DVNh3zKb7C4O4kio2DDIvm" LanguageVersion="2025.7.0" Version="0.128">
+  <Patch Id="EyoF9RnhzvZNZr7Rhw75jq">
+    <Canvas Id="F4B6hYdP6X0OnfoAaH239d" DefaultCategory="Schema.Blocks.Color.Pixel" CanvasType="FullCategory">
+      <!--
+
+    ************************ Rainbow ************************
+
+-->
+      <Node Name="Rainbow" Bounds="71,80" Id="GoK9Gvf33dQLxKJR2D97fl">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
+          <Choice Kind="ClassDefinition" Name="Class" />
+        </p:NodeReference>
+        <p:Interfaces>
+          <TypeReference LastCategoryFullName="VVVV.Schema" LastDependency="VVVV.Schema.Core.vl">
+            <Choice Kind="InterfaceTypeFlag" Name="IBee" />
+          </TypeReference>
+        </p:Interfaces>
+        <Patch Id="SKusLXURMKVLdVSM7dtVbt">
+          <Canvas Id="ALH3pYPt3IsORNq8G8ix1m" CanvasType="Group">
+            <ControlPoint Id="ILa3dSedO8SMFKHVBKhJGT" Bounds="1467,242" />
+            <ControlPoint Id="JcdSovE7yxbM9mLQIJZ5Wp" Bounds="1490,622" />
+            <Overlay Id="IthpgLC62ENNkjBC5Sczk9" Name="Declare Properties (accessible through the UI)" Bounds="393,310,446,342" />
+            <Node Bounds="1465,315,45,19" Id="Dn5hK6KMHEuNFBwIRAnyP1">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Merge" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="AILLreVjJWfNNUf4PdvoKG" Name="Input" Kind="InputPin" />
+              <Pin Id="RZlHEVP2kr0LXxw3Nw4w4D" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Overlay Id="FTuQKCVjE85LXMg87a6v9G" Name="Pick current properties" Bounds="928,300,234,262" />
+            <Overlay Id="KOlPWDKu2fXLD5hfiGwBbG" Name="Handle incoming spread" Bounds="1436,280,262,98" />
+            <Overlay Id="T1fzgo7GmXgOqmCXNVV31P" Name="Set new attributes" Bounds="1438,425,266,234" />
+            <ControlPoint Id="Ddn6uwByyrTPYCQHThInfc" Bounds="1191,265" />
+            <Node Bounds="1186,293,91,19" Id="BKb6jaxuRYZLpNGHjx623O">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetPixelCount" />
+              </p:NodeReference>
+              <Pin Id="PXeheYU7WvgOy8Z5jL29Sj" Name="Input" Kind="StateInputPin" />
+              <Pin Id="M9QZF0gmU1KQG7i6bmvUIh" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="I5B8RudItjNLhQquFvcLPQ" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="ODA1KqlyJnyLicLFeLfDUW" Bounds="1055,254" />
+            <Pad Id="HIDQz3XlaPQNp8HG104CL9" Comment="Key" Bounds="810,133,133,20" ShowValueBox="true" isIOBox="true" Value="Width">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="998,380,78,26" Id="S8wLkmbURZiNvquLx2fOty">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetFloat32" />
+              </p:NodeReference>
+              <Pin Id="L9YRpCIaHAAPoKlplVPhK2" Name="Input" Kind="StateInputPin" />
+              <Pin Id="TOICo22stR1NR7s8g1G50o" Name="Key" Kind="InputPin" />
+              <Pin Id="KF7CjdswmyuLSaRc8lrNjq" Name="Default Value" Kind="InputPin" />
+              <Pin Id="DlvfdCYTNXgQMgoLtktFP1" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="HuZ4nUIQgjONZpjVhYX1Fe" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="GFHgg22njiVOG8kElPm7DY" Bounds="921,636" />
+            <Pad Id="MVtB3vHeGeGPqibGyAYTtu" Comment="Color" Bounds="922,603,40,19" ShowValueBox="true" isIOBox="true" Value="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Pad Id="ATDZA9MKmzHMIUNKPwELjR" Comment="Key" Bounds="840,163,133,20" ShowValueBox="true" isIOBox="true" Value="Position">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="998,423,78,26" Id="R68qoCQbf1JPG4IlZsoMrV">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetFloat32" />
+              </p:NodeReference>
+              <Pin Id="B1CoCwy4nT5NXjdzxw4L0h" Name="Input" Kind="StateInputPin" />
+              <Pin Id="VyWHd5ENEbuQQ95Qe8HcgK" Name="Key" Kind="InputPin" />
+              <Pin Id="U31gVX5m3jzQQ1XdDudxuf" Name="Default Value" Kind="InputPin" />
+              <Pin Id="Fk18FmMi9RMMipaMv0D37K" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="EuStemgSmUsLE85WW2W8NA" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="1185,321,84,19" Id="Sf0iCdjtJWiPLhqVI8lsB1">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetDirection" />
+              </p:NodeReference>
+              <Pin Id="QNtNm9j7Ca4MCdbLR98AdU" Name="Input" Kind="InputPin" />
+              <Pin Id="LP0pMUQyoZwLRcIlIaJNqk" Name="Output" Kind="OutputPin" />
+              <Pin Id="Psknq1YLWzKL5WPDGsMRro" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="I2Rct2NaoVZOGNPfYEJ3X5" Bounds="624,534" />
+            <Node Bounds="551,366,89,19" Id="San82wyMJL4PJsSeX3k7JY">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CreateDefault" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="KKP1tQOVSMgOtHZl5yT3Py" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="551,481,77,26" Id="VLL4zt7AOZsLdhSqBpRrqw">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToImmutable" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="OpeYDKd5v5zORb0zHq4M7x" Name="Input" Kind="StateInputPin" />
+              <Pin Id="A9qSMF2f4nwLMc2BW2kvHH" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="KFo0iBv7UzgO1G4HX3QoFX" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="551,406,205,19" Id="Jj3Etyc21q5M3O2RqgQyQI">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="AddFloat32" />
+              </p:NodeReference>
+              <Pin Id="FWTD28viJ0lOoS8SxyBVN7" Name="Input" Kind="InputPin" />
+              <Pin Id="A63WNheU7D6L22DxTEO6q3" Name="Key" Kind="InputPin" />
+              <Pin Id="D3cBUBeTUaIMQqEHWOzRV7" Name="Default" Kind="InputPin" DefaultValue="0.6">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Float32" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="LjPdz5baK2FMU2eYpuHJKY" Name="Min" Kind="InputPin" />
+              <Pin Id="MI7lJg0LfAkOjDMxdhf8e5" Name="Max" Kind="InputPin" />
+              <Pin Id="HN2yE0A5ZuJQAYpSnsY7CQ" Name="Step" Kind="InputPin" />
+              <Pin Id="EgPoKWGl1nJLsAY5WLuMPh" Name="Between Spread" Kind="InputPin" />
+              <Pin Id="QWwXIdprHdOObBN2JVU8JB" Name="Children Spread" Kind="InputPin" />
+              <Pin Id="Ogp3Q0dL89fLZRgbLWcBmA" Name="Type" Kind="InputPin" />
+              <Pin Id="GpO6YAlkRHmOGDdLTpEP4A" Name="Tooltip" Kind="InputPin" />
+              <Pin Id="B1xMgTyKiysO5PPlsfRdOK" Name="Unit" Kind="InputPin" />
+              <Pin Id="SzNqZVi1pCMO9WPztnfF7W" Name="Properties" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="551,446,205,19" Id="J4U3ym01VZHMABVzA06Wpj">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="AddFloat32" />
+              </p:NodeReference>
+              <Pin Id="C5zhalqHOd9OzFAKcopAbJ" Name="Input" Kind="InputPin" />
+              <Pin Id="Uhv9EGnAcK3PNJxA9U6l6Z" Name="Key" Kind="InputPin" />
+              <Pin Id="E5GHZDsrSVpNNfkQS0mMRR" Name="Default" Kind="InputPin" DefaultValue="0.5">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Float32" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="GZ3HoYMJNAhLIB5NRlOjyy" Name="Min" Kind="InputPin" />
+              <Pin Id="ROVIyrBqs4hMJwvNE33Aee" Name="Max" Kind="InputPin" />
+              <Pin Id="LP76TDQOUlNNJe1l4iquQJ" Name="Step" Kind="InputPin" />
+              <Pin Id="TVz0Jx1kB1jPxz8jKU9ysV" Name="Between Spread" Kind="InputPin" />
+              <Pin Id="UvAEIiKmNL6QY7A3oiRDm8" Name="Children Spread" Kind="InputPin" />
+              <Pin Id="PnvMVicifM5PyX9anZMH8W" Name="Type" Kind="InputPin" />
+              <Pin Id="VJKqVpbXHhbN8cvpzKric6" Name="Tooltip" Kind="InputPin" />
+              <Pin Id="EEIqDjnmJCBOf657Q2OkgO" Name="Unit" Kind="InputPin" />
+              <Pin Id="LNMjT7CshVTN9EM2ek0jii" Name="Properties" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="1486,572,59,19" Id="DObC8aNGA9jNnq1z3MJmu1">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetColors" />
+              </p:NodeReference>
+              <Pin Id="SH8JlgQEC8YPSkJWmtWgUY" Name="Input" Kind="InputPin" />
+              <Pin Id="O7Xl6UP3BjVLl2xawu6m6q" Name="Value" Kind="InputPin" />
+              <Pin Id="SvprobWfyMWQGE976Ezt0j" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="1540,535,68,19" Id="CPs4rKu4FvzO08oTAed94F">
+              <p:NodeReference LastCategoryFullName="Schema.Blocks.Color.Pixel" LastDependency="Schema.Blocks.Source.Color.Pixel.Rainbow.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="RainbowFill" />
+              </p:NodeReference>
+              <Pin Id="SGWyA0sIvCTMGY6o8rMMHD" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="J0Tdwg583NVMYAqVnZUE7v" Name="Input" Kind="InputPin" />
+              <Pin Id="LQUfkaQfNHYLs1YDFQJTnP" Name="Count" Kind="InputPin" />
+              <Pin Id="DjUECuRVWwpLkXp4iU82Gw" Name="Reverse" Kind="InputPin" />
+              <Pin Id="J2X2NssygogLNbv4JyGiTr" Name="Width" Kind="InputPin" />
+              <Pin Id="CfDPPEOmouOLgb8XrEiNpk" Name="Output" Kind="OutputPin" />
+            </Node>
+          </Canvas>
+          <Patch Id="R8E7na8SyRsMExWQ0LxeSe" Name="Create" />
+          <ProcessDefinition Id="LaMQBE2Lm1QPeEWQMCMkWN" IsHidden="true">
+            <Fragment Id="PPeP6KMnCQdP5VPA3tkEhO" Patch="R8E7na8SyRsMExWQ0LxeSe" Enabled="true" />
+            <Fragment Id="TWwCYAjJPuCL2gpaCpa8PD" Patch="TRjZcZiAeusNQUiYWFnYNr" Enabled="true" />
+            <Fragment Id="R9fTR9PGFuyObL7kqwPXAe" Patch="OV8PL55Dhp6QXnd8rD5CAk" Enabled="true" />
+            <Fragment Id="KTc1aZ3BBMSNeIhJ2muiRo" Patch="SBiEJe0Jd3HLK7ep06KVmt" Enabled="true" />
+            <Fragment Id="HBb857Cf6R3QVFfh25LLCl" Patch="DRfjBHcWWIROj0tDUtlwE6" Enabled="true" />
+            <Fragment Id="HvgZnW8RxcFQBzx6DiVpak" Patch="SxFwXffyteSLemQoexqjRG" Enabled="true" />
+            <Fragment Id="B8tvBcWAaZrOjpV0dRpRYV" Patch="CePVmaKYaNeNKz3IaCUo6z" Enabled="true" />
+            <Fragment Id="UgcQBG7qDWGMWmBZo5tNRp" Patch="Cff1HK1hqaSLvq6op272tP" Enabled="true" />
+            <Fragment Id="G8Wqa9PIgqTMAyqxCcrnJm" Patch="IYQoe6gfRPVNfgleKn7xkV" Enabled="true" />
+            <Fragment Id="Pr6v9ecizwyPRxZbe3jehN" Patch="I58vQrxnosDLbc2VKnnxcB" Enabled="true" />
+          </ProcessDefinition>
+          <Patch Id="TRjZcZiAeusNQUiYWFnYNr" Name="Update">
+            <Pin Id="UxfUrsdBWgiQUERTPGS6lG" Name="Setup" Kind="InputPin" />
+            <Pin Id="Vosx0YMhrimPCungJLkzXN" Name="State" Kind="InputPin" />
+            <Pin Id="MeIigfpKjieOVu2YYJaPNY" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="DjLx6aV8JMTQOx2mcdo5LM" Name="Global" Kind="InputPin" />
+            <Pin Id="Uh9yI9Nms4HOHoOLvksZUP" Name="Properties" Kind="InputPin" />
+            <Pin Id="OabJyRwswdAMi8bFkXMrpQ" Name="New State" Kind="OutputPin" />
+            <Pin Id="IIWH88ZH3xvLqpizzJ5v2h" Name="Node Operation" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="OV8PL55Dhp6QXnd8rD5CAk" Name="Provides">
+            <Pin Id="Slo2VJFV64GLLnhqGxbP6l" Name="Color" Kind="OutputPin" />
+            <Pin Id="GEfYOxBOFqDOtKTQic96Kf" Name="Pick" Kind="OutputPin" />
+            <Pin Id="DPRoiXzPUfWLWPrXVCzgtP" Name="Gate" Kind="OutputPin" />
+            <Pin Id="O0kAvr7B2WYMjKYmW7eYJk" Name="Own Color" Kind="OutputPin" />
+            <Pin Id="JiA8aJnfQuGPa4uMcTx7xH" Name="Text" Kind="OutputPin" />
+            <Pin Id="JVesSDhs8WzLeo2mQxD6xb" Name="Progress" Kind="OutputPin" />
+            <Pin Id="K6nTAhMhgj9NP77dD1UhHQ" Name="Levels" Kind="OutputPin" />
+            <Pin Id="Qt1GCbIs3yNPBLsucpmcav" Name="Active Levels" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="SBiEJe0Jd3HLK7ep06KVmt" Name="GetPick">
+            <Pin Id="K9Q79K2j8COM3nvBG2wyVx" Name="Index" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="DRfjBHcWWIROj0tDUtlwE6" Name="GetGate">
+            <Pin Id="SnVIiT6sU4AQQEDi2ZMfQl" Name="Open" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="SxFwXffyteSLemQoexqjRG" Name="GetPropertyDefinitions">
+            <Pin Id="Tz2nbq9z2FEOPIA8ttcj7c" Name="Properties" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="CePVmaKYaNeNKz3IaCUo6z" Name="GetColor">
+            <Pin Id="ELfcDc4EJ3qON6jKT8QHV9" Name="Color" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="Cff1HK1hqaSLvq6op272tP" Name="GetText">
+            <Pin Id="JK7VE4WnYiGLf7mu6NqvV8" Name="Text" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="IYQoe6gfRPVNfgleKn7xkV" Name="GetProgress">
+            <Pin Id="F8714WfsmR7N1qBLd2KV3T" Name="Progress" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="I58vQrxnosDLbc2VKnnxcB" Name="GetLevels">
+            <Pin Id="P7d5e4JPuWlOBMhfH5XRPe" Name="Levels" Kind="OutputPin" />
+          </Patch>
+          <Link Id="O4y12GQ8zAXPghQVojRS4N" Ids="Vosx0YMhrimPCungJLkzXN,ILa3dSedO8SMFKHVBKhJGT" IsHidden="true" />
+          <Link Id="RQYjRDBlb4FLuls2K1WPvz" Ids="JcdSovE7yxbM9mLQIJZ5Wp,OabJyRwswdAMi8bFkXMrpQ" IsHidden="true" />
+          <Link Id="VrXP59Q9a8kPsDgcu1iZ17" Ids="ILa3dSedO8SMFKHVBKhJGT,AILLreVjJWfNNUf4PdvoKG" />
+          <Link Id="CDNvUcVPPZhOHH9F8TH400" Ids="UxfUrsdBWgiQUERTPGS6lG,Ddn6uwByyrTPYCQHThInfc" IsHidden="true" />
+          <Link Id="OgEpoetsF98OokSgcXql9w" Ids="Ddn6uwByyrTPYCQHThInfc,PXeheYU7WvgOy8Z5jL29Sj" />
+          <Link Id="KJcRlRFMLa7N4R1TM3StKD" Ids="Uh9yI9Nms4HOHoOLvksZUP,ODA1KqlyJnyLicLFeLfDUW" IsHidden="true" />
+          <Link Id="DJK3szrQ1lnNLllwr63lzL" Ids="HIDQz3XlaPQNp8HG104CL9,TOICo22stR1NR7s8g1G50o" />
+          <Link Id="Bua9U1yzI4yLNr3IH3fMXy" Ids="ODA1KqlyJnyLicLFeLfDUW,L9YRpCIaHAAPoKlplVPhK2" />
+          <Link Id="UwcaAVexk1jQFp0rKaHP2c" Ids="MVtB3vHeGeGPqibGyAYTtu,GFHgg22njiVOG8kElPm7DY" />
+          <Link Id="BZcRykusZgmMaok4qdu3hl" Ids="DlvfdCYTNXgQMgoLtktFP1,B1CoCwy4nT5NXjdzxw4L0h" />
+          <Link Id="HIBAeL2W4nqNkO0OTDp3Mp" Ids="ATDZA9MKmzHMIUNKPwELjR,VyWHd5ENEbuQQ95Qe8HcgK" />
+          <Link Id="UmqezezAHQaQIxgw4gOTkD" Ids="M9QZF0gmU1KQG7i6bmvUIh,QNtNm9j7Ca4MCdbLR98AdU" />
+          <Link Id="PmosErK40MXPvCPH5HZ1ZD" Ids="I2Rct2NaoVZOGNPfYEJ3X5,Tz2nbq9z2FEOPIA8ttcj7c" IsHidden="true" />
+          <Link Id="TS0fXJNbq36QNbDWEXcm11" Ids="KFo0iBv7UzgO1G4HX3QoFX,I2Rct2NaoVZOGNPfYEJ3X5" />
+          <Link Id="PjHEzpKD6ygOzr7C0bkl4w" Ids="KKP1tQOVSMgOtHZl5yT3Py,FWTD28viJ0lOoS8SxyBVN7" />
+          <Link Id="TAQYfd2zv0QPOAZKT9wvnU" Ids="HIDQz3XlaPQNp8HG104CL9,A63WNheU7D6L22DxTEO6q3" />
+          <Link Id="MEjw4zINeljL2yiEYfXisE" Ids="ATDZA9MKmzHMIUNKPwELjR,Uhv9EGnAcK3PNJxA9U6l6Z" />
+          <Link Id="AZC5e3Wm16eMcuWOAN6UaR" Ids="SzNqZVi1pCMO9WPztnfF7W,C5zhalqHOd9OzFAKcopAbJ" />
+          <Link Id="Le4k8bpL5vjLdZetkavG8I" Ids="GFHgg22njiVOG8kElPm7DY,Slo2VJFV64GLLnhqGxbP6l" IsHidden="true" />
+          <Link Id="BauuHjR5YRnOH4Y9goxPo8" Ids="I5B8RudItjNLhQquFvcLPQ,LQUfkaQfNHYLs1YDFQJTnP" />
+          <Link Id="CjLQkTokuOsOJZJl9j9YcJ" Ids="Psknq1YLWzKL5WPDGsMRro,DjUECuRVWwpLkXp4iU82Gw" />
+          <Link Id="Iz1tBDYqyUSOosVDK4ZE2i" Ids="RZlHEVP2kr0LXxw3Nw4w4D,SH8JlgQEC8YPSkJWmtWgUY" />
+          <Link Id="KwY7a7wOB2HOBb5t0EFKoS" Ids="SvprobWfyMWQGE976Ezt0j,JcdSovE7yxbM9mLQIJZ5Wp" />
+          <Link Id="B7V5CChycbJO4nl0NbSJlT" Ids="CfDPPEOmouOLgb8XrEiNpk,O7Xl6UP3BjVLl2xawu6m6q" />
+          <Link Id="PJfWJuTJNGwMpTh9eswE3o" Ids="LNMjT7CshVTN9EM2ek0jii,OpeYDKd5v5zORb0zHq4M7x" />
+          <Link Id="DZ8zbIsDrXaOOe7N42Erlx" Ids="EuStemgSmUsLE85WW2W8NA,J0Tdwg583NVMYAqVnZUE7v" />
+          <Link Id="JQDgpDJp4ZsNIbHWX1Awha" Ids="HuZ4nUIQgjONZpjVhYX1Fe,J2X2NssygogLNbv4JyGiTr" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ RainbowFill ************************
+
+-->
+      <Node Name="RainbowFill" Bounds="71,150" Id="TAY6CpMMYZeP1Okqo2bYWx">
+        <p:NodeReference>
+          <Choice Kind="ContainerDefinition" />
+        </p:NodeReference>
+        <Patch Id="T131j2cqPdSL6oZAkxP3nA">
+          <Canvas Id="JRr8pOCBN3sQSIDVQMKB74" CanvasType="Group">
+            <Node Bounds="106,189,115,180" Id="UDK71VmeQONPOzXoMKSeLE">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+              </p:NodeReference>
+              <Pin Id="TDklF8thvvfLjRXgTY8WRd" Name="Break" Kind="OutputPin" />
+              <ControlPoint Id="HGm3r5y4nVcPnCwTJcVJMU" Bounds="158,195" Alignment="Top" />
+              <ControlPoint Id="Rajef1vHqT1M8yXxvUQp8u" Bounds="139,363" Alignment="Bottom" />
+              <Patch Id="PCXIiUGbypDOeRg3RDBo2l" ManuallySortedPins="true">
+                <Patch Id="OIHpdNYYzfgNKOcrrPIcpp" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="DdR847iChhaLA1eBMOzU4l" Name="Update" ManuallySortedPins="true" />
+                <Patch Id="HnvMg1eOZMrMeOcUPq5Bmc" Name="Dispose" ManuallySortedPins="true" />
+                <Node Bounds="118,213,91,19" Id="Vvp3XOf9AkANYmgsKgxewI">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="-" />
+                    <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="P6xGqslMxjcLdXH1e5QWHD" Name="Input" Kind="InputPin" />
+                  <Pin Id="KFFrkuboT9LNf3l5IxXqk3" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="QWeBvBpPWDBMJ5vxqMgH0L" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="118,297,55,19" Id="R8M5delA5U0LFOZ2k2aosF">
+                  <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Clamp" />
+                    <CategoryReference Kind="Category" Name="Ranges" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="QiWJYtaqGtZNibWcxI6DVR" Name="Input" Kind="InputPin" />
+                  <Pin Id="RSGdwWeD7oqOeBeJncwA96" Name="Minimum" Kind="InputPin" />
+                  <Pin Id="E8TGmBf6AX8OT5u87p1a0j" Name="Maximum" Kind="InputPin" DefaultValue="1">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="Float32" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="K7ZWo8WXAAhO3eB17fzCvO" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="118,241,43,19" Id="E7eVoM20nQLO5cskzQ2ofT">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Abs" />
+                  </p:NodeReference>
+                  <Pin Id="Rz1kz4XBuSFPlQSlxK5wF2" Name="Input" Kind="InputPin" />
+                  <Pin Id="EDFTCdPXQiyQYbv8vuaYkG" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="118,269,25,19" Id="O7kHgHlSXKYMPs1F95s2Zn">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="/" />
+                    <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="TAzghewJWkBO69AwfyTE2n" Name="Input" Kind="InputPin" />
+                  <Pin Id="La1qSGGyM8EN9pntZYBUlD" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="PLYBTabiOvJMDi683ZbqXn" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="124,330,65,19" Id="Saeh4jzu9ewQOst4uNduuq">
+                  <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="FromHSL" />
+                  </p:NodeReference>
+                  <Pin Id="NWtleJksSVuOYVpjP22UNn" Name="Hue" Kind="InputPin" />
+                  <Pin Id="VtO8yZqkUdNOAreqLyMkVk" Name="Saturation" Kind="InputPin" />
+                  <Pin Id="PsxKFCNuK0nL1RIa0UQ05w" Name="Lightness" Kind="InputPin" />
+                  <Pin Id="AfMcuzaE2kRNeYUTdOraLh" Name="Alpha" Kind="InputPin" />
+                  <Pin Id="Oz8so84dQD5LA8HFft4irl" Name="Result" Kind="OutputPin" />
+                </Node>
+              </Patch>
+            </Node>
+            <Node Bounds="70,100,86,19" Id="Bsyq0U0VgXZNCgEQerCdtH">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="LinearSpread" />
+              </p:NodeReference>
+              <Pin Id="ANJienfyIRNL8sCep9bVcf" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="SlvY3Z2PnRJLosgjpOb2WI" Name="Center" Kind="InputPin" DefaultValue="0.5">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Float32" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="ChD4aUJsu7SLihpPESexJS" Name="Width" Kind="InputPin" />
+              <Pin Id="KBsbqG0oFMFPZHkQTTIyYt" Name="Alignment" Kind="InputPin" DefaultValue="Block" />
+              <Pin Id="RUnzQF4yOh7MVREDpdCMsz" Name="Phase" Kind="InputPin" />
+              <Pin Id="AbLkkkiYnscPa5hcsQRtgn" Name="Count" Kind="InputPin" />
+              <Pin Id="GllTzzCQdFWNRwLtdpR0Fc" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="205,152,72,19" Id="RTFWe0CxEGsLoMmZgMi9xS">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="OneMinus" />
+              </p:NodeReference>
+              <Pin Id="LpoSuE4JUHVPMdwETyKSkD" Name="Input" Kind="InputPin" />
+              <Pin Id="OqcJ8N39AUENjXCCDrXgoE" Name="Apply" Kind="InputPin" />
+              <Pin Id="Gp5LbjZTsTnOAvfr6MZAWN" Name="Output" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="JisQq3tR1CQLPk29vftTsZ" Bounds="207,31" />
+            <ControlPoint Id="FPlm95N1GkxOZC00mghAIA" Bounds="136,486" />
+            <ControlPoint Id="TqcLqrTtEYDMhnMKim519k" Bounds="106,31" />
+            <ControlPoint Id="RTdoTxhMiWeL4sRoxPqBg9" Bounds="286,31" />
+            <ControlPoint Id="KET8P1tepCkMf1uU5q9NK8" Bounds="384,31" />
+          </Canvas>
+          <Patch Id="ICow0GHY1KXNwRhL4z89TS" Name="Create" />
+          <Patch Id="TMn6ce4UNcoOQRG1da1IZX" Name="Update">
+            <Pin Id="UKohVD7zTrhOiAj5f0pbxl" Name="Input" Kind="InputPin" Bounds="826,206" />
+            <Pin Id="SLwTjYJToOOO1NPwXGC7mv" Name="Count" Kind="InputPin" />
+            <Pin Id="L4xy6V6TJh8PfoLp330qxq" Name="Reverse" Kind="InputPin" Bounds="901,211" />
+            <Pin Id="EMZKOq0Art5OwuWCWbO9Uz" Name="Width" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="QDI21TV0TSKQct6C6UN2Fp" Name="Output" Kind="OutputPin" Bounds="597,543" />
+          </Patch>
+          <!--
+
+    ************************  ************************
+
+-->
+          <ProcessDefinition Id="DqwotYaDhACLHMmlH3sjDx">
+            <Fragment Id="Bm2nFp4iStMNrUkJU5boeX" Patch="ICow0GHY1KXNwRhL4z89TS" Enabled="true" />
+            <Fragment Id="G3iinkEZJWcPBDJY7ThV7C" Patch="TMn6ce4UNcoOQRG1da1IZX" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="O6KD2XlCMj2NOTMWUl1mVP" Ids="GllTzzCQdFWNRwLtdpR0Fc,HGm3r5y4nVcPnCwTJcVJMU" />
+          <Link Id="QkjycjWtGfYPGieO9Zi33g" Ids="HGm3r5y4nVcPnCwTJcVJMU,P6xGqslMxjcLdXH1e5QWHD" />
+          <Link Id="U1LXM6uZRTLMIyzAnZMU7I" Ids="EDFTCdPXQiyQYbv8vuaYkG,TAzghewJWkBO69AwfyTE2n" />
+          <Link Id="SaDkCBoV7yILfJMIpUYhJg" Ids="Gp5LbjZTsTnOAvfr6MZAWN,KFFrkuboT9LNf3l5IxXqk3" />
+          <Link Id="BcDBT9emVO8MzWOV0Xqlxy" Ids="PLYBTabiOvJMDi683ZbqXn,QiWJYtaqGtZNibWcxI6DVR" />
+          <Link Id="TWcmoXQZTPEMaEKk0zV7uK" Ids="SLwTjYJToOOO1NPwXGC7mv,JisQq3tR1CQLPk29vftTsZ" IsHidden="true" />
+          <Link Id="VXjLeksWLroLR14Z36k1Sq" Ids="JisQq3tR1CQLPk29vftTsZ,AbLkkkiYnscPa5hcsQRtgn" />
+          <Link Id="V2IoRGwF56EPnWAmfFW0qx" Ids="FPlm95N1GkxOZC00mghAIA,QDI21TV0TSKQct6C6UN2Fp" IsHidden="true" />
+          <Link Id="LrscbdMD5bLQUrhHBKRRPy" Ids="TqcLqrTtEYDMhnMKim519k,LpoSuE4JUHVPMdwETyKSkD" />
+          <Link Id="NPVsvO8ljEzQKfyCZFa2dp" Ids="UKohVD7zTrhOiAj5f0pbxl,TqcLqrTtEYDMhnMKim519k" IsHidden="true" />
+          <Link Id="BrYB52r6LFCNGT0FgkgZmQ" Ids="RTdoTxhMiWeL4sRoxPqBg9,OqcJ8N39AUENjXCCDrXgoE" />
+          <Link Id="GN9L3Dx3knPOmd8EGtr7oX" Ids="L4xy6V6TJh8PfoLp330qxq,RTdoTxhMiWeL4sRoxPqBg9" IsHidden="true" />
+          <Link Id="BknoNJhaAMHQGSxFKuFEd8" Ids="QWeBvBpPWDBMJ5vxqMgH0L,Rz1kz4XBuSFPlQSlxK5wF2" />
+          <Link Id="V6RvxksaVPpPdS9NYQBytB" Ids="Rajef1vHqT1M8yXxvUQp8u,FPlm95N1GkxOZC00mghAIA" />
+          <Link Id="PAbM17W3wxjOFxfMmXdW2A" Ids="EMZKOq0Art5OwuWCWbO9Uz,KET8P1tepCkMf1uU5q9NK8" IsHidden="true" />
+          <Link Id="OQPVTm5qTRbOsu0xAxl9Fn" Ids="KET8P1tepCkMf1uU5q9NK8,La1qSGGyM8EN9pntZYBUlD" />
+          <Link Id="IZTgaqAJSdENp0D942xN9X" Ids="K7ZWo8WXAAhO3eB17fzCvO,NWtleJksSVuOYVpjP22UNn" />
+          <Link Id="Q1ODJS5rRFdNAzYRWDNAwg" Ids="Oz8so84dQD5LA8HFft4irl,Rajef1vHqT1M8yXxvUQp8u" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="VMmYB9dDKDUOMO5q1GmD5w">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="LdFiLdNcnwALxeQbxreq3A">
+        <Canvas Id="UdEIeh71BYIMmrerX7Uz1a" CanvasType="Group" />
+        <Patch Id="VnTMS3SJdaVQE2m5dxKoio" Name="Create" />
+        <Patch Id="RICxVptQPVBLtfUSPGxsSH" Name="Update" />
+        <ProcessDefinition Id="GsoVKF5kAvOMh3v4vxnitq">
+          <Fragment Id="S773peQXkSNNh2I9yvpZXN" Patch="VnTMS3SJdaVQE2m5dxKoio" Enabled="true" />
+          <Fragment Id="VdEg2tu24NuMp6g2BEXVhz" Patch="RICxVptQPVBLtfUSPGxsSH" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="VG86WJm48uvM3D85XeZuKL" Location="../../../../VVVV.Schema.Core.vl" />
+  <DocumentDependency Id="CqeQuZOqtG3Pn6AdcvXhZY" Location="./Schema.Blocks.Source.Color.Pixel.PulseCannon.vl" />
+  <NugetDependency Id="IPxth3hg1jQMm4PC0PKHRV" Location="VL.CoreLib" Version="2025.7.0" />
+</Document>

--- a/Main/vl/Blocks/Source/Schema.Blocks.Source.vl
+++ b/Main/vl/Blocks/Source/Schema.Blocks.Source.vl
@@ -304,7 +304,7 @@
     ************************ RegisterColorSources (Internal) ************************
 
 -->
-      <Node Name="RegisterColorSources (Internal)" Bounds="1077,145,367,380" Id="L91yI7MrtKfOxQj1loAaM4">
+      <Node Name="RegisterColorSources (Internal)" Bounds="1077,145,367,512" Id="L91yI7MrtKfOxQj1loAaM4">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
@@ -344,7 +344,7 @@
           <Link Id="GzOsMQeZ661MYUclcqvfwa" Ids="AxhEkdst5n0NFVAlGwUXmQ,JMrXacWQsJEOcI3dJ4YEWa" IsHidden="true" />
           <Link Id="KlmCMT9gm2vPLdE4IYRAfg" Ids="JMrXacWQsJEOcI3dJ4YEWa,NxmuvcRNzGbMeQfn3yf8IK" />
           <Pin Id="CYleKdqdq12Py3yvcHUFlr" Name="Output" Kind="OutputPin" />
-          <ControlPoint Id="VCZ43OzDYDPMHqtSx4sco0" Bounds="1158,508" />
+          <ControlPoint Id="VCZ43OzDYDPMHqtSx4sco0" Bounds="1158,640" />
           <Link Id="BQfTEcc1IhPOdQIdTqmiTP" Ids="VCZ43OzDYDPMHqtSx4sco0,CYleKdqdq12Py3yvcHUFlr" IsHidden="true" />
           <Node Bounds="1157,341,87,76" Id="F2kWtXXBZZKQL4XnorNdLb">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
@@ -377,7 +377,38 @@
           <Link Id="CWpb5yMokHLOmeBgH6yD3A" Ids="NxLJ8jnlVOhPxcUW1Eo33E,AnDZWCSTB1tQFiPfUKvMWm" />
           <Link Id="ANC0rXrbQy7OcOI6wK9ECS" Ids="SWeNvLNF3cYNi7sRq8yA4y,UNz4BK916JJLEpUKLzC9tL" />
           <Link Id="DcsJxdNuz1sQXHIjdLwSbF" Ids="TUK6hPrmPE4OAr0j9QOAPM,Seytv2Kp34KLxUVfwWXCFj" />
-          <Link Id="PaAwHHjLWqGP49cOTyU3Js" Ids="QchT2sVS8x5LbSZ83y6lYf,VCZ43OzDYDPMHqtSx4sco0" />
+          <Node Bounds="1157,480,87,76" Id="UkYImnYjIIxLRodyvZ2K73">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
+            </p:NodeReference>
+            <Pin Id="KV19wMz1NCPPwyRN5RN6M6" Name="Input" Kind="StateInputPin" />
+            <Pin Id="Vcuucmvwr5YN4rD8WtEuLY" Name="Key" Kind="InputPin" />
+            <Pin Id="TtXy2FP6j0ePtNdpSxQyDD" Name="Output" Kind="StateOutputPin" />
+            <Patch Id="Q7Ezk6rGsw4QNWKskA6SQF" Name="Constructor" ManuallySortedPins="true">
+              <Pin Id="FLT9OdksRTkMZdeqmBHGM9" Name="Result" Kind="OutputPin" />
+              <ControlPoint Id="JRUvWTXkvjjN1TYsAgadiz" Bounds="1161,549" />
+              <Node Bounds="1170,503,62,26" Id="SEwinxcBKgPPA3IV0mcbDB">
+                <p:NodeReference LastCategoryFullName="Schema.Blocks.Color.Pixel.Rainbow" LastDependency="Schema.Blocks.Source.Color.Pixel.Rainbow.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="Rainbow" />
+                  <Choice Kind="OperationCallFlag" Name="Create" />
+                </p:NodeReference>
+                <Pin Id="Sm8HkazDIkbNzY9TDAZyub" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="QSBjmvPjKM8NcyZYS3WFKq" Name="Output" Kind="StateOutputPin" />
+              </Node>
+            </Patch>
+          </Node>
+          <Pad Id="KztBjFdRb1eMtnHkEhPnbl" Comment="Key" Bounds="1229,450,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Color.Pixel.Rainbow">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Link Id="QiFIk4twSLJPp89pIfdy89" Ids="JRUvWTXkvjjN1TYsAgadiz,FLT9OdksRTkMZdeqmBHGM9" IsHidden="true" />
+          <Link Id="BmX5pkcAABPMqLwlUWxLM2" Ids="KztBjFdRb1eMtnHkEhPnbl,Vcuucmvwr5YN4rD8WtEuLY" />
+          <Link Id="GcBqgKCKXmoOgpA6hYZ07D" Ids="QSBjmvPjKM8NcyZYS3WFKq,JRUvWTXkvjjN1TYsAgadiz" />
+          <Link Id="MaJJxnVkfDBNtSax93LvnA" Ids="QchT2sVS8x5LbSZ83y6lYf,KV19wMz1NCPPwyRN5RN6M6" />
+          <Link Id="JmCK3gL4cdgLlVU6G8QA3p" Ids="TtXy2FP6j0ePtNdpSxQyDD,VCZ43OzDYDPMHqtSx4sco0" />
         </Patch>
       </Node>
       <!--
@@ -597,4 +628,5 @@
   <NugetDependency Id="HCKTC6cuMlZNOvp0SBCbQf" Location="VL.CoreLib" Version="2025.7.0" />
   <DocumentDependency Id="T3zdFVszpihQPnbKwSSX1U" Location="./Resource/Schema.Blocks.Source.Resource.Constant.vl" />
   <DocumentDependency Id="K2DfpaqICinNCsJxidtsMC" Location="./Value/Schema.Blocks.Source.Value.Expression.vl" />
+  <DocumentDependency Id="Hd9HqGbRu2MNBRP6InYuPA" Location="./Color/Pixel/Schema.Blocks.Source.Color.Pixel.Rainbow.vl" />
 </Document>

--- a/Main/vl/Blocks/Source/Schema.Blocks.Source.vl
+++ b/Main/vl/Blocks/Source/Schema.Blocks.Source.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="TwwwmktRN49MLYLaNZFi0B" LanguageVersion="2024.6.2" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="TwwwmktRN49MLYLaNZFi0B" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="Gql5WLoCHdZMTNYgfAMR3o">
     <Canvas Id="ONZw2kKUbs5NUJL83wygr9" DefaultCategory="Schema.Blocks" CanvasType="FullCategory">
       <!--
@@ -7,18 +7,18 @@
     ************************ RegisterSources ************************
 
 -->
-      <Node Name="RegisterSources" Bounds="437,278,374,379" Id="IQTPYzPLPaIPhTlN5pBlmX">
+      <Node Name="RegisterSources" Bounds="122,156,374,379" Id="IQTPYzPLPaIPhTlN5pBlmX">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="OXtc7DjVkYAOtIjJH0k2b5">
-          <ControlPoint Id="T3MzGc1BdtrNOPauI3me8f" Bounds="516,296" />
-          <ControlPoint Id="TOpdW4qrPPkLdZVfVb0vdL" Bounds="515,640" />
+          <ControlPoint Id="T3MzGc1BdtrNOPauI3me8f" Bounds="201,174" />
+          <ControlPoint Id="TOpdW4qrPPkLdZVfVb0vdL" Bounds="200,518" />
           <Pin Id="OumCOfn3ba8OukJQF8Uygc" Name="Input" Kind="InputPin" Bounds="471,214" />
           <Pin Id="VudVeKxHfyWOcRt6xBbSmg" Name="Output" Kind="OutputPin" Bounds="466,454" />
           <Link Id="IC68YqRgaEXMLS3biER0V6" Ids="OumCOfn3ba8OukJQF8Uygc,T3MzGc1BdtrNOPauI3me8f" IsHidden="true" />
           <Link Id="G0cxhRl0aW6M8nhOI0aFCm" Ids="TOpdW4qrPPkLdZVfVb0vdL,VudVeKxHfyWOcRt6xBbSmg" IsHidden="true" />
-          <Node Bounds="514,349,85,76" Id="JqGzxwx8vCZOAzgohOUs05">
+          <Node Bounds="199,227,85,76" Id="JqGzxwx8vCZOAzgohOUs05">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -28,8 +28,8 @@
             <Pin Id="CKSDLzJLXcTQFaYP4zD1Ku" Name="Output" Kind="StateOutputPin" />
             <Patch Id="OOyvNvFicHHPdynkVBtySK" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="S0IH440OiSbOwQ1e7uIqd7" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="TjSRPSyF0vlNxSKWWwbPjc" Bounds="518,418" />
-              <Node Bounds="527,372,60,26" Id="TZfBnRxJbQYQRVCR5FTilq">
+              <ControlPoint Id="TjSRPSyF0vlNxSKWWwbPjc" Bounds="203,296" />
+              <Node Bounds="212,250,60,26" Id="TZfBnRxJbQYQRVCR5FTilq">
                 <p:NodeReference LastCategoryFullName="Main.Copycat" LastDependency="Schema.Blocks.Source.Generic.Copycat.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Copycat" />
@@ -40,7 +40,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="OTEPlIDnq1WLAB9L5dLMXZ" Comment="Key" Bounds="596,331,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Copycat">
+          <Pad Id="OTEPlIDnq1WLAB9L5dLMXZ" Comment="Key" Bounds="281,209,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Copycat">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -48,7 +48,7 @@
           <Link Id="GrwHfRDQktEMQqWPBF8P0Y" Ids="TjSRPSyF0vlNxSKWWwbPjc,S0IH440OiSbOwQ1e7uIqd7" IsHidden="true" />
           <Link Id="PBzgslnuoiEOjiuUsSLnfv" Ids="OTEPlIDnq1WLAB9L5dLMXZ,AI4shT3sBFlLJvpGTmELch" />
           <Link Id="DwMsmyf6brRPg9F7cWURse" Ids="JcSxstH109HMBjBUTB68My,TjSRPSyF0vlNxSKWWwbPjc" />
-          <Node Bounds="513,454,113,19" Id="H6iXI1lbcWpN4Vn0gVIHoh">
+          <Node Bounds="198,332,113,19" Id="H6iXI1lbcWpN4Vn0gVIHoh">
             <p:NodeReference LastCategoryFullName="Schema.Blocks" LastDependency="Schema.Blocks.Source.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationNode" Name="RegisterValueSources" />
@@ -56,7 +56,7 @@
             <Pin Id="DGnCOEFTghNLGhWkrjtpl2" Name="Input" Kind="InputPin" />
             <Pin Id="CaxyzP1bbnSObYG3aW1RdE" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="513,486,133,19" Id="F43uv3ZKRtCNK6pkKHlzGH">
+          <Node Bounds="198,364,133,19" Id="F43uv3ZKRtCNK6pkKHlzGH">
             <p:NodeReference LastCategoryFullName="Schema.Blocks" LastDependency="Schema.Blocks.Source.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterReferenceSources" />
@@ -68,7 +68,7 @@
           <Link Id="MuJqzWbJthzMYqX05VZYjT" Ids="CaxyzP1bbnSObYG3aW1RdE,RsxUQNkYexYPXh0DiCYlzZ" />
           <Link Id="LWetqfsr3UMNZMtJUqiiPa" Ids="OF6Z32xnJ42L8ltXPn7y2Y,TWR6sKHkyKBLIA352DIh9G" />
           <Link Id="BZ8Kp9RBAXHQTvKZiv01vo" Ids="T3MzGc1BdtrNOPauI3me8f,R6aV1vTakazQUMYhbhlzYQ" />
-          <Node Bounds="513,518,113,19" Id="BssJJPcYEBXOXoWX9crLo0">
+          <Node Bounds="198,396,113,19" Id="BssJJPcYEBXOXoWX9crLo0">
             <p:NodeReference LastCategoryFullName="Schema.Blocks" LastDependency="Schema.Blocks.Source.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterColorSources" />
@@ -76,7 +76,7 @@
             <Pin Id="TWR6sKHkyKBLIA352DIh9G" Name="Input" Kind="InputPin" />
             <Pin Id="TdQL6ABOmAKMc66ptb6sES" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="513,550,146,19" Id="LEUzs41vPXlNW3Onhns4Mw">
+          <Node Bounds="198,428,146,19" Id="LEUzs41vPXlNW3Onhns4Mw">
             <p:NodeReference LastCategoryFullName="Schema.Blocks" LastDependency="Schema.Blocks.Source.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterSystemValueSources" />
@@ -86,7 +86,7 @@
           </Node>
           <Link Id="UyzSFfkX7zfL6BLaKsByyU" Ids="TdQL6ABOmAKMc66ptb6sES,NyJ8utZ1DvPOIGhKi7kGwl" />
           <Link Id="K45embhVkyPLCWFuwarwUX" Ids="MULLXJmxpn6NlkpEyLnNw0,RZy2CKqdABZOTaxC5jzTKJ" />
-          <Node Bounds="513,582,130,19" Id="IauE4vMON4VOSC0B0lDgAD">
+          <Node Bounds="198,460,130,19" Id="IauE4vMON4VOSC0B0lDgAD">
             <p:NodeReference LastCategoryFullName="Schema.Blocks" LastDependency="Schema.Blocks.Source.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterResourceSources" />
@@ -102,12 +102,12 @@
     ************************ RegisterValueSources (Internal) ************************
 
 -->
-      <Node Name="RegisterValueSources (Internal)" Bounds="896,129,380,492" Id="OM0MEnbRWbePOSrN9V4q3u">
+      <Node Name="RegisterValueSources (Internal)" Bounds="623,142,397,651" Id="OM0MEnbRWbePOSrN9V4q3u">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="HOLxt9osN1FNR7P661SmQh">
-          <Node Bounds="973,187,85,76" Id="AGans68plEDOMTdYzfbev2">
+          <Node Bounds="700,200,85,76" Id="AGans68plEDOMTdYzfbev2">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -117,8 +117,8 @@
             <Pin Id="TmsM6Ogo1QOPbS9mocwsqy" Name="Output" Kind="StateOutputPin" />
             <Patch Id="NhQACcYbGKjNdlOEZMoovk" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="OweG1KLrU4LLE4aYhafaLd" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="TpGcfuUaaOTQRAcULC3HEs" Bounds="977,256" />
-              <Node Bounds="986,210,60,26" Id="VgtI6jQS6kRQStOthbxpbn">
+              <ControlPoint Id="TpGcfuUaaOTQRAcULC3HEs" Bounds="704,269" />
+              <Node Bounds="713,223,60,26" Id="VgtI6jQS6kRQStOthbxpbn">
                 <p:NodeReference LastCategoryFullName="Main.AxisPosition" LastDependency="Schema.Blocks.Source.Value.Group.AxisPosition.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="AxisPosition" />
@@ -129,7 +129,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="KixexKpaBnKNKWHNOLBHHN" Comment="Key" Bounds="1045,157,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Group.AxisPosition">
+          <Pad Id="KixexKpaBnKNKWHNOLBHHN" Comment="Key" Bounds="772,170,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Group.AxisPosition">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -137,7 +137,7 @@
           <Link Id="QxE41Q8iMyHLAfyXslOkbh" Ids="TpGcfuUaaOTQRAcULC3HEs,OweG1KLrU4LLE4aYhafaLd" IsHidden="true" />
           <Link Id="OjPHo3pQM3OL3BNUFahJsm" Ids="KixexKpaBnKNKWHNOLBHHN,Cvn6EBNpniMMepq9VcbCBl" />
           <Link Id="IMomYtqrPSCNgiPlcUS5GI" Ids="ScgYnX4Pof2QJeUR0hIZ25,TpGcfuUaaOTQRAcULC3HEs" />
-          <Node Bounds="978,329,92,76" Id="DsEs8owvRvSMooHeMHuVOI">
+          <Node Bounds="705,342,92,76" Id="DsEs8owvRvSMooHeMHuVOI">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -147,8 +147,8 @@
             <Pin Id="HUPWjsJCj5tM5DYepMzInB" Name="Output" Kind="StateOutputPin" />
             <Patch Id="U6dhhmdQLskNCAfnwHlagQ" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="EkM4vWdlu9jPsjhvHQJ618" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="Dq3Ko8cycM9PmPcU8BTiIH" Bounds="982,398" />
-              <Node Bounds="991,352,67,26" Id="PU2IQ5AUwJXK9yDdqm8EAX">
+              <ControlPoint Id="Dq3Ko8cycM9PmPcU8BTiIH" Bounds="709,411" />
+              <Node Bounds="718,365,67,26" Id="PU2IQ5AUwJXK9yDdqm8EAX">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Value.DistanceValue" LastDependency="Schema.Blocks.Source.Value.Distance.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="DistanceValue" />
@@ -159,7 +159,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="UFOUtJsPxtyLfoKoXZPgAP" Comment="Key" Bounds="1060,299,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Distance">
+          <Pad Id="UFOUtJsPxtyLfoKoXZPgAP" Comment="Key" Bounds="787,312,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Distance">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -169,13 +169,13 @@
           <Link Id="BrvOui1nRK5Nu8NG3DP1vt" Ids="I7n1lhYaExOPtpvqcL7mCm,Dq3Ko8cycM9PmPcU8BTiIH" />
           <Link Id="Tl5GSXIGNhoQBu97SiTnbi" Ids="TmsM6Ogo1QOPbS9mocwsqy,QR5UAn2tjCtOwGdfwbQXdy" />
           <Pin Id="GNm0E36zAdaLsObWO7Nnpq" Name="Input" Kind="InputPin" />
-          <ControlPoint Id="QW5E3T19moxM6p1P6vqy5q" Bounds="973,157" />
+          <ControlPoint Id="QW5E3T19moxM6p1P6vqy5q" Bounds="700,170" />
           <Link Id="KvjMe4TGR3sLh588SUiz3X" Ids="GNm0E36zAdaLsObWO7Nnpq,QW5E3T19moxM6p1P6vqy5q" IsHidden="true" />
           <Link Id="RxKsK94zXp2PdBO6cgZP1C" Ids="QW5E3T19moxM6p1P6vqy5q,OK9VPvASzG3QZAh0DgxSF0" />
           <Pin Id="GBnzGE7m97JL0nEz964hEf" Name="Output" Kind="OutputPin" />
-          <ControlPoint Id="BHHuSdVd2yILY63ly50YOE" Bounds="976,604" />
+          <ControlPoint Id="BHHuSdVd2yILY63ly50YOE" Bounds="703,776" />
           <Link Id="JdFc4EvUrkUOHCVaJWI9mY" Ids="BHHuSdVd2yILY63ly50YOE,GBnzGE7m97JL0nEz964hEf" IsHidden="true" />
-          <Node Bounds="976,568,140,19" Id="Jlhp5OOf53oNwI3iV6LV7l">
+          <Node Bounds="703,740,140,19" Id="Jlhp5OOf53oNwI3iV6LV7l">
             <p:NodeReference LastCategoryFullName="Schema.Blocks" LastDependency="Schema.Blocks.Source.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationNode" Name="RegisterAudioValueSources" />
@@ -184,7 +184,7 @@
             <Pin Id="Isx6ojrRb6KMZLbwbGth2h" Name="Output" Kind="OutputPin" />
           </Node>
           <Link Id="BUOvAPQ3EeKM6yHac1QkjY" Ids="Isx6ojrRb6KMZLbwbGth2h,BHHuSdVd2yILY63ly50YOE" />
-          <Node Bounds="979,446,145,76" Id="GV8QGwzcPJVM6ZvaNdBxYu">
+          <Node Bounds="706,459,145,76" Id="GV8QGwzcPJVM6ZvaNdBxYu">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -194,8 +194,8 @@
             <Pin Id="UsbumeM8vpBNbdCn3Vj6VP" Name="Output" Kind="StateOutputPin" />
             <Patch Id="ScgSKR4kt01ML4FYZ2fb7c" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="Q5UAPQZXVeZM9i7jLg7YMI" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="EikVuygs8UfOjGnzy9rfDN" Bounds="983,515" />
-              <Node Bounds="992,469,120,26" Id="G0oS2UZtF11NyozCJZlujg">
+              <ControlPoint Id="EikVuygs8UfOjGnzy9rfDN" Bounds="710,528" />
+              <Node Bounds="719,482,120,26" Id="G0oS2UZtF11NyozCJZlujg">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Value.Fixture.IsSelected.FixtureIsSelectedValueSource" LastDependency="Schema.Blocks.Source.Value.Fixture.IsSelected.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="FixtureIsSelectedValueSource" />
@@ -206,7 +206,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="Eype0XrgeUtLyvoOslEm1M" Comment="Key" Bounds="1061,416,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Fixture.IsSelected">
+          <Pad Id="Eype0XrgeUtLyvoOslEm1M" Comment="Key" Bounds="788,429,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Fixture.IsSelected">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -215,7 +215,38 @@
           <Link Id="O0nFwI2dNpmNNo7uU8Ajpf" Ids="Eype0XrgeUtLyvoOslEm1M,SxT8wbHeZsaMZDbunjIVvk" />
           <Link Id="Dq8EybTzrs1MC2b4Lmb9Ux" Ids="ISLXYN2CdTHLpW3aalGpCv,EikVuygs8UfOjGnzy9rfDN" />
           <Link Id="CXHfN5m3b4JPJ1vUNnutNy" Ids="HUPWjsJCj5tM5DYepMzInB,IkMbOBycLcwMQcgcI43f51" />
-          <Link Id="Do3ybQAF0DnQWDX2hsp5td" Ids="UsbumeM8vpBNbdCn3Vj6VP,JhOwvz07AaxMIym4ktwch2" />
+          <Node Bounds="703,610,109,94" Id="Rsk163PKDWgLyUFD6K0PuS">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
+            </p:NodeReference>
+            <Pin Id="VYp6FEiuqqIOwkdvKVfQ67" Name="Input" Kind="StateInputPin" />
+            <Pin Id="Nyq7BxumavnPPnsxF0dY97" Name="Key" Kind="InputPin" />
+            <Pin Id="Q6FFUz77sXTNV1SR4iBBlH" Name="Output" Kind="StateOutputPin" />
+            <Patch Id="NYrxRgxwxJLOHvaD4XoyzR" Name="Constructor" ManuallySortedPins="true">
+              <Pin Id="UGuENm4j8B3NQMX6JA3JpE" Name="Result" Kind="OutputPin" />
+              <ControlPoint Id="GjpMSDtPCoVLszdEVaHbkO" Bounds="707,695" />
+              <Node Bounds="719,633,81,26" Id="NppFJ18MiRcQHw5klx47XM">
+                <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Value.ExpressionValue" LastDependency="Schema.Blocks.Source.Value.Expression.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="ClassType" Name="ExpressionValue" />
+                  <Choice Kind="OperationCallFlag" Name="Create" />
+                </p:NodeReference>
+                <Pin Id="U8drCZabsxYMDKGJkBnBwy" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="OA6qfy9s7mxOjyVuzoASfi" Name="Output" Kind="StateOutputPin" />
+              </Node>
+            </Patch>
+          </Node>
+          <Pad Id="BK3aGeuARabNcSGHKkui3N" Comment="Key" Bounds="809,571,160,20" ShowValueBox="true" isIOBox="true" Value="Create.Value.Expression">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Link Id="BgYkp7iBMVGQIvTh06lTS6" Ids="GjpMSDtPCoVLszdEVaHbkO,UGuENm4j8B3NQMX6JA3JpE" IsHidden="true" />
+          <Link Id="T6ArKqInZosP5m28Dagmww" Ids="OA6qfy9s7mxOjyVuzoASfi,GjpMSDtPCoVLszdEVaHbkO" />
+          <Link Id="GjGJGHeNrtXOJZQd5agLCd" Ids="BK3aGeuARabNcSGHKkui3N,Nyq7BxumavnPPnsxF0dY97" />
+          <Link Id="VvPeFCO7u30MJF2k2XfT2i" Ids="UsbumeM8vpBNbdCn3Vj6VP,VYp6FEiuqqIOwkdvKVfQ67" />
+          <Link Id="DsjSr7qvKXJOjqeJo8xXrU" Ids="Q6FFUz77sXTNV1SR4iBBlH,JhOwvz07AaxMIym4ktwch2" />
         </Patch>
       </Node>
       <!--
@@ -223,12 +254,12 @@
     ************************ RegisterReferenceSources (Internal) ************************
 
 -->
-      <Node Name="RegisterReferenceSources (Internal)" Bounds="1391,1084,364,181" Id="FvBaKDV5XNlNlQp8knbiiX">
+      <Node Name="RegisterReferenceSources (Internal)" Bounds="2395,119,364,181" Id="FvBaKDV5XNlNlQp8knbiiX">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="CVjdGuOi4eUMpJtc00XnPZ">
-          <Node Bounds="1468,1142,101,76" Id="HHdOlZuewOYOMFROeGgtM0">
+          <Node Bounds="2472,177,101,76" Id="HHdOlZuewOYOMFROeGgtM0">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -238,8 +269,8 @@
             <Pin Id="K0mTHu4vHGsOVwWfTsRpUN" Name="Output" Kind="StateOutputPin" />
             <Patch Id="T1vfWF4OMbgN06CmHAnU6u" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="K6WaPCvEkitOJas4bYudqj" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="FcMc3yqKt0tOdKlm1hddbu" Bounds="1472,1211" />
-              <Node Bounds="1481,1165,76,26" Id="Fd4xwMRK6O7NHV9HD5zwEc">
+              <ControlPoint Id="FcMc3yqKt0tOdKlm1hddbu" Bounds="2476,246" />
+              <Node Bounds="2485,200,76,26" Id="Fd4xwMRK6O7NHV9HD5zwEc">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Reference.FixtureReference" LastDependency="Schema.Blocks.Source.Reference.Fixture.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="FixtureReference" />
@@ -250,20 +281,20 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="JsKnUcIQVg0O0NYs5xuFsK" Comment="Key" Bounds="1540,1112,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Reference.Fixture">
+          <Pad Id="JsKnUcIQVg0O0NYs5xuFsK" Comment="Key" Bounds="2544,147,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Reference.Fixture">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Pin Id="PCyBxzVqqBFOSlqY15mYV5" Name="Input" Kind="InputPin" />
-          <ControlPoint Id="P36jl735FhnPybhdCr01TG" Bounds="1468,1112" />
+          <ControlPoint Id="P36jl735FhnPybhdCr01TG" Bounds="2472,147" />
           <Link Id="VfDn1qH5zeWMvKX3lkMeOf" Ids="FcMc3yqKt0tOdKlm1hddbu,K6WaPCvEkitOJas4bYudqj" IsHidden="true" />
           <Link Id="ROMprqB4OwaPNNuVVHZiNd" Ids="JsKnUcIQVg0O0NYs5xuFsK,AZcZOhYHuBsPKFkOTg1KDb" />
           <Link Id="G4CNUfkagwdMD0xgeZ6dY8" Ids="SuRtfOYfpbPQQFoIhHAzDj,FcMc3yqKt0tOdKlm1hddbu" />
           <Link Id="QxTiaZe439jNHPKFlgnaw6" Ids="PCyBxzVqqBFOSlqY15mYV5,P36jl735FhnPybhdCr01TG" IsHidden="true" />
           <Link Id="Sc6FhxILoLwLoFM3037bJO" Ids="P36jl735FhnPybhdCr01TG,TjDTKiIu9nNPBYoTv0IHis" />
           <Pin Id="QOHPGGvcQG9Mx0HPpYQVBS" Name="Output" Kind="OutputPin" />
-          <ControlPoint Id="GJWDC0Y3oeaMbUHKKRlFyJ" Bounds="1468,1248" />
+          <ControlPoint Id="GJWDC0Y3oeaMbUHKKRlFyJ" Bounds="2472,283" />
           <Link Id="MRrWzH25HwNMDqohHXvm52" Ids="GJWDC0Y3oeaMbUHKKRlFyJ,QOHPGGvcQG9Mx0HPpYQVBS" IsHidden="true" />
           <Link Id="HabRQXye18dOeMcnoz7qXR" Ids="K0mTHu4vHGsOVwWfTsRpUN,GJWDC0Y3oeaMbUHKKRlFyJ" />
         </Patch>
@@ -273,12 +304,12 @@
     ************************ RegisterColorSources (Internal) ************************
 
 -->
-      <Node Name="RegisterColorSources (Internal)" Bounds="1357,628,367,380" Id="L91yI7MrtKfOxQj1loAaM4">
+      <Node Name="RegisterColorSources (Internal)" Bounds="1077,145,367,380" Id="L91yI7MrtKfOxQj1loAaM4">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="LtYLqhlFhgDO4aM4yubqkc">
-          <Node Bounds="1434,705,87,76" Id="LOMliiIw1sKOKRNYLdLx89">
+          <Node Bounds="1154,222,87,76" Id="LOMliiIw1sKOKRNYLdLx89">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -288,8 +319,8 @@
             <Pin Id="TUK6hPrmPE4OAr0j9QOAPM" Name="Output" Kind="StateOutputPin" />
             <Patch Id="U3bCwD1Ict9MwfpvkVox4l" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="C7P6uCGR03GOJ9yQ8B4DLM" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="AQpeZtZkZwzOggh5XUOqHH" Bounds="1438,774" />
-              <Node Bounds="1447,728,62,26" Id="Jj0ElZf3iSMPGFt09Y16Fi">
+              <ControlPoint Id="AQpeZtZkZwzOggh5XUOqHH" Bounds="1158,291" />
+              <Node Bounds="1167,245,62,26" Id="Jj0ElZf3iSMPGFt09Y16Fi">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Color.Pixel.PulseCannon" LastDependency="Schema.Blocks.Source.Color.Pixel.PulseCannon.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="PulseCannon" />
@@ -300,22 +331,22 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="VDmolenf0WwMVGFsIff69n" Comment="Key" Bounds="1506,675,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Color.Pixel.Pulse.Cannon">
+          <Pad Id="VDmolenf0WwMVGFsIff69n" Comment="Key" Bounds="1226,192,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Color.Pixel.Pulse.Cannon">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Pin Id="AxhEkdst5n0NFVAlGwUXmQ" Name="Input" Kind="InputPin" />
-          <ControlPoint Id="JMrXacWQsJEOcI3dJ4YEWa" Bounds="1434,646" />
+          <ControlPoint Id="JMrXacWQsJEOcI3dJ4YEWa" Bounds="1154,163" />
           <Link Id="MdGyomEzSAbQXK8oUGt8PB" Ids="AQpeZtZkZwzOggh5XUOqHH,C7P6uCGR03GOJ9yQ8B4DLM" IsHidden="true" />
           <Link Id="HYZ1TWTmdR7LJephxMSEhR" Ids="VDmolenf0WwMVGFsIff69n,FtO8FJgHwnzPDHS3E2t2vZ" />
           <Link Id="UdY23IA5fsyOcTAFhbgpCr" Ids="VmmA3Iz5uBpMZ6EIgzCdVy,AQpeZtZkZwzOggh5XUOqHH" />
           <Link Id="GzOsMQeZ661MYUclcqvfwa" Ids="AxhEkdst5n0NFVAlGwUXmQ,JMrXacWQsJEOcI3dJ4YEWa" IsHidden="true" />
           <Link Id="KlmCMT9gm2vPLdE4IYRAfg" Ids="JMrXacWQsJEOcI3dJ4YEWa,NxmuvcRNzGbMeQfn3yf8IK" />
           <Pin Id="CYleKdqdq12Py3yvcHUFlr" Name="Output" Kind="OutputPin" />
-          <ControlPoint Id="VCZ43OzDYDPMHqtSx4sco0" Bounds="1438,991" />
+          <ControlPoint Id="VCZ43OzDYDPMHqtSx4sco0" Bounds="1158,508" />
           <Link Id="BQfTEcc1IhPOdQIdTqmiTP" Ids="VCZ43OzDYDPMHqtSx4sco0,CYleKdqdq12Py3yvcHUFlr" IsHidden="true" />
-          <Node Bounds="1437,824,87,76" Id="F2kWtXXBZZKQL4XnorNdLb">
+          <Node Bounds="1157,341,87,76" Id="F2kWtXXBZZKQL4XnorNdLb">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -325,8 +356,8 @@
             <Pin Id="QchT2sVS8x5LbSZ83y6lYf" Name="Output" Kind="StateOutputPin" />
             <Patch Id="LKBS4dJKGrgOidynPEwQ0r" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="FPd1BdL3QlBMeqxXmwher9" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="UNz4BK916JJLEpUKLzC9tL" Bounds="1441,893" />
-              <Node Bounds="1450,847,62,26" Id="FwX2VF9OSEJOTvhRLkV3IQ">
+              <ControlPoint Id="UNz4BK916JJLEpUKLzC9tL" Bounds="1161,410" />
+              <Node Bounds="1170,364,62,26" Id="FwX2VF9OSEJOTvhRLkV3IQ">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Color.Pixel.PulseManual" LastDependency="Schema.Blocks.Source.Color.Pixel.PulseManual.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="PulseManual" />
@@ -337,7 +368,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="NxLJ8jnlVOhPxcUW1Eo33E" Comment="Key" Bounds="1509,794,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Color.Pixel.Pulse.Manual">
+          <Pad Id="NxLJ8jnlVOhPxcUW1Eo33E" Comment="Key" Bounds="1229,311,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Color.Pixel.Pulse.Manual">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -354,12 +385,12 @@
     ************************ RegisterAudioValueSources (Internal) ************************
 
 -->
-      <Node Name="RegisterAudioValueSources (Internal)" Bounds="843,769,377,299" Id="IrfbqQVcZB0QDMk8RKnhz4">
+      <Node Name="RegisterAudioValueSources (Internal)" Bounds="1523,124,377,299" Id="IrfbqQVcZB0QDMk8RKnhz4">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="UJNeA8nKoESMYekuFlDO7W">
-          <Node Bounds="920,827,85,76" Id="NyIiOGuaiQRQXiuYFSWglQ">
+          <Node Bounds="1600,182,85,76" Id="NyIiOGuaiQRQXiuYFSWglQ">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -369,8 +400,8 @@
             <Pin Id="G4lDb6akiNfK9gRcx2iQZy" Name="Output" Kind="StateOutputPin" />
             <Patch Id="Abg5P2SLvqSN1dLbFqLjdF" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="I81aFQsUGX6P84230bTrvH" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="TWbxLyvwSz6OXu4frgUu4X" Bounds="924,896" />
-              <Node Bounds="933,850,60,26" Id="Gc4uWfAYpTrMUs3b5ulidA">
+              <ControlPoint Id="TWbxLyvwSz6OXu4frgUu4X" Bounds="1604,251" />
+              <Node Bounds="1613,205,60,26" Id="Gc4uWfAYpTrMUs3b5ulidA">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Value.Audio.PeakPower" LastDependency="Schema.Blocks.Source.Value.Audio.PeakPower.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="PeakPower" />
@@ -381,7 +412,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="F1Ax4cEVL30MjoLlo92bA8" Comment="Key" Bounds="1002,797,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Audio.PeakPower">
+          <Pad Id="F1Ax4cEVL30MjoLlo92bA8" Comment="Key" Bounds="1682,152,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Audio.PeakPower">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -389,7 +420,7 @@
           <Link Id="FK7hTSKwFQ4LUeNh3gMH0c" Ids="TWbxLyvwSz6OXu4frgUu4X,I81aFQsUGX6P84230bTrvH" IsHidden="true" />
           <Link Id="UvrBGhiV4lfMtjXoA6UmAz" Ids="F1Ax4cEVL30MjoLlo92bA8,CmVNmV6CjPqObCsK9StJrX" />
           <Link Id="JRzoYEe4cuMQIlQKt3Q38W" Ids="JhkVPPSFVrxMBRslEx0zEo,TWbxLyvwSz6OXu4frgUu4X" />
-          <Node Bounds="923,945,92,76" Id="HOcy8I0erV8PqbTQajXmuo">
+          <Node Bounds="1603,300,92,76" Id="HOcy8I0erV8PqbTQajXmuo">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -399,8 +430,8 @@
             <Pin Id="QR0icPYr3yFOS4OmrRa7mK" Name="Output" Kind="StateOutputPin" />
             <Patch Id="Fy6TknVjKufO223hOtfXXw" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="BVZHljXmXRnNRaoCD9OdYk" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="KXzMKUvLd2tMRY6lo9LcR0" Bounds="927,1014" />
-              <Node Bounds="936,968,67,26" Id="ItvijZggG8DLYVZaDTqrxS">
+              <ControlPoint Id="KXzMKUvLd2tMRY6lo9LcR0" Bounds="1607,369" />
+              <Node Bounds="1616,323,67,26" Id="ItvijZggG8DLYVZaDTqrxS">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Value.Audio.Pitch" LastDependency="Schema.Blocks.Source.Value.Audio.Pitch.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="Pitch" />
@@ -411,7 +442,7 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="Ur4y7UEDEcCNqRco5htQvz" Comment="Key" Bounds="1005,915,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Audio.Pitch">
+          <Pad Id="Ur4y7UEDEcCNqRco5htQvz" Comment="Key" Bounds="1685,270,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.Audio.Pitch">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -421,11 +452,11 @@
           <Link Id="O1JlazfuLczPKeogfNvpUK" Ids="Ou6eDPGhVHIQMT4O0CJHaQ,KXzMKUvLd2tMRY6lo9LcR0" />
           <Link Id="RRQRCfmbOKBM7oLVR4M6hM" Ids="G4lDb6akiNfK9gRcx2iQZy,RQulcVrMZ8wOQdIzg4Q3Gw" />
           <Pin Id="NKle59MEuNnP1oDQZ2VATW" Name="Input" Kind="InputPin" />
-          <ControlPoint Id="E9vroTc5GhcLiTRtid6ZJ9" Bounds="920,797" />
+          <ControlPoint Id="E9vroTc5GhcLiTRtid6ZJ9" Bounds="1600,152" />
           <Link Id="UP1kNHTxFVOOy1XyRLwkBK" Ids="NKle59MEuNnP1oDQZ2VATW,E9vroTc5GhcLiTRtid6ZJ9" IsHidden="true" />
           <Link Id="HOjVib87IKvNdzKdYdOXWb" Ids="E9vroTc5GhcLiTRtid6ZJ9,N9mnkrddx3qPMkWN2TtkiP" />
           <Pin Id="DIXo4ybsljuQRifjEXWgSb" Name="Output" Kind="OutputPin" />
-          <ControlPoint Id="FVmonfNnoh3Ortdd9Rsjtz" Bounds="923,1051" />
+          <ControlPoint Id="FVmonfNnoh3Ortdd9Rsjtz" Bounds="1603,406" />
           <Link Id="NdGwPxPEkFTMDooZD8ksgj" Ids="FVmonfNnoh3Ortdd9Rsjtz,DIXo4ybsljuQRifjEXWgSb" IsHidden="true" />
           <Link Id="N9Ns68ERGi5M3j4mFEbiOD" Ids="QR0icPYr3yFOS4OmrRa7mK,FVmonfNnoh3Ortdd9Rsjtz" />
         </Patch>
@@ -435,12 +466,12 @@
     ************************ RegisterSystemValueSources (Internal) ************************
 
 -->
-      <Node Name="RegisterSystemValueSources (Internal)" Bounds="862,1164,374,181" Id="Ci7l4e56BoMPVrFOeC8bY8">
+      <Node Name="RegisterSystemValueSources (Internal)" Bounds="1961,122,374,181" Id="Ci7l4e56BoMPVrFOeC8bY8">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="FAjnnvVCEGcLvchZfy7eNG">
-          <Node Bounds="939,1222,118,76" Id="CKU25mfcDj5PAOShtm1VBN">
+          <Node Bounds="2038,180,118,76" Id="CKU25mfcDj5PAOShtm1VBN">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -450,8 +481,8 @@
             <Pin Id="AgkcHZBAu1QOURT9dJzb5w" Name="Output" Kind="StateOutputPin" />
             <Patch Id="VTbISp09nDyOJ0JBtAgADQ" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="R3aqMwawRs3LG9v7bzOrwO" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="PZ6Sprrog3eM4klUtgwDo2" Bounds="943,1291" />
-              <Node Bounds="952,1245,93,26" Id="GXrQYtdwkxxLAfJRuKQjOo">
+              <ControlPoint Id="PZ6Sprrog3eM4klUtgwDo2" Bounds="2042,249" />
+              <Node Bounds="2051,203,93,26" Id="GXrQYtdwkxxLAfJRuKQjOo">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Value.System.FileExistsValueSource" LastDependency="Schema.Blocks.Source.System.FileExists.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="FileExistsValueSource" />
@@ -462,18 +493,18 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="QBvCYOdZ2RFQcaeyuUtwUx" Comment="Key" Bounds="1021,1192,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.System.FileExists">
+          <Pad Id="QBvCYOdZ2RFQcaeyuUtwUx" Comment="Key" Bounds="2120,150,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Value.System.FileExists">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
-          <ControlPoint Id="TFlU0x5hpJMNA4l6ZMUPv6" Bounds="939,1328" />
+          <ControlPoint Id="TFlU0x5hpJMNA4l6ZMUPv6" Bounds="2038,286" />
           <Link Id="QRvhS4bqgSEMFpaexyibW2" Ids="PZ6Sprrog3eM4klUtgwDo2,R3aqMwawRs3LG9v7bzOrwO" IsHidden="true" />
           <Link Id="V7IkIlZV1yONuFMlB8b6Fm" Ids="QBvCYOdZ2RFQcaeyuUtwUx,PEUt5IvcrwwMkTBr63G1iW" />
           <Link Id="AKZwrX6kfF8PFUAaquo9fU" Ids="I1xbgY4QgeIMAobsKIsLKU,PZ6Sprrog3eM4klUtgwDo2" />
           <Link Id="Uf1dOY5v6iFN4Cq8O17YLD" Ids="TFlU0x5hpJMNA4l6ZMUPv6,Pb4MJK1czpZQI6R76ChxbR" IsHidden="true" />
           <Link Id="KQO6mkCeW4pMNwD3FUBLNc" Ids="AgkcHZBAu1QOURT9dJzb5w,TFlU0x5hpJMNA4l6ZMUPv6" />
-          <ControlPoint Id="QG0NmZZji7fMd4qCbzSwpJ" Bounds="941,1183" />
+          <ControlPoint Id="QG0NmZZji7fMd4qCbzSwpJ" Bounds="2040,141" />
           <Link Id="VPgrmhPqcJuOPUGYBBVrwq" Ids="QG0NmZZji7fMd4qCbzSwpJ,K4i1ItGoEFBMrHEcb0jwcx" />
           <Link Id="BLcSUiWWSjdLRmYJfmaYRn" Ids="DExprZqXojlMBtPLfiUOt3,QG0NmZZji7fMd4qCbzSwpJ" IsHidden="true" />
           <Pin Id="DExprZqXojlMBtPLfiUOt3" Name="Input" Kind="InputPin" Bounds="962,1231" />
@@ -485,12 +516,12 @@
     ************************ RegisterResourceSources (Internal) ************************
 
 -->
-      <Node Name="RegisterResourceSources (Internal)" Bounds="1391,1369,364,181" Id="BQHB7enxFb7LBsMXtIUsEB">
+      <Node Name="RegisterResourceSources (Internal)" Bounds="2806,119,364,181" Id="BQHB7enxFb7LBsMXtIUsEB">
         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="OperationDefinition" Name="Operation" />
         </p:NodeReference>
         <Patch Id="GbhP7XZZBVELvGiDlWp5aU">
-          <Node Bounds="1468,1427,132,76" Id="PdGnIo4O9kLOPY6DntLZcR">
+          <Node Bounds="2883,177,130,76" Id="PdGnIo4O9kLOPY6DntLZcR">
             <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
               <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
@@ -500,8 +531,8 @@
             <Pin Id="LEuPtuQTFX0NmW1sjaMbs5" Name="Output" Kind="StateOutputPin" />
             <Patch Id="AR2GeYgROAaOlfhFn8pyLj" Name="Constructor" ManuallySortedPins="true">
               <Pin Id="KIKqSXesuarMZLOivg6BUm" Name="Result" Kind="OutputPin" />
-              <ControlPoint Id="DqZtE9UYaauPjxtMEqwLSp" Bounds="1472,1496" />
-              <Node Bounds="1481,1450,105,26" Id="DlPj6UmY1y1LMkLoBhfeFt">
+              <ControlPoint Id="DqZtE9UYaauPjxtMEqwLSp" Bounds="2887,246" />
+              <Node Bounds="2896,200,105,26" Id="DlPj6UmY1y1LMkLoBhfeFt">
                 <p:NodeReference LastCategoryFullName="Schema.Blocks.Source.Resource.ConstantResourceSource" LastDependency="Schema.Blocks.Source.Resource.Constant.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="ClassType" Name="ConstantResourceSource" />
@@ -512,20 +543,20 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="I76r7E7JQgfPJMqGb3Y3EW" Comment="Key" Bounds="1540,1397,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Resource.Constant">
+          <Pad Id="I76r7E7JQgfPJMqGb3Y3EW" Comment="Key" Bounds="2955,147,164,15" ShowValueBox="true" isIOBox="true" Value="Create.Resource.Constant">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Pin Id="JD4X2mRB4IoQBy9F0cE25a" Name="Input" Kind="InputPin" />
-          <ControlPoint Id="JiGpGS2G6J6Nfvb8Vn8ffx" Bounds="1468,1397" />
+          <ControlPoint Id="JiGpGS2G6J6Nfvb8Vn8ffx" Bounds="2883,147" />
           <Link Id="E65JekJ67hhPImaOla90Hk" Ids="DqZtE9UYaauPjxtMEqwLSp,KIKqSXesuarMZLOivg6BUm" IsHidden="true" />
           <Link Id="KtVqFTrmVGgQLh4aFDu5ka" Ids="I76r7E7JQgfPJMqGb3Y3EW,Vkabf4HTzqzQN466wdkV8T" />
           <Link Id="GhR7RE1faumOSBGA01Xd0a" Ids="BYUBwkqaSAtNf2YRqDsm7i,DqZtE9UYaauPjxtMEqwLSp" />
           <Link Id="PJeSj1CfAxgO7kH4ZP6ucC" Ids="JD4X2mRB4IoQBy9F0cE25a,JiGpGS2G6J6Nfvb8Vn8ffx" IsHidden="true" />
           <Link Id="CfE2BFyBRV9ND93GZ7KMXs" Ids="JiGpGS2G6J6Nfvb8Vn8ffx,TcaMlXKDrTXMDqTK6cKLiV" />
           <Pin Id="JvZMQrYP9baNrOXAls06C1" Name="Output" Kind="OutputPin" />
-          <ControlPoint Id="QUhO4U1AfpLL4yxbzZ7n51" Bounds="1468,1533" />
+          <ControlPoint Id="QUhO4U1AfpLL4yxbzZ7n51" Bounds="2883,283" />
           <Link Id="AvlxaGlL2yjPbkcJVfdExv" Ids="QUhO4U1AfpLL4yxbzZ7n51,JvZMQrYP9baNrOXAls06C1" IsHidden="true" />
           <Link Id="QxtPH4pujikO3CJp1BvRGv" Ids="LEuPtuQTFX0NmW1sjaMbs5,QUhO4U1AfpLL4yxbzZ7n51" />
         </Patch>
@@ -563,6 +594,7 @@
   <DocumentDependency Id="Kk6xA5epyjTLsntS7czmSa" Location="./Value/Audio/Schema.Blocks.Source.Value.Audio.Pitch.vl" />
   <DocumentDependency Id="BqqeG3P0ksbObdQeWrZxpj" Location="./Value/System/Schema.Blocks.Source.System.FileExists.vl" />
   <DocumentDependency Id="NFZECmhj0TkO6pcORwEZlj" Location="./Value/Fixture/Schema.Blocks.Source.Value.Fixture.IsSelected.vl" />
-  <NugetDependency Id="HCKTC6cuMlZNOvp0SBCbQf" Location="VL.CoreLib" Version="2024.6.2" />
+  <NugetDependency Id="HCKTC6cuMlZNOvp0SBCbQf" Location="VL.CoreLib" Version="2025.7.0" />
   <DocumentDependency Id="T3zdFVszpihQPnbKwSSX1U" Location="./Resource/Schema.Blocks.Source.Resource.Constant.vl" />
+  <DocumentDependency Id="K2DfpaqICinNCsJxidtsMC" Location="./Value/Schema.Blocks.Source.Value.Expression.vl" />
 </Document>

--- a/Main/vl/Blocks/Source/Value/Schema.Blocks.Source.Value.Distance.vl
+++ b/Main/vl/Blocks/Source/Value/Schema.Blocks.Source.Value.Distance.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="QwDBdV70UDTQH7y5qPl29n" LanguageVersion="2024.6.2" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="MPlK874xUimQYdGb3V9JHj" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="RazQeVk0O8NPlx2jSpnjPs">
     <Canvas Id="AjHpOANzdO0PFqJri2Qoxt" DefaultCategory="Schema.Blocks.Source.Value" CanvasType="FullCategory">
       <!--
@@ -415,6 +415,6 @@
   <DocumentDependency Id="K4GyEFI8eHdNHJSouTEzpo" Location="../../../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="DynIwdoNrI1QE0Evr8R7Cl" Location="../../../Schema.PropertyExtensions.vl" />
   <DocumentDependency Id="BcjF1DsTWJyMCWLlqlPy69" Location="../Reference/Schema.Blocks.Source.Reference.Fixture.vl" />
-  <NugetDependency Id="Lkn86Fb1Y1oLTYsnwiduBg" Location="VL.CoreLib" Version="2024.6.2" />
+  <NugetDependency Id="Lkn86Fb1Y1oLTYsnwiduBg" Location="VL.CoreLib" Version="2025.7.0" />
   <DocumentDependency Id="JY7yLYaZZR0P2ygvvxdBw2" Location="../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
 </Document>

--- a/Main/vl/Blocks/Source/Value/Schema.Blocks.Source.Value.Expression.vl
+++ b/Main/vl/Blocks/Source/Value/Schema.Blocks.Source.Value.Expression.vl
@@ -1,0 +1,352 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="QwDBdV70UDTQH7y5qPl29n" LanguageVersion="2025.7.0" Version="0.128">
+  <Patch Id="RazQeVk0O8NPlx2jSpnjPs">
+    <Canvas Id="AjHpOANzdO0PFqJri2Qoxt" DefaultCategory="Schema.Blocks.Source.Value" CanvasType="FullCategory">
+      <!--
+
+    ************************ ExpressionValue ************************
+
+-->
+      <Node Name="ExpressionValue" Bounds="84,90" Id="Fc6DLwrUtiLMlxP9xAJa44">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+          <Choice Kind="ClassDefinition" Name="Class" />
+        </p:NodeReference>
+        <p:Interfaces>
+          <TypeReference LastCategoryFullName="VVVV.Beehive" LastDependency="VVVV.domj.Chapeau.vl">
+            <Choice Kind="InterfaceTypeFlag" Name="IBee" />
+          </TypeReference>
+        </p:Interfaces>
+        <Patch Id="BDHssC6XktqQGKSM6HNBpK">
+          <Canvas Id="HBgC199RIyjO4IUMDLUlaw" CanvasType="Group">
+            <ControlPoint Id="Olz6IK1iX1QPQRu7rjppwM" Bounds="83,53" />
+            <ControlPoint Id="AvA8uLZE6DcQAFZ2Ca1VB8" Bounds="153,51" />
+            <ControlPoint Id="F2VHRBX60E6Pf7bDZ8jEg5" Bounds="135,869" />
+            <ControlPoint Id="Iijv0UH67DAN2gTGt8ip4o" Bounds="414,51" />
+            <Node Bounds="151,122,54,19" Id="V41tzVG7VwkM9WkP74RsI6">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Merge" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="OqqRBLLJ4O8OoPrgCXKsi7" Name="Input" Kind="InputPin" />
+              <Pin Id="NYqR5BtQb1dMo43t3dmCfk" Name="Output" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="AOFJwFi50mOOk1wyFCByB3" Bounds="348,293" />
+            <Pad Id="QVvlu2TrN9uLAYVOxoWmrF" Comment="Key" Bounds="294,133,133,20" ShowValueBox="true" isIOBox="true" Value="Expression">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="138,803,65,19" Id="SPgsGqyRrPhPVx6t6E1E0Q">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetValue" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="SNesIOT9emQQVUMsSPknAI" Name="Input" Kind="InputPin" />
+              <Pin Id="RRn3rHHd1nXOktcfiZVf91" Name="Value" Kind="InputPin" />
+              <Pin Id="TtJZZps2amCM92W2kecwTr" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Pad Id="HjnLx0ORhl5QOtBlCgLAby" Bounds="683,127,269,49" ShowValueBox="true" isIOBox="true" Value="TODO expression effect, expression source with value set by another parameter">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:fontsize p:Type="Int32">9</p:fontsize>
+                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+              </p:ValueBoxSettings>
+            </Pad>
+            <Pad Id="PpiSxrqGRf3OXay1D8ArC0" Bounds="684,176,364,56" ShowValueBox="true" isIOBox="true" Value="TODO set time source (local, global, reset on load, etc.)">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:fontsize p:Type="Int32">9</p:fontsize>
+                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+              </p:ValueBoxSettings>
+            </Pad>
+            <Pad Id="BAlByW2Cl2OLKPkELBH7t4" Comment="Key" Bounds="466,153,91,19" ShowValueBox="true" isIOBox="true" Value="s">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Pad Id="C6ONlREl9XQNNSXz7t2iAG" Comment="Value" Bounds="368,450,63,19" ShowValueBox="true" isIOBox="true" Value="0.5">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Float32" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="219,473,184,275" Id="VjhretoMJflMOaUemDAea4">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
+              </p:NodeReference>
+              <Patch Id="FZmUYGRBymEMIoxc2gSIYC" ManuallySortedPins="true">
+                <Patch Id="Oc08kF8RpdCMGAJt4I3rhE" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="HoXk2dqGMoeN70Fuom69Nk" Name="Try" ParticipatingElements="HhCS6WoEk8JMd0El2TFDQr" ManuallySortedPins="true">
+                  <Pin Id="DCjycPYtdTHN4k7y1FiL51" Name="Output" Kind="OutputPin" />
+                </Patch>
+                <ControlPoint Id="RpMGt2O3MnELydsT4HFG1B" Bounds="223,733" />
+                <Node Bounds="238,649,55,19" Id="Vl5VaNxoN9jNaGq8xh3CnT">
+                  <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Evaluate" />
+                  </p:NodeReference>
+                  <Pin Id="AdvKDJEhz0HMKOBN88Neqp" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="IeJ945I3dsDMGu8PETR6KP" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="GcYp0igtfk2Mww254u2u7M" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="254,709,72,19" Id="K6X9uUtwV6WMqP85jj0v7u">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToFloat32 (Expression Result)" />
+                  </p:NodeReference>
+                  <Pin Id="FZuWgXp0p8TMP4bGsNLM6a" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="BPLRZrJF48eNPzkTdA32m0" Name="Defaultvalue" Kind="InputPin" />
+                  <Pin Id="GB74ZJ5eM7JQMREeeWrMGs" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="241,527,55,19" Id="HhCS6WoEk8JMd0El2TFDQr">
+                  <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.Sync.dll" OverloadStrategy="UserSelectedPins">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="NCalc" />
+                    <CategoryReference Kind="AssemblyCategory" Name="Expression" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                    <PinReference Kind="InputPin" Name="Expression">
+                      <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="System" LastDependency="mscorlib.dll">
+                        <Choice Kind="TypeFlag" Name="String" />
+                      </p:DataTypeReference>
+                    </PinReference>
+                  </p:NodeReference>
+                  <Pin Id="MBZmWS9ce4PPYVjcX2W6UR" Name="Expression" Kind="InputPin" />
+                  <Pin Id="AHs2I7dVFzQLhyw1hYpsPZ" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="240,567,81,19" Id="V7bgUrUktszOj3vV9iBmOf">
+                  <p:NodeReference LastCategoryFullName="NCalc.ExpressionBase`1" LastDependency="NCalc.Core.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ExpressionBase`1" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetParameters" />
+                  </p:NodeReference>
+                  <Pin Id="H5S8DfbzMIsOKOuqBTfMnc" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VcsCRIx3UODM8yKPtTXUmr" Name="Value" Kind="InputPin" />
+                  <Pin Id="CvxIJmtCaGzPCHx2zzzoW8" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="305,523,81,26" Id="G82s246JbAKPxK1dNyvLBa">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetItem" />
+                    <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="JcfBRWmVNqtNLas9mjyL5p" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="K9HIEHtBOApQRvI0Yhu5vu" Name="Key" Kind="InputPin" />
+                  <Pin Id="IY0HVUwx5wIOkKefGJY6wL" Name="Value" Kind="InputPin" />
+                  <Pin Id="D2bV01UCMEVLy3ZGUjZyRz" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="302,496,89,19" Id="QG31165bGlHMkG75vrHJFk">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="CreateDefault" />
+                    <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="AwPVQlqNgwSNj1bPpcekl4" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="240,610,48,19" Id="UkB2oxhXKxRNgzL4xcWPeY">
+                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="CastAs" />
+                  </p:NodeReference>
+                  <Pin Id="Ihij08uSieuPmGcsUtUMQT" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="PrFqmvBwri0O7EtGH61avK" Name="Default" Kind="InputPin" />
+                  <Pin Id="IN3YOEW1XNINZsAwEVi980" Name="Result" Kind="OutputPin" />
+                  <Pin Id="AmbLMRUWNZOQctS90lUSZ8" Name="Success" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <Pin Id="VFk8OWDPKn2PoH5RVezv0r" Name="Default Output" Kind="InputPin" />
+              <Pin Id="JWPKEtvhLkaN6p28JSHTQ2" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
+              <Pin Id="MDaa24NM4ewOkOjyj3s5hL" Name="Result" Kind="OutputPin" />
+              <Pin Id="Kx2EBiZoI1HPgXjidIsysT" Name="Success" Kind="OutputPin" />
+              <Pin Id="AZqgHDVdwweMwmkNuR5rjA" Name="Error Message" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="207,764,45,19" Id="RIHu3nsIw2WOjKJJVLoC8B">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="S+H" />
+                <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="JP1W0cBt9l4MHau1rWVC2s" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="BAEcDI2hX5MOjRM3zKnMSO" Name="Initial Value" Kind="InputPin" />
+              <Pin Id="CKjZofpDhfiNe9buWWP0A9" Name="Value" Kind="InputPin" />
+              <Pin Id="Jxq2fRacjR4MsWSqgxS82R" Name="Sample" Kind="InputPin" />
+              <Pin Id="UJp81WODrNoLEFysb7JZ0C" Name="Value" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="362,347,101,19" Id="UrgTCTQ4vn2PMmN0OvM5Tg">
+              <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CurrentFrameTime" />
+              </p:NodeReference>
+              <Pin Id="Ed42WIY33yCP3bQfvZy9Px" Name="Current Frame Time" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="364,376,54,26" Id="H9cx2LMSYhTLPy9lgibwVE">
+              <p:NodeReference LastCategoryFullName="Animation.Time" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Seconds" />
+                <CategoryReference Kind="RecordType" Name="Time" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="BOkq6DOZtWPQY5e5hHI7dX" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Ova1uxdYKdoLPQHjtPBGjL" Name="Seconds" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="363,417,72,19" Id="U25QVa8xSToLFnJbrF3BBC">
+              <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToFloat32" />
+              </p:NodeReference>
+              <Pin Id="LNIHoTVS870L2FC0QmeJMH" Name="Input" Kind="InputPin" />
+              <Pin Id="IimjQfKpnj7OYT0pxrDw2T" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="272,193,145,19" Id="VQbp0S8bgfYNvXPFSM1Nit">
+              <p:NodeReference LastCategoryFullName="Schema.PropertyDefinition.Helpers" LastDependency="Schema.PropertyDefinition.Helpers.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Helpers" />
+                <Choice Kind="ProcessAppFlag" Name="String" />
+              </p:NodeReference>
+              <Pin Id="Egk44gVMfs4MA8Ymz7dm4u" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="VnbW0LyC0DNLjzeHgSGU12" Name="Input" Kind="InputPin" />
+              <Pin Id="EG3GVZDX7b0Lp9OoWf6vcG" Name="Key" Kind="InputPin" />
+              <Pin Id="Vs6unalXbTsQK0nqN5i6Et" Name="Default" Kind="InputPin" />
+              <Pin Id="RaujbVzsxMkPPGfWnjUz8X" Name="Between Spread" Kind="InputPin" />
+              <Pin Id="UpTOy2DTGs2M7Na0bZ4OQe" Name="Children Spread" Kind="InputPin" />
+              <Pin Id="RPD1ddlkRLHNBtouoGs4Ww" Name="Type" Kind="InputPin" DefaultValue="Label" />
+              <Pin Id="UKxpiQy9e0BN70NxZh6PCK" Name="Tooltip" Kind="InputPin" />
+              <Pin Id="Dwkg2BsehXDP8zo5qGXrpy" Name="Properties" Kind="InputPin" />
+              <Pin Id="AnxA9wozF1xOxP5rJG7hA5" Name="Properties" Kind="OutputPin" />
+              <Pin Id="TSI5znjiyIPNyLeXB1d8rw" Name="Output" Kind="OutputPin" />
+              <Pin Id="G0bJzjNxcfvPmWUQ70lqSi" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="272,162,79,19" Id="RoyVaEGsx1mO8DMg4q1Ek3">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CreateDefault" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="IMABacccRK9PRs0v1mnFwc" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="274,232,77,26" Id="KkNO2GTYTPjL2Qphg46R9D">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToImmutable" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="IBHE0G0th8hMAlx2nv61Uc" Name="Input" Kind="StateInputPin" />
+              <Pin Id="FWySYp3TRmbP8Lu0wma8JD" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="FMFE5qeALiCPEnbYahzXwr" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Pad Id="G1h7d3HCK9UOc3xkSBEB2a" Bounds="684,202,361,32" ShowValueBox="true" isIOBox="true" Value="TODO remove Label type hack, allow string editing">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:fontsize p:Type="Int32">9</p:fontsize>
+                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+              </p:ValueBoxSettings>
+            </Pad>
+          </Canvas>
+          <Patch Id="FQblJsNf0WLN4USmEVCqJV" Name="Create" />
+          <ProcessDefinition Id="E2Iof7VH3UVOk0JZFYtqHh" IsHidden="true">
+            <Fragment Id="T29JRlNH08xOmMOzGMqTVd" Patch="FQblJsNf0WLN4USmEVCqJV" Enabled="true" />
+            <Fragment Id="HuYvaCf27zAPa6Z5x9DS95" Patch="AoVhwrdwm2nOkUlg6sznYr" Enabled="true" />
+            <Fragment Id="BEHuDYBIoEjOxNitKYQW7M" Patch="VAUcp89XjDoQVecTtuvgti" Enabled="true" />
+            <Fragment Id="IPkdWrx3jLfOayNzdO7ahN" Patch="JYvD36hCiwdN6MiC4EKj64" Enabled="true" />
+            <Fragment Id="OWWwBlPo1hrMOeEN1w9hGE" Patch="JYdLEQ7YLCxPKb3dMajeQx" Enabled="true" />
+            <Fragment Id="DoIC1rrN9dsQUGuNGvh2Ui" Patch="Mtq6MHr7iTqLcl4YNLI56v" />
+          </ProcessDefinition>
+          <Patch Id="AoVhwrdwm2nOkUlg6sznYr" Name="Update">
+            <Pin Id="GmAx4Q0Qs7UQOFerYI4Cyt" Name="Setup" Kind="InputPin" />
+            <Pin Id="QWOi5hvziurOfuGUT1QlQo" Name="State" Kind="InputPin" />
+            <Pin Id="ViJp3Uv0TMKN5BuTpL8xy0" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="JLKm23rnERHMyh0YUse11j" Name="Global" Kind="InputPin" />
+            <Pin Id="ESi9XHEKJojQcu4iwg7CjG" Name="Properties" Kind="InputPin" />
+            <Pin Id="PgrSN9EUZwHQLufYEZ8eMW" Name="New State" Kind="OutputPin" />
+            <Pin Id="Nd7iFLuuhi6QCqi3ocRdqE" Name="Node Operation" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="VAUcp89XjDoQVecTtuvgti" Name="Provides">
+            <Pin Id="ExsY2VF3UOVMZpMPIngKci" Name="Color" Kind="OutputPin" />
+            <Pin Id="CXLCTtNitTUNmvTGACDh2Y" Name="Pick" Kind="OutputPin" />
+            <Pin Id="GEAUEAxzC0qOAtKb6xFj0z" Name="Gate" Kind="OutputPin" />
+            <Pin Id="OMB4nWdTJtNPBXTnuVdi4L" Name="Own Color" Kind="OutputPin" />
+            <Pin Id="Vi1y1fB06zzOADdGzBm0nA" Name="Text" Kind="OutputPin" />
+            <Pin Id="Vf9zIHA16m3PUh2cVZh2j5" Name="Progress" Kind="OutputPin" />
+            <Pin Id="ASkd2AXjPLHMbZ1OF5gtgq" Name="Levels" Kind="OutputPin" />
+            <Pin Id="G1TAb9DKLEnMPfbjXXj6EF" Name="Active Levels" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYvD36hCiwdN6MiC4EKj64" Name="GetColor">
+            <Pin Id="KU7IpArLZeNMkQNWjtr6ZD" Name="Color" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYdLEQ7YLCxPKb3dMajeQx" Name="GetPropertyDefinitions">
+            <Pin Id="LO8eH78NDSkMrj1WAy6tqK" Name="Properties" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="Mtq6MHr7iTqLcl4YNLI56v" Name="GetText">
+            <Pin Id="QkS2LUMSgzEMmJYZdmOBvA" Name="Text" Kind="OutputPin" />
+          </Patch>
+          <Link Id="MZRjKYsOd3uNIRkmMbG3hP" Ids="GmAx4Q0Qs7UQOFerYI4Cyt,Olz6IK1iX1QPQRu7rjppwM" IsHidden="true" />
+          <Link Id="JP1HjI3P3huNc0nDb6PydB" Ids="QWOi5hvziurOfuGUT1QlQo,AvA8uLZE6DcQAFZ2Ca1VB8" IsHidden="true" />
+          <Link Id="TJyBl73m1LnOvGGr0N5xKa" Ids="F2VHRBX60E6Pf7bDZ8jEg5,PgrSN9EUZwHQLufYEZ8eMW" IsHidden="true" />
+          <Link Id="D7AF0tuGpAbOEalmvH7P4a" Ids="ESi9XHEKJojQcu4iwg7CjG,Iijv0UH67DAN2gTGt8ip4o" IsHidden="true" />
+          <Link Id="GJiMhGKQmAPOdNObH1thPX" Ids="AvA8uLZE6DcQAFZ2Ca1VB8,OqqRBLLJ4O8OoPrgCXKsi7" />
+          <Link Id="Bt8YtjdREx1NsFi1lHdL39" Ids="AOFJwFi50mOOk1wyFCByB3,LO8eH78NDSkMrj1WAy6tqK" IsHidden="true" />
+          <Link Id="OHT4LGWsR54LEUcwZZF1NB" Ids="TtJZZps2amCM92W2kecwTr,F2VHRBX60E6Pf7bDZ8jEg5" />
+          <Link Id="Ky35ebFiGFeQB9rv7IHjGd" Ids="NYqR5BtQb1dMo43t3dmCfk,SNesIOT9emQQVUMsSPknAI" />
+          <Link Id="DW0cTbBmdS6NqEOrpoUYKA" Ids="AwPVQlqNgwSNj1bPpcekl4,JcfBRWmVNqtNLas9mjyL5p" />
+          <Link Id="VxlaZAvA5RSQbJj9GZSOaW" Ids="D2bV01UCMEVLy3ZGUjZyRz,VcsCRIx3UODM8yKPtTXUmr" />
+          <Link Id="KqOU3MY99KSOSNxCUQH54N" Ids="BAlByW2Cl2OLKPkELBH7t4,K9HIEHtBOApQRvI0Yhu5vu" />
+          <Link Id="N44lDfpqqMUNz5q7SXaFus" Ids="C6ONlREl9XQNNSXz7t2iAG,IY0HVUwx5wIOkKefGJY6wL" />
+          <Link Id="DepDs9bw2eUPbHJUSJbrO2" Ids="RpMGt2O3MnELydsT4HFG1B,DCjycPYtdTHN4k7y1FiL51" IsHidden="true" />
+          <Link Id="KkJTXK4rV5AMIavGJDEF2N" Ids="GcYp0igtfk2Mww254u2u7M,FZuWgXp0p8TMP4bGsNLM6a" />
+          <Link Id="Us24FjsNwiSPBi2gYrel6P" Ids="GB74ZJ5eM7JQMREeeWrMGs,RpMGt2O3MnELydsT4HFG1B" />
+          <Link Id="U44EEZcb3GxOc3K5x954c6" Ids="MDaa24NM4ewOkOjyj3s5hL,CKjZofpDhfiNe9buWWP0A9" />
+          <Link Id="FiDcwCsyFmNNwgeDrPXumx" Ids="Kx2EBiZoI1HPgXjidIsysT,Jxq2fRacjR4MsWSqgxS82R" />
+          <Link Id="VIyVZJor0fzOPZBiDi3a0S" Ids="UJp81WODrNoLEFysb7JZ0C,RRn3rHHd1nXOktcfiZVf91" />
+          <Link Id="QIXEODYabETMvCg1RmDO3Z" Ids="Ed42WIY33yCP3bQfvZy9Px,BOkq6DOZtWPQY5e5hHI7dX" />
+          <Link Id="JAuCpwpXVHqPMOxcP5Tbta" Ids="Ova1uxdYKdoLPQHjtPBGjL,LNIHoTVS870L2FC0QmeJMH" />
+          <Link Id="UTHvF2A6sitPw144mNr4dC" Ids="IimjQfKpnj7OYT0pxrDw2T,C6ONlREl9XQNNSXz7t2iAG" />
+          <Link Id="RVop7pUmuaYMeKe3cfMD7Z" Ids="AHs2I7dVFzQLhyw1hYpsPZ,H5S8DfbzMIsOKOuqBTfMnc" />
+          <Link Id="Iz0rIwNualEODmupRuINW9" Ids="CvxIJmtCaGzPCHx2zzzoW8,Ihij08uSieuPmGcsUtUMQT" />
+          <Link Id="PIdvoZcNelfLCGQKSHP9S2" Ids="IN3YOEW1XNINZsAwEVi980,AdvKDJEhz0HMKOBN88Neqp" />
+          <Link Id="Booxr1acVrlQB2jyVw2ZCJ" Ids="Iijv0UH67DAN2gTGt8ip4o,Dwkg2BsehXDP8zo5qGXrpy" />
+          <Link Id="J6x9QaLMnt7OljhcrSTJ0m" Ids="QVvlu2TrN9uLAYVOxoWmrF,EG3GVZDX7b0Lp9OoWf6vcG" />
+          <Link Id="BgyrnKYuzBrQPgd01WmIWL" Ids="IMABacccRK9PRs0v1mnFwc,VnbW0LyC0DNLjzeHgSGU12" />
+          <Link Id="FeRFxcZk1sZLFQWMFQ2fnn" Ids="AnxA9wozF1xOxP5rJG7hA5,IBHE0G0th8hMAlx2nv61Uc" />
+          <Link Id="BGtlE3xzUH0MNEBh94SAV6" Ids="FMFE5qeALiCPEnbYahzXwr,AOFJwFi50mOOk1wyFCByB3" />
+          <Link Id="Vk5P4VOxG9wLwQgdO1e5qb" Ids="BAlByW2Cl2OLKPkELBH7t4,Vs6unalXbTsQK0nqN5i6Et" />
+          <Link Id="VQmgoFyJbTHOAWjg3Dsl4F" Ids="G0bJzjNxcfvPmWUQ70lqSi,MBZmWS9ce4PPYVjcX2W6UR" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="RCKiHBrLdcZPG7jFRmFgin">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="K6NpIgswrghPmoVYMiy9VS">
+        <Canvas Id="Dz992g9vlFnOPw1v4Uwqj8" CanvasType="Group" />
+        <Patch Id="ES9epZJHgV1PILstcerFrF" Name="Create" />
+        <Patch Id="GZtpz52P0agNh112TUU7yP" Name="Update" />
+        <ProcessDefinition Id="BzfKXFFCeF4Mr3Mvpz7Zke">
+          <Fragment Id="SSlvRu502zqNI2XNqdlj35" Patch="ES9epZJHgV1PILstcerFrF" Enabled="true" />
+          <Fragment Id="EMaCNGaAWgLLSWSrUBE1mL" Patch="GZtpz52P0agNh112TUU7yP" Enabled="true" />
+          <Fragment Id="O3jGv7VXNhhLoeikprCF7f" Patch="RA7eMM0t8g8Ln8KI3q9jBH" Enabled="true" />
+        </ProcessDefinition>
+        <Patch Id="RA7eMM0t8g8Ln8KI3q9jBH" Name="GetPropertyDefinitions" />
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="K4GyEFI8eHdNHJSouTEzpo" Location="../../../VVVV.Schema.Core.vl" />
+  <DocumentDependency Id="DynIwdoNrI1QE0Evr8R7Cl" Location="../../../Schema.PropertyExtensions.vl" />
+  <DocumentDependency Id="BcjF1DsTWJyMCWLlqlPy69" Location="../Reference/Schema.Blocks.Source.Reference.Fixture.vl" />
+  <DocumentDependency Id="JY7yLYaZZR0P2ygvvxdBw2" Location="../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
+  <NugetDependency Id="UemBBlwqhH6NknU6oQSUYC" Location="VL.CoreLib" Version="2025.7.0" />
+  <NugetDependency Id="BaLY0oO1LHyN5GScvLZxll" Location="NCalc.Core" Version="5.2.2" />
+  <NugetDependency Id="ING7InmkUQyQHIZ52T3ewg" Location="NCalcSync" Version="5.2.2" />
+</Document>

--- a/Main/vl/Model/Schema.Model.PropertyBank.vl
+++ b/Main/vl/Model/Schema.Model.PropertyBank.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="PT3eNxOqfVAN8xrvfRMxMT" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="HIdEMdJ6PQMOFUhJtgHXHB" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="PT3eNxOqfVAN8xrvfRMxMT" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="HIdEMdJ6PQMOFUhJtgHXHB" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="FRHa9ALiUVDODlbFiFCDmg">
     <Canvas Id="DQUErVc31qlOCBpArO3Ihz" DefaultCategory="Schema.Model" CanvasType="FullCategory">
       <!--
@@ -819,6 +819,23 @@
                     <Choice Kind="OperationNode" Name="StateKeys" />
                   </p:NodeReference>
                   <Pin Id="FLlW9YWOhbRMo2R5ipPTRE" Name="Colors SpreadRGBA" Kind="OutputPin" />
+                  <Pin Id="IMepLP9XwhLPkRlHdkaoRf" Name="Value Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="J2nOruwH7npLIKEEyCPrgR" Name="Radius Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="TkzrGwaPIIVPgVtCRAShIh" Name="Speed Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="Rpxp10SXuMGPkHKju6U46A" Name="Duration Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="C1h7BWtYR1hNRa2Nv4Q0J1" Name="Rotation Vector3" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="FeuMIpzslEIMg6kSKyMZiY" Name="Zoom Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="BrnLKTS3nGvPcrE4tpjrZK" Name="Shake Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="IVB8EQvfrTDPxdCnaphXo9" Name="Gobo1 Integer32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="VPlg9GDyS1MM5klB50jrMQ" Name="Focus Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="LTf9kcwQXWRQc1hlVaoqxt" Name="GoboRotate Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="GvSVRdL7wzuPzHTWY11g0I" Name="Iris Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="MTTsbRIM3GxLlZdOxKck2Y" Name="Gobo Integer32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="Tmbh89Mou2XPSKCxpvBhVI" Name="Prism Integer32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="TVpnjZ0ywoCNhUNZto9vPd" Name="PrismRotate Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="DZD4j1Y66SwMU048DvLQzC" Name="ColorWheel Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="Tkb9MVMKRn9O7r7NIcc7gn" Name="Frost Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="G1CaruCTgmKPjKpt59slh9" Name="Operations Spread Delegate 0-&gt;0" Kind="OutputPin" IsHidden="true" />
                 </Node>
                 <ControlPoint Id="LLbufTPMjLeQFoAS6jsG6V" Bounds="539,-2180" />
                 <Link Id="FMOB6Erq3bFMs2Q2dVjyKY" Ids="LLbufTPMjLeQFoAS6jsG6V,KCnik1IPtE6OkFscfBxJFK" />
@@ -1190,8 +1207,8 @@
                   </p:NodeReference>
                   <Pin Id="F72Y4YZbQqjPyeRzFef0hh" Name="Condition" Kind="InputPin" />
                   <ControlPoint Id="A392GQKMJ3NPiSiD6gpDCG" Bounds="1388,-768" Alignment="Top" />
-                  <ControlPoint Id="Eau0LZUfFeNMeAhBveQ6J8" Bounds="1388,-603" Alignment="Bottom" />
-                  <ControlPoint Id="Jki6gUhAnpmMKTL0kcqqwZ" Bounds="1520,-603" Alignment="Bottom" />
+                  <ControlPoint Id="Eau0LZUfFeNMeAhBveQ6J8" Bounds="1388,-602" Alignment="Bottom" />
+                  <ControlPoint Id="Jki6gUhAnpmMKTL0kcqqwZ" Bounds="1520,-602" Alignment="Bottom" />
                   <ControlPoint Id="VQndnQObWTNN45RTW2CN94" Bounds="1520,-768" Alignment="Top" />
                   <Patch Id="Oi39qTgx2icNp9b3XX6XGH" ManuallySortedPins="true">
                     <Patch Id="VpDWmyDGcz7LpTtAR7IOGy" Name="Create" ManuallySortedPins="true" />
@@ -1979,6 +1996,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="SdeOduTu66MPbbHEjNgsap" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LPgBwULEwUjNxH7M16ODkW" Name="Properties" Kind="InputPin" />
                   <Pin Id="FxNb2VfxbZAPgZKbR2uNSf" Name="Output" Kind="StateOutputPin" />
                 </Node>
@@ -2322,7 +2340,7 @@
                   <Pin Id="J0y0QzgJXS3OJlv0SvS63F" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="N4W8BYAdmaJOlUp828aG4C" Name="Key" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="-373,975,40,26" Id="Ojw56CsbVqfLgcMVz8YGzJ">
+                <Node Bounds="-373,975,78,26" Id="Ojw56CsbVqfLgcMVz8YGzJ">
                   <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="GetHashCode" />
@@ -2630,6 +2648,7 @@
                       </p:NodeReference>
                       <Pin Id="ErhrpatJ1zWMs0mCRIrR9S" Name="Input" Kind="StateInputPin" />
                       <Pin Id="O9yaLvbk2pXNMt5eW24KM1" Name="Key" Kind="InputPin" />
+                      <Pin Id="PoYX0swSUa1NVlAf8XMR36" Name="Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="BhrVXjnDO5DOMfN7Aoxteu" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="-799,443,62,26" Id="QmSv8g886QeLCJfW0b5pjn">
@@ -2673,6 +2692,7 @@
                           </p:NodeReference>
                           <Pin Id="AVDUGfAhZqeNcYtHKoMxwa" Name="Input" Kind="StateInputPin" />
                           <Pin Id="BSX7EcG3yDbLNFEi2evWMy" Name="Key" Kind="InputPin" />
+                          <Pin Id="JTNRI322QHGNLlEmDf3j3K" Name="Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="BFHjQBEnPTFPIlRtVZT4Un" Name="Item" Kind="OutputPin" />
                         </Node>
                       </Patch>
@@ -2701,6 +2721,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="Oasg4xA6KIeOgC9Cus8cOv" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Vo70Or0gpFQLgg2HVAvEr5" Name="Properties" Kind="InputPin" />
                   <Pin Id="JrrOFi4QSMUNNrjksj6j6W" Name="Output" Kind="StateOutputPin" />
                 </Node>
@@ -5050,7 +5071,7 @@
                 <Choice Kind="OperationDefinition" Name="Operation" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
-              <Patch Id="RYIW5CLZz8TLszrdQOwW28">
+              <Patch Id="RYIW5CLZz8TLszrdQOwW28" IsGeneric="true">
                 <Node Bounds="1762,-2475,86,26" Id="OVD4qEv72aKLNO6BRvJuuN">
                   <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -6142,13 +6163,13 @@
     ************************ SetObject ************************
 
 -->
-            <Node Name="SetObject" Bounds="387,-87,162,108" Id="UkvSpSh6pSCNvetboCMmLa">
+            <Node Name="SetObject" Bounds="380,-138,162,108" Id="UkvSpSh6pSCNvetboCMmLa">
               <p:NodeReference>
                 <Choice Kind="OperationDefinition" Name="Operation" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
-              <Patch Id="RgCDb9fmQPMPRBMtReIru6">
-                <Node Bounds="401,-39,86,26" Id="T1MPoZ9DG19O4KpElc30BF">
+              <Patch Id="RgCDb9fmQPMPRBMtReIru6" IsGeneric="true">
+                <Node Bounds="394,-90,86,26" Id="T1MPoZ9DG19O4KpElc30BF">
                   <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Set" />
@@ -6159,16 +6180,16 @@
                   <Pin Id="Kqli0HG5MJxMyTAGamkwOb" Name="Value" Kind="InputPin" />
                   <Pin Id="IWcQ554PwWOPg3cIm1Yr24" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <ControlPoint Id="OFhzsorJWMbLBIksql2bam" Bounds="401,-69" />
+                <ControlPoint Id="OFhzsorJWMbLBIksql2bam" Bounds="394,-120" />
                 <Link Id="T0ZzgSf5FgOP8ZNU2lwLd4" Ids="CAL2OL359WxMdZjiNsC14q,OFhzsorJWMbLBIksql2bam" IsHidden="true" />
                 <Link Id="JgY38hnrFXxPhL25HyPYOi" Ids="OFhzsorJWMbLBIksql2bam,S3x7CHgSsMdPSRj9d4D1PH" />
-                <ControlPoint Id="DYHeyxIj2wDLgjxqYe0KHT" Bounds="455,-69" />
+                <ControlPoint Id="DYHeyxIj2wDLgjxqYe0KHT" Bounds="448,-120" />
                 <Link Id="AmPCw392YbeQRnsJSDTMMO" Ids="DBDYDRmtKrfOYMHXGprVgV,DYHeyxIj2wDLgjxqYe0KHT" IsHidden="true" />
                 <Link Id="LAQ42OVnMNSLT6Wsf5EOQ9" Ids="DYHeyxIj2wDLgjxqYe0KHT,Aa6AF0syofxNzDZwgVqH8E" />
-                <ControlPoint Id="FvCLnjFQHWuLr5bxFjhcW5" Bounds="501,-69" />
+                <ControlPoint Id="FvCLnjFQHWuLr5bxFjhcW5" Bounds="494,-120" />
                 <Link Id="UcuZa12iSaEPOiqpvKOd9h" Ids="QqDeqNlR8bmOzzo7ymxRug,FvCLnjFQHWuLr5bxFjhcW5" IsHidden="true" />
                 <Link Id="E3JwRLEOEKgOG2jjqcXysX" Ids="FvCLnjFQHWuLr5bxFjhcW5,Kqli0HG5MJxMyTAGamkwOb" />
-                <ControlPoint Id="PuguQt5yKsZQdT3DODOc7V" Bounds="401,4" />
+                <ControlPoint Id="PuguQt5yKsZQdT3DODOc7V" Bounds="394,-47" />
                 <Link Id="N9I8FTRdk4hNgBmeH2tUpL" Ids="PuguQt5yKsZQdT3DODOc7V,SkLyKricb3jQA4pU5cMZzc" IsHidden="true" />
                 <Link Id="GQBt673RspdNg6Nvdk9RNo" Ids="IWcQ554PwWOPg3cIm1Yr24,PuguQt5yKsZQdT3DODOc7V" />
                 <Pin Id="CAL2OL359WxMdZjiNsC14q" Name="Input" Kind="InputPin" />
@@ -6583,7 +6604,11 @@
                 <Link Id="DBAW4HPw2ovNYPvHWjFpyY" Ids="GbW3EcpwiXcNBWG6yFdW2B,KSY3zfuh42YORTca23ykK9" />
                 <Pin Id="F6gvBvwNeu5Nye0uRlU3vZ" Name="Input" Kind="InputPin" />
                 <Pin Id="G2BdQTYLjiwLTjgCHz1iD8" Name="Slot" Kind="InputPin" />
-                <Pin Id="PqI5ONlRA2MQYFeFL79vvx" Name="Value" Kind="InputPin" />
+                <Pin Id="PqI5ONlRA2MQYFeFL79vvx" Name="Value" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
                 <Pin Id="ACI5DqdFGSuPAG0CcJPLlO" Name="Output" Kind="OutputPin" />
               </Patch>
             </Node>
@@ -6682,7 +6707,11 @@
                 <Link Id="E4b1Z6uZ49OPwgDN77VtXs" Ids="Ocb1pZYOog8MsT7rtRwALv,PD2GU79jfOJNhSWhqtR4Mf" />
                 <Pin Id="DmzotoHZ036PICfKT4v6py" Name="Input" Kind="InputPin" />
                 <Pin Id="IMIc6mtZ6KnLg8bwlrnu0S" Name="Slot" Kind="InputPin" />
-                <Pin Id="EJrkunVfhHVNEmpHyuSRJc" Name="Value" Kind="InputPin" />
+                <Pin Id="EJrkunVfhHVNEmpHyuSRJc" Name="Value" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
                 <Pin Id="MxeEGfgxwi4NPwN7SF9VoJ" Name="Output" Kind="OutputPin" />
               </Patch>
             </Node>
@@ -6777,7 +6806,11 @@
                 <Link Id="Ue1z7jlJ6rMPwcXdhOQJsl" Ids="Chb6jtFvuOtMTcxNQzyBoU,Gx6l9cmM0NNOe7tnSXdHTx" IsHidden="true" />
                 <Link Id="Rnwi1bOfXAjMeojuqrXzjB" Ids="RnZZSb4ZGwzM05ySo3b58J,Chb6jtFvuOtMTcxNQzyBoU" />
                 <Pin Id="SeLcwdKNtpRPIcx6a22xKM" Name="Input" Kind="InputPin" />
-                <Pin Id="FUhClNbsiHjPbUxyFOMGeO" Name="Value" Kind="InputPin" />
+                <Pin Id="FUhClNbsiHjPbUxyFOMGeO" Name="Value" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
                 <Pin Id="Gx6l9cmM0NNOe7tnSXdHTx" Name="Output" Kind="OutputPin" />
               </Patch>
             </Node>
@@ -6913,7 +6946,11 @@
                 <Link Id="FFoGWzRbJcFO91drgnP18a" Ids="RABZ2rcP8vIN1T4p62kctP,FzyutoiJV9RMW7b82thw6E" />
                 <Pin Id="RsVr786KrrnMlOK9ydKKA7" Name="Input" Kind="InputPin" />
                 <Pin Id="VXExOvc5a0oOik2n3MfKXD" Name="Slot" Kind="InputPin" />
-                <Pin Id="BPu5OxnaQ77MEAvAVG3Lor" Name="Value" Kind="InputPin" />
+                <Pin Id="BPu5OxnaQ77MEAvAVG3Lor" Name="Value" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
                 <Pin Id="PQ8PYGN8z9LPE3JxjXyBIL" Name="Output" Kind="OutputPin" />
               </Patch>
             </Node>
@@ -7012,7 +7049,11 @@
                 <Link Id="PddRfe82YmpLJAntZEZIJs" Ids="HvF1OAemxcHQQZqoPRCDKF,ShGeOqZ3xSXO3Prp5tzd6z" />
                 <Pin Id="STqS8ayIyL6OJstNdS4o7G" Name="Input" Kind="InputPin" />
                 <Pin Id="E5FMGQDvni2QbRLZXBJ5pd" Name="Slot" Kind="InputPin" />
-                <Pin Id="MpBxbF2kag5NoinbRt0wrF" Name="Value" Kind="InputPin" />
+                <Pin Id="MpBxbF2kag5NoinbRt0wrF" Name="Value" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
                 <Pin Id="HWaLZvOOpFZOtYOfMsEy0f" Name="Output" Kind="OutputPin" />
               </Patch>
             </Node>
@@ -7128,7 +7169,11 @@
                 <Link Id="TLHpV9viiDFMYGmddDxp5k" Ids="PS5nZjQCiaoPSH1qLN8mYl,FDBdCdBUaInOea3kddGk5S" IsHidden="true" />
                 <Link Id="PfzFAzpiISqLnFaM2lflFa" Ids="FuG6R9GMDOzQMDzGWVWG5n,PS5nZjQCiaoPSH1qLN8mYl" />
                 <Pin Id="CxksAjtQh5BL2kzdR8E3N5" Name="Input" Kind="InputPin" />
-                <Pin Id="KpSoc2STJ3NO6kteKgbUIg" Name="Value" Kind="InputPin" />
+                <Pin Id="KpSoc2STJ3NO6kteKgbUIg" Name="Value" Kind="InputPin">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
                 <Pin Id="FDBdCdBUaInOea3kddGk5S" Name="Output" Kind="OutputPin" />
               </Patch>
             </Node>
@@ -7294,6 +7339,23 @@
                     <Choice Kind="OperationNode" Name="StateKeys" />
                   </p:NodeReference>
                   <Pin Id="RysVQuF2WOmLqvw1MyDCaF" Name="Colors SpreadRGBA" Kind="OutputPin" />
+                  <Pin Id="Ecb5uCNGOblPwVbyxTyZaa" Name="Value Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="JN1VA9sB09UPukD5hpaQF2" Name="Radius Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="QuykJ39wkQgOni3z77VicW" Name="Speed Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="Hc87n6ncmllP7Dewx4FZuR" Name="Duration Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="GhVJ02unKsKOoG0CvcTjOb" Name="Rotation Vector3" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="R33b63rve3jOT1iaVtAq6R" Name="Zoom Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="MDEDmE3i4SmMS3QsFhfbOB" Name="Shake Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="NwgB94KA3pfMn9WCQ7kPqX" Name="Gobo1 Integer32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="NJr8qXmQRznMjBxmpEj40I" Name="Focus Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="F2oAv9pllyKLkdhZsVT1s1" Name="GoboRotate Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="IJObxgD5RYPPYurBh4j7Pj" Name="Iris Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="T4QeT2JzunsLZQUBa81Quf" Name="Gobo Integer32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="DyDFGLuAuY4P1yJyjTA7Xb" Name="Prism Integer32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="CKrYhoxysUBPBJgP7HsuIa" Name="PrismRotate Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="MlmVZYkmcMbPQYeHN1RBpU" Name="ColorWheel Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="DXj7rAjEGDhNAfAQLtHI4f" Name="Frost Float32" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="NNHo5eK6J9OQZ15EjtuWAn" Name="Operations Spread Delegate 0-&gt;0" Kind="OutputPin" IsHidden="true" />
                 </Node>
                 <ControlPoint Id="N4tRh5PkIXmN1TpIlmP55o" Bounds="535,-2413" />
                 <Link Id="IJ3JufSyLJ8P4TovOIrynL" Ids="N4tRh5PkIXmN1TpIlmP55o,LO78l4mDq6PM92IQehv6X7" />

--- a/Main/vl/Plugins/ArtNetOutput/Schema.Plugins.ArtNetOutput.vl
+++ b/Main/vl/Plugins/ArtNetOutput/Schema.Plugins.ArtNetOutput.vl
@@ -726,7 +726,7 @@
             </p:NodeReference>
             <Patch Id="Ub1CD4FctacLUDwo8U0iY8">
               <Canvas Id="MhG9BqhWOp7LxT3Zf2pSli" CanvasType="Group">
-                <Node Bounds="106,74,44,19" Id="Id4Ch34KZJrNfuu0sdeeT4">
+                <Node Bounds="20,60,44,19" Id="Id4Ch34KZJrNfuu0sdeeT4">
                   <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -735,7 +735,7 @@
                   <Pin Id="CdDprrJU3GjPaJ0vyfP7h7" Name="Input" Kind="StateInputPin" />
                   <Pin Id="QMDqkc9bj22Ov9y2BAsuBF" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="150,147,25,19" Id="PzSFBVquqeJLi4RZBddzsK">
+                <Node Bounds="20,130,25,19" Id="PzSFBVquqeJLi4RZBddzsK">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="/" />
@@ -744,12 +744,12 @@
                   <Pin Id="TWqOZtqXcJaOOo7EsBFvY9" Name="Input 2" Kind="InputPin" />
                   <Pin Id="PTJaaiFMGlHL6bOSjgK7OQ" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Pad Id="PKNxSJrdCryOem6NKG1Ds3" Comment="" Bounds="187,84,35,15" ShowValueBox="true" isIOBox="true" Value="512">
+                <Pad Id="PKNxSJrdCryOem6NKG1Ds3" Comment="" Bounds="466,51,35,15" ShowValueBox="true" isIOBox="true" Value="512">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="106,120,62,19" Id="AdXbcixM4i7QGEgW9Ma9iN">
+                <Node Bounds="20,100,62,19" Id="AdXbcixM4i7QGEgW9Ma9iN">
                   <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToFloat32" />
@@ -757,7 +757,7 @@
                   <Pin Id="SFFOyXI2kNgOep2IH0aVhH" Name="Input" Kind="InputPin" />
                   <Pin Id="D39ok7ym0tHODrmTSZLgAO" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="150,175,34,19" Id="Ix6f0QgZeIqOdSldGW42il">
+                <Node Bounds="20,160,34,19" Id="Ix6f0QgZeIqOdSldGW42il">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Ceil" />
@@ -765,7 +765,7 @@
                   <Pin Id="EPcPADeXA5qP8b9BweoDvn" Name="Input" Kind="InputPin" />
                   <Pin Id="NfB0JF1KiZRPKC72ypcSDF" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="150,193,230,265" Id="AzdeDB6FxizMYRUGEagp8c">
+                <Node Bounds="45,193,612,334" Id="AzdeDB6FxizMYRUGEagp8c">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -773,18 +773,17 @@
                   </p:NodeReference>
                   <Pin Id="OAfZ8GuHvdiOO1wUCalCQJ" Name="Iteration Count" Kind="InputPin" />
                   <Pin Id="CyPobgxa53TNlA0ECOUSMo" Name="Break" Kind="OutputPin" />
-                  <ControlPoint Id="AgE6Vh69SI9P65MlSFlYG3" Bounds="164,452" Alignment="Bottom" />
-                  <ControlPoint Id="BNi0wXb5QUnO0vXPyD9VLx" Bounds="319,452" Alignment="Bottom" />
-                  <ControlPoint Id="CqWCvWpOJc7NEBzo1J1I9E" Bounds="284,452" Alignment="Bottom" />
-                  <ControlPoint Id="H3j1aiVtzw5N5BLA3j1IEO" Bounds="257,452" Alignment="Bottom" />
+                  <ControlPoint Id="BNi0wXb5QUnO0vXPyD9VLx" Bounds="198,521" Name="Universes" Alignment="Bottom" />
+                  <ControlPoint Id="CqWCvWpOJc7NEBzo1J1I9E" Bounds="316,521" Name="Universe Start Channels" Alignment="Bottom" />
+                  <ControlPoint Id="H3j1aiVtzw5N5BLA3j1IEO" Bounds="548,521" Name="Channel Values" Alignment="Bottom" />
                   <Patch Id="DihBuYd23qYNA08n9RxK7w" ManuallySortedPins="true">
                     <Patch Id="ExvGhvfDr3KQS3RTk2WHgE" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="KfToBQetHKPOqXb2H9b6qa" Name="Update" ManuallySortedPins="true">
                       <Pin Id="NXYxOMntfVqOXQI8t2np5V" Name="Index" Kind="InputPin" />
                     </Patch>
                     <Patch Id="JbtsyIWcungLWSzg1ax07O" Name="Dispose" ManuallySortedPins="true" />
-                    <ControlPoint Id="FbKe5nxwI6zNvZSTbYwnlF" Bounds="168,249" />
-                    <Node Bounds="188,278,25,19" Id="Mus1HujzAyQPbIEzmhNv8d">
+                    <ControlPoint Id="FbKe5nxwI6zNvZSTbYwnlF" Bounds="123,211" />
+                    <Node Bounds="101,260,25,19" Id="Mus1HujzAyQPbIEzmhNv8d">
                       <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="+" />
@@ -793,26 +792,7 @@
                       <Pin Id="MDXV48LIdaUMjKLGfQfMdz" Name="Input 2" Kind="InputPin" />
                       <Pin Id="AiGz8N4KbkPOusnVB6tG9Y" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="162,419,105,19" Id="TQEFGVWBFvZNRpQqAkwvvB">
-                      <p:NodeReference LastCategoryFullName="IO.ArtNet" LastDependency="VL.IO.ArtNet.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="Category" Name="ArtNet" />
-                        <Choice Kind="ProcessAppFlag" Name="ArtNet (Sender)" />
-                      </p:NodeReference>
-                      <Pin Id="R4e9cX7wUltNiVnO7Nobes" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                      <Pin Id="NNDj6elzx8LPZ4ZCRmP3dn" Name="Remote Host" Kind="InputPin" DefaultValue="192.168.0.99">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="String" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="OJIvE4BQAViOB15gSDYaPV" Name="Remote Port" Kind="InputPin" />
-                      <Pin Id="IyhiFalzFOfL85U1buU65q" Name="Value" Kind="InputPin" />
-                      <Pin Id="MQnbpzR3CGRO8rUkp3vQmN" Name="Universe" Kind="InputPin" />
-                      <Pin Id="RE8b1BEj6GhQVIGf30ep6C" Name="Send" Kind="InputPin" />
-                      <Pin Id="JlNiO5CAmVgOCzX4ZQwRMQ" Name="Enabled" Kind="InputPin" />
-                      <Pin Id="Kf8BdXXyhtkOYb5NtCpDQH" Name="Is Open" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="230,301,87,84" Id="TZHbmIUTWJXPKmiNa5PD0c">
+                    <Node Bounds="444,334,201,102" Id="TZHbmIUTWJXPKmiNa5PD0c">
                       <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <CategoryReference Kind="Category" Name="Primitive" />
@@ -822,21 +802,29 @@
                       <Patch Id="L4bQyKGnqmIO8dsS5lk393" ManuallySortedPins="true">
                         <Patch Id="DkJJDlBR5h7NTHOJinlft0" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="OXSECu9MjfKQSCj1k5E6Y0" Name="Then" ManuallySortedPins="true" />
-                        <Node Bounds="242,332,63,26" Id="SjQd7Y4W03VMwQY6uFnUmI">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                        <Node Bounds="456,390,95,26" Id="URIpcu0065xOP13VuG2iyu">
+                          <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArraySegment" LastDependency="VL.CoreLib.vl" OverloadStrategy="AllPinsThatAreNotCommon">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GetSpread" />
+                            <FullNameCategoryReference ID="Collections.Mutable.MutableArraySegment" />
+                            <Choice Kind="OperationCallFlag" Name="Slice" />
+                            <PinReference Kind="InputPin" Name="Count" />
                           </p:NodeReference>
-                          <Pin Id="JlKaKsfVymGN3ZGObrVf8m" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="Hrcxp9iliTJQZ5mOlcpYgA" Name="Index" Kind="InputPin" />
-                          <Pin Id="Ot8kjUUoyeBK9zjLSqlGOu" Name="Count" Kind="InputPin" DefaultValue="512" />
-                          <Pin Id="DQXYv5GbTwvLTVVEmqmKw3" Name="Output" Kind="StateOutputPin" />
+                          <Pin Id="EfPYRAckvn4OPm2IHb4ug4" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="QY75UmeIZKVLeL8kSBrMFj" Name="Index" Kind="InputPin" />
+                          <Pin Id="MtItl7lbv4nLBacE74n1ga" Name="Count" Kind="InputPin" />
+                          <Pin Id="NOPxw67XNPyLBacP1n9Ujy" Name="Output" Kind="StateOutputPin" />
+                          <Pin Id="TCMmJKMmQB0MC3UdOv5qT1" Name="Result" Kind="OutputPin" />
                         </Node>
+                        <Pad Id="BXYQUCzBZ91MMHUm8ufKiT" Comment="Count" Bounds="548,370,35,15" ShowValueBox="true" isIOBox="true" Value="512">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="TypeFlag" Name="Integer32" />
+                          </p:TypeAnnotation>
+                        </Pad>
                       </Patch>
-                      <ControlPoint Id="DQ0MCmFxoAlPoCBzaafCTN" Bounds="244,307" Alignment="Top" />
-                      <ControlPoint Id="Fk74Ye3bVAhMKHQyv8s2jb" Bounds="244,379" Alignment="Bottom" />
+                      <ControlPoint Id="GlWLn1RQGcxMJd0Z9E2gCp" Bounds="548,430" Alignment="Bottom" />
+                      <ControlPoint Id="MtiUjsbxizFQGPLHZIILkT" Bounds="458,340" Alignment="Top" />
                     </Node>
-                    <Node Bounds="295,216,25,19" Id="VSvdk7fejr5OWgMaT7cOWN">
+                    <Node Bounds="314,240,25,19" Id="VSvdk7fejr5OWgMaT7cOWN">
                       <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
@@ -846,25 +834,7 @@
                       <Pin Id="RAv4AZxqGroOHJgsZTZwvx" Name="Input 2" Kind="InputPin" />
                       <Pin Id="Tow8Y8niH23ORYSQlUeWwv" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="302,248,25,19" Id="VkjHTZKOYW8Oz41W2U3noH">
-                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="-" />
-                      </p:NodeReference>
-                      <Pin Id="SqooZ3cKfIPNWp4vzeRPYE" Name="Input" Kind="InputPin" />
-                      <Pin Id="GjoCrsLZvWQOoJkXeST8lj" Name="Input 2" Kind="InputPin" DefaultValue="0" />
-                      <Pin Id="PbfRpH6XTqHN6U4gsNzUlF" Name="Output" Kind="OutputPin" />
-                    </Node>
-                    <Pad Id="ONgF6AI2yCvOkBxM9Rwti9" Bounds="326,254,35,19" ShowValueBox="true" isIOBox="true" Value="???">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
-                      </p:TypeAnnotation>
-                      <p:ValueBoxSettings>
-                        <p:fontsize p:Type="Int32">9</p:fontsize>
-                        <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-                      </p:ValueBoxSettings>
-                    </Pad>
-                    <Node Bounds="302,275,35,19" Id="CenQbLRdYioNr4986UqqKD">
+                    <Node Bounds="314,265,35,19" Id="CenQbLRdYioNr4986UqqKD">
                       <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Max" />
@@ -872,6 +842,20 @@
                       <Pin Id="SgUu3jN8W8QLBliX75cCq2" Name="Input" Kind="InputPin" />
                       <Pin Id="EErshVJyucvOMiQJjJzLoT" Name="Input 2" Kind="InputPin" />
                       <Pin Id="Ij2BCgdZjHEPABSsKu1jMa" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="57,480,65,26" Id="ODAx1HdI89iPLZ7eRtVcLB">
+                      <p:NodeReference LastCategoryFullName="IO.ArtNet.ArtNet" LastDependency="VL.IO.ArtNet.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="ArtNet" />
+                        <Choice Kind="OperationCallFlag" Name="Send" />
+                      </p:NodeReference>
+                      <Pin Id="TkRh9rTqmvLM1jvjeX0KOu" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="QeMhlXAjrwuOLegQJ2JS4N" Name="Data" Kind="InputPin" />
+                      <Pin Id="T2f2Uj5B2iQMHb0sT9VOqj" Name="Universe" Kind="InputPin" />
+                      <Pin Id="DW4IXKA16fEPWV4GrPAO67" Name="Remote Host" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="Tm7r7XdABAUONmWmc3yQFd" Name="Remote Port" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="RuuDAzWFtd9OoIjMxOBUA2" Name="Apply" Kind="InputPin" />
+                      <Pin Id="USxVcogM8VnP49pCw1mtiB" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
                 </Node>
@@ -881,8 +865,8 @@
                 <ControlPoint Id="Ew4bSCr1ZpyNc4IxndNJzY" Bounds="275,30" />
                 <ControlPoint Id="R6SZCtnUJMSMnH180gu8Zs" Bounds="346,30" />
                 <ControlPoint Id="DqbAutIdLnyLBWREAYivqy" Bounds="400,30" />
-                <ControlPoint Id="KMqioJt7IaHQaglylM3mUM" Bounds="164,492" />
-                <Node Bounds="234,173,25,19" Id="PYaCBObOrDmQZ4G70BSzjT">
+                <ControlPoint Id="KMqioJt7IaHQaglylM3mUM" Bounds="22,580" />
+                <Node Bounds="444,90,25,19" Id="PYaCBObOrDmQZ4G70BSzjT">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -891,13 +875,45 @@
                   <Pin Id="MlOjtgDyeKIO6U717u8avo" Name="Input 2" Kind="InputPin" />
                   <Pin Id="UjHe87Bx56zNE7Aq8CqiSx" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="FT2xWhyrtDwLP2nznG92Zs" Comment="Universes" Bounds="235,587,35,80" ShowValueBox="true" isIOBox="true" Value="0" />
-                <Pad Id="IH5i3Grqwl2OZDH3hGA9mx" Comment="Universe Start Channel" Bounds="338,587,35,80" ShowValueBox="true" isIOBox="true" Value="0" />
-                <Pad Id="JzFO87klJ3gO0ORlR0cuhi" Comment="" Bounds="550,438,643,391" ShowValueBox="true" isIOBox="true">
+                <Pad Id="FT2xWhyrtDwLP2nznG92Zs" Comment="Universes" Bounds="198,590,35,80" ShowValueBox="true" isIOBox="true" Value="0" />
+                <Pad Id="IH5i3Grqwl2OZDH3hGA9mx" Comment="Universe Start Channel" Bounds="316,590,35,80" ShowValueBox="true" isIOBox="true" Value="0" />
+                <Pad Id="JzFO87klJ3gO0ORlR0cuhi" Comment="" Bounds="548,591,643,391" ShowValueBox="true" isIOBox="true">
                   <p:Value>
                     <Item></Item>
                   </p:Value>
                 </Pad>
+                <Node Bounds="57,160,46,19" Id="UmYTEii31HhMRGY1uKBvCJ">
+                  <p:NodeReference LastCategoryFullName="IO.ArtNet" LastDependency="VL.IO.ArtNet.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="ArtNet" />
+                  </p:NodeReference>
+                  <Pin Id="KoiKg9kK7MoMzl8YdQJhlg" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="J4o4O7MnZ6pMnihbRMss5B" Name="Local Address" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="Vb1B0c4Psz0P2JhSZZELKM" Name="Local Port" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="JXv1LA4IS77PgaMcF9y2a9" Name="Remote Host" Kind="InputPin" />
+                  <Pin Id="F31MM80IYq6PpImuP9HpOI" Name="Remote Port" Kind="InputPin" />
+                  <Pin Id="OjJk3C54N0qOh2uXQU0vuy" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="H6QF3ukUozmOOAJHWhK2uz" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="Uo3IjAWsZyJPFC5FjxHGIy" Name="Data" Kind="OutputPin" />
+                  <Pin Id="VplhrU1ryDHMxroshwPQ5L" Name="Is Open" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="487,96,91,26" Id="NNdfshYtyEKOxolFAGt1mM">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="GetInternalArray" />
+                  </p:NodeReference>
+                  <Pin Id="NVl4h3LSxhGQI7Pb45dmHC" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="BOoqbqqL2CyMBd70kbHccf" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="487,140,95,26" Id="Lf0UnpjGYZ9PpE7PCwO5mT">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArraySegment" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Collections.Mutable.MutableArraySegment" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="LA5ep9krZu3PnQEwtAslpx" Name="Array" Kind="InputPin" />
+                  <Pin Id="NOs1JpXSMXNPszs3YqneH4" Name="Output" Kind="StateOutputPin" />
+                </Node>
               </Canvas>
               <ProcessDefinition Id="MPLptclY8rbPxMOD85BI2n">
                 <Fragment Id="OYL2ZZ4AWNlObgFIzTiZAv" Patch="KvmZtYb7lAhPapBak9AHVT" Enabled="true" />
@@ -909,17 +925,11 @@
               <Link Id="B7nIeGcpfS4MWooYU0P5nt" Ids="NfB0JF1KiZRPKC72ypcSDF,OAfZ8GuHvdiOO1wUCalCQJ" />
               <Link Id="AcDAzMWf4gAOyL3uqnidgB" Ids="NXYxOMntfVqOXQI8t2np5V,FbKe5nxwI6zNvZSTbYwnlF" IsHidden="true" />
               <Link Id="SrvapoEWy4iNjLmuoawCEM" Ids="GDPJcwXzzp0OT05kS6wLSR,IXirliyBM7yNsM1eB8QMBs" IsHidden="true" />
-              <Link Id="JjK8JBraRpSO96qc5Izaxe" Ids="IXirliyBM7yNsM1eB8QMBs,NNDj6elzx8LPZ4ZCRmP3dn" />
               <Link Id="VOKhQuDYD52P1mKvA9yKzr" Ids="L2vO66c5v7HLpmQRLKLj2M,Mv9JrHXLTayPn63zzEdtHL" IsHidden="true" />
-              <Link Id="RHlGde8F7mJMuIWUPCLRzW" Ids="Mv9JrHXLTayPn63zzEdtHL,OJIvE4BQAViOB15gSDYaPV" />
               <Link Id="Ei4eMS7jydlPpXvxvDtjyW" Ids="GtmfGkBiXmzPTJcBLedgly,Gc4C3hfOuzPPqr3AQL66wI" IsHidden="true" />
               <Link Id="STVNFHLfpx1N2gCv3xF9jU" Ids="O1QbbkJ40pBQYWbb9ZU6gz,Ew4bSCr1ZpyNc4IxndNJzY" IsHidden="true" />
               <Link Id="RzrWlzjiksVLTEqrhYywpQ" Ids="LwPqGuq2MFvMGz9xU68hmF,R6SZCtnUJMSMnH180gu8Zs" IsHidden="true" />
-              <Link Id="PvzT5L7ZKcJPmKWlXWBmbG" Ids="R6SZCtnUJMSMnH180gu8Zs,RE8b1BEj6GhQVIGf30ep6C" />
               <Link Id="JLxxLkn4TfJLR9Ty4p36Yg" Ids="GC3DmFjfXmkLI8d6ALNxea,DqbAutIdLnyLBWREAYivqy" IsHidden="true" />
-              <Link Id="SCMES5h21PLOPIvFVhdKXW" Ids="DqbAutIdLnyLBWREAYivqy,JlNiO5CAmVgOCzX4ZQwRMQ" />
-              <Link Id="PsB1PFqeZfWN3TZ0Q9wkcL" Ids="Kf8BdXXyhtkOYb5NtCpDQH,AgE6Vh69SI9P65MlSFlYG3" />
-              <Link Id="IIgTJT96C9gO4rB2t5DqPV" Ids="AgE6Vh69SI9P65MlSFlYG3,KMqioJt7IaHQaglylM3mUM" />
               <Link Id="GNnxenJWwOhL01q2jDTpDw" Ids="KMqioJt7IaHQaglylM3mUM,QSvc3HHqi0qPuplvW65Ran" IsHidden="true" />
               <Patch Id="KvmZtYb7lAhPapBak9AHVT" Name="Create" />
               <Patch Id="E5kK8Aw4lGCMxtNUbHC2Q7" Name="Update">
@@ -931,30 +941,38 @@
                 <Pin Id="GC3DmFjfXmkLI8d6ALNxea" Name="Enabled" Kind="InputPin" />
                 <Pin Id="QSvc3HHqi0qPuplvW65Ran" Name="Is Open" Kind="OutputPin" Bounds="160,397" />
               </Patch>
-              <Link Id="GZU1usWht4vMzrBFZl76mD" Ids="AiGz8N4KbkPOusnVB6tG9Y,MQnbpzR3CGRO8rUkp3vQmN" />
               <Link Id="PuuYob5wz9FQF7DhZsdyLs" Ids="FbKe5nxwI6zNvZSTbYwnlF,MDXV48LIdaUMjKLGfQfMdz" />
               <Link Id="AjaoJm29aH3PMgSu9kYvIp" Ids="Ew4bSCr1ZpyNc4IxndNJzY,HQlqbuz9oJ4NiOdrQEenQl" />
               <Link Id="B0SXLvzvHhaOgnSYO7dJdG" Ids="Gc4C3hfOuzPPqr3AQL66wI,CdDprrJU3GjPaJ0vyfP7h7" />
               <Link Id="L9oFjfFaUhXNIJeDjVYU9y" Ids="QMDqkc9bj22Ov9y2BAsuBF,SFFOyXI2kNgOep2IH0aVhH" />
-              <Link Id="J39ohOKwTN7P79cBPfOwo6" Ids="DQ0MCmFxoAlPoCBzaafCTN,Fk74Ye3bVAhMKHQyv8s2jb" IsFeedback="true" />
-              <Link Id="BxwQaj9GLWLMSwIYg8k0bw" Ids="DQ0MCmFxoAlPoCBzaafCTN,JlKaKsfVymGN3ZGObrVf8m" />
-              <Link Id="RNHuwXilfoCNrVsDK6ceGy" Ids="DQXYv5GbTwvLTVVEmqmKw3,Fk74Ye3bVAhMKHQyv8s2jb" />
               <Link Id="EI6uZe5ZabOOuhQXLQD6Cd" Ids="QMDqkc9bj22Ov9y2BAsuBF,VExvSYhRphZOQTylEMMPIw" />
               <Link Id="A22qB5H4swnM7Oqsp1oSQ6" Ids="PKNxSJrdCryOem6NKG1Ds3,MlOjtgDyeKIO6U717u8avo" />
-              <Link Id="T37hDhrku5NOR1TGt47IZ8" Ids="UjHe87Bx56zNE7Aq8CqiSx,TVhzGTzk6j2M5AzaTB7IvY" />
-              <Link Id="TYTwUesKG3zOM7uPU6grcV" Ids="Gc4C3hfOuzPPqr3AQL66wI,DQ0MCmFxoAlPoCBzaafCTN" />
-              <Link Id="BWwD7f90DTMMEDryGXM5jz" Ids="Fk74Ye3bVAhMKHQyv8s2jb,IyhiFalzFOfL85U1buU65q" />
               <Link Id="V8lcPu40RVHPFFrw8g3oPn" Ids="AiGz8N4KbkPOusnVB6tG9Y,BNi0wXb5QUnO0vXPyD9VLx" />
               <Link Id="CEoxFMnYHFMNeRcEZhqXWR" Ids="BNi0wXb5QUnO0vXPyD9VLx,FT2xWhyrtDwLP2nznG92Zs" />
               <Link Id="Q8NYaBLBljqNVpeVJezJ6s" Ids="FbKe5nxwI6zNvZSTbYwnlF,Kyk1OUPAo2lQOCoxGXNnIR" />
               <Link Id="KFAVtUUYTmDLGGSmBPAM8t" Ids="PKNxSJrdCryOem6NKG1Ds3,RAv4AZxqGroOHJgsZTZwvx" />
-              <Link Id="M5UPvxP9Kg5OGTUFgcrdDX" Ids="Tow8Y8niH23ORYSQlUeWwv,SqooZ3cKfIPNWp4vzeRPYE" />
               <Link Id="JO60xIGukfHOEloUFLyMFn" Ids="CqWCvWpOJc7NEBzo1J1I9E,IH5i3Grqwl2OZDH3hGA9mx" />
-              <Link Id="VWDeFo8ueucNTDdq1bhPZ0" Ids="Fk74Ye3bVAhMKHQyv8s2jb,H3j1aiVtzw5N5BLA3j1IEO" />
               <Link Id="CzAhvs3Cu7pQcPxX9RAFxD" Ids="H3j1aiVtzw5N5BLA3j1IEO,JzFO87klJ3gO0ORlR0cuhi" />
-              <Link Id="PHkkS08fFmzOlYx8beSbqZ" Ids="PbfRpH6XTqHN6U4gsNzUlF,SgUu3jN8W8QLBliX75cCq2" />
-              <Link Id="GOPMs6rW2TPMYaJQanTaZq" Ids="Ij2BCgdZjHEPABSsKu1jMa,Hrcxp9iliTJQZ5mOlcpYgA" />
               <Link Id="FQRb39o2UjUOynMuAn1vQY" Ids="Ij2BCgdZjHEPABSsKu1jMa,CqWCvWpOJc7NEBzo1J1I9E" />
+              <Link Id="QS9PQThJ4nVLkWceWrlXiU" Ids="Tow8Y8niH23ORYSQlUeWwv,SgUu3jN8W8QLBliX75cCq2" />
+              <Link Id="GZHKlEcE16DLKgTbNvAGiM" Ids="UjHe87Bx56zNE7Aq8CqiSx,TVhzGTzk6j2M5AzaTB7IvY" />
+              <Link Id="PGlBzJTSFzUOB9PGqVCnqk" Ids="IXirliyBM7yNsM1eB8QMBs,JXv1LA4IS77PgaMcF9y2a9" />
+              <Link Id="CJiFeNMNBnbO5fYLb6tRoc" Ids="DqbAutIdLnyLBWREAYivqy,OjJk3C54N0qOh2uXQU0vuy" />
+              <Link Id="KqDIvLyrCAdOeu7rxs3zSX" Ids="H6QF3ukUozmOOAJHWhK2uz,TkRh9rTqmvLM1jvjeX0KOu" />
+              <Link Id="GKcKcTAB59IN6tCg0UPPWX" Ids="Mv9JrHXLTayPn63zzEdtHL,F31MM80IYq6PpImuP9HpOI" />
+              <Link Id="LeYTRkVvBh1QGQPh14N3dH" Ids="VplhrU1ryDHMxroshwPQ5L,KMqioJt7IaHQaglylM3mUM" />
+              <Link Id="D9a9KNviergQJlQTXrELuG" Ids="AiGz8N4KbkPOusnVB6tG9Y,T2f2Uj5B2iQMHb0sT9VOqj" />
+              <Link Id="TVo45vHbNVML7LLdI15e47" Ids="BOoqbqqL2CyMBd70kbHccf,LA5ep9krZu3PnQEwtAslpx" />
+              <Link Id="U9MVgcePwpqNod7Cl2BucI" Ids="R6SZCtnUJMSMnH180gu8Zs,RuuDAzWFtd9OoIjMxOBUA2" />
+              <Link Id="Achok0TQScFMLDTmTcMGcA" Ids="Gc4C3hfOuzPPqr3AQL66wI,NVl4h3LSxhGQI7Pb45dmHC" />
+              <Link Id="Eu9aI4DvktYNyYfbXX2JbJ" Ids="Ij2BCgdZjHEPABSsKu1jMa,QY75UmeIZKVLeL8kSBrMFj" />
+              <Link Id="KrzbLr1ybh3O3bdUlRadIF" Ids="BXYQUCzBZ91MMHUm8ufKiT,MtItl7lbv4nLBacE74n1ga" />
+              <Link Id="GbDT0Chsb5lQDMyjMu495S" Ids="MtiUjsbxizFQGPLHZIILkT,GlWLn1RQGcxMJd0Z9E2gCp" IsFeedback="true" />
+              <Link Id="KwC5JKRBQ7uMRd822vHRKu" Ids="TCMmJKMmQB0MC3UdOv5qT1,GlWLn1RQGcxMJd0Z9E2gCp" />
+              <Link Id="Li0WNjgtQOoQZ6FgB5d25v" Ids="GlWLn1RQGcxMJd0Z9E2gCp,QeMhlXAjrwuOLegQJ2JS4N" />
+              <Link Id="CcNmQWpDNJ0NQuM2iz8T0f" Ids="NOs1JpXSMXNPszs3YqneH4,MtiUjsbxizFQGPLHZIILkT" />
+              <Link Id="Nl2zrzvzUkGOzmsLcCw7Qo" Ids="MtiUjsbxizFQGPLHZIILkT,EfPYRAckvn4OPm2IHb4ug4" />
+              <Link Id="KDy7KYeBeYsM0hjEgLDT9T" Ids="GlWLn1RQGcxMJd0Z9E2gCp,H3j1aiVtzw5N5BLA3j1IEO" />
             </Patch>
           </Node>
           <Pad Id="TghjspqfpbLOnbb95tdsmn" Bounds="89,53,158,19" ShowValueBox="true" isIOBox="true" Value="TODO publish separately">
@@ -966,6 +984,298 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
+          <!--
+
+    ************************ ArtNetMultiUniverseWithOffsets ************************
+
+-->
+          <Node Name="ArtNetMultiUniverseWithOffsets" Bounds="82,190" Id="N1P4IJWMEFgQXz4KYTAj5H">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+              <Choice Kind="ContainerDefinition" Name="Process" />
+            </p:NodeReference>
+            <Patch Id="VkwV6WGgIvfLZQ3I6leP8g">
+              <Canvas Id="Si9P8i2L86LLLVfi060daK" CanvasType="Group">
+                <Node Bounds="20,60,44,19" Id="NqDIBrx542mNBiQhMUZ5I9">
+                  <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Count" />
+                  </p:NodeReference>
+                  <Pin Id="OW4BsW4GVcdMvwtX15OMfu" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="N6hiDeLJbvNLjskehnF0Qp" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="20,130,25,19" Id="H0UnudFEhA7PnhElWYfvhH">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="/" />
+                  </p:NodeReference>
+                  <Pin Id="Gg1Vowk7IJWPJBSNrNgDJr" Name="Input" Kind="InputPin" />
+                  <Pin Id="PVMnQ8ELJmKQZsBnqWq32m" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="EQUzhhouklUL6eG7l9zX1W" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="MULsW59NbhTPl5NpUdwvD2" Comment="" Bounds="466,51,35,15" ShowValueBox="true" isIOBox="true" Value="512">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Integer32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="20,100,62,19" Id="ALjMq1BTM0tO4o5fJHKzhx">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToFloat32" />
+                  </p:NodeReference>
+                  <Pin Id="EPmSQWuUtZHNd4q4NsipmX" Name="Input" Kind="InputPin" />
+                  <Pin Id="He10zjGXlwRNMwTOMIEen2" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="20,160,34,19" Id="Up1wpwcTCssNE4gVLUywvZ">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Ceil" />
+                  </p:NodeReference>
+                  <Pin Id="RTwmynU01E9MExe9dZZX8j" Name="Input" Kind="InputPin" />
+                  <Pin Id="NRd9meMZuaJMYPCZ0htjAc" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="20,210,653,336" Id="Ctak6zo6bQnNraGmPhjMfP">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="Repeat" />
+                  </p:NodeReference>
+                  <Pin Id="ASbQipIUJ1UPBjJEv7E6Sc" Name="Iteration Count" Kind="InputPin" />
+                  <Pin Id="HEKmtggWzcmPLlroGzV2Xb" Name="Break" Kind="OutputPin" />
+                  <ControlPoint Id="Ky9oWjx3Q4BN6f1eBddSkG" Bounds="129,540" Name="Universes" Alignment="Bottom" />
+                  <ControlPoint Id="HKrag6LULqYN9nQFDNTFWk" Bounds="247,540" Name="Universe Start Channels" Alignment="Bottom" />
+                  <ControlPoint Id="LjZBvd0sFbwLwbrEtB1LyZ" Bounds="389,540" Name="Channel Values" Alignment="Bottom" />
+                  <Patch Id="LLnwGgQwIuCLyN5ui3ArVs" ManuallySortedPins="true">
+                    <Patch Id="EEPTWDlcC6mPi4DpgdpK6B" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="R1HOjgHJkHjM97gE7TCgyr" Name="Update" ManuallySortedPins="true">
+                      <Pin Id="PjgGnjPZBkDLrk6A2b6zMw" Name="Index" Kind="InputPin" />
+                    </Patch>
+                    <Patch Id="NpxbxYWuidPLRII19DuqAu" Name="Dispose" ManuallySortedPins="true" />
+                    <ControlPoint Id="P5tHn5RshD8QDQJOHD2iOS" Bounds="54,228" />
+                    <Node Bounds="32,277,25,19" Id="CfRwEXWreLANz41j2KuWtT">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="+" />
+                      </p:NodeReference>
+                      <Pin Id="RY2CvbhN9RvNVr4vtiyWCA" Name="Input" Kind="InputPin" />
+                      <Pin Id="PbcWbDIlrcjMex7Rw90WeV" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="PbEviLGp44nMd3w3kcKKxr" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="245,257,25,19" Id="LPIUYeKichQNgw80ieQ8gj">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="*" />
+                      </p:NodeReference>
+                      <Pin Id="REZlphdifWVMx9ME8X9Cyx" Name="Input" Kind="InputPin" />
+                      <Pin Id="Sv76AlGr65mO8UB84LByvh" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="DgLQWLgwfRGO4MMXQ1da9f" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="245,282,35,19" Id="HOmfxo10wU8LSto2NeEzBf">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Max" />
+                      </p:NodeReference>
+                      <Pin Id="DLmGQgmsjDJLoBeu8Ay8q5" Name="Input" Kind="InputPin" />
+                      <Pin Id="FI39OeMaq3fOMgO4ROPgBV" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="N4WTYE8V9BAPEqEYmfnBad" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="128,440,65,26" Id="Bqkw0tMYJ0uN6NpwTp5OV9">
+                      <p:NodeReference LastCategoryFullName="IO.ArtNet.ArtNet" LastDependency="VL.IO.ArtNet.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="ArtNet" />
+                        <Choice Kind="OperationCallFlag" Name="Send" />
+                      </p:NodeReference>
+                      <Pin Id="ND68dKXHlWlOETo0ccAA6i" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="MLyV4i2WAFpNUdTorH1tAQ" Name="Data" Kind="InputPin" />
+                      <Pin Id="UWs5Sh4MePwLuNoUN1ugIX" Name="Universe" Kind="InputPin" />
+                      <Pin Id="UGMFVKqj2F0PD9umzcafmH" Name="Remote Host" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="KONuKLocVE7QQp4RUAYTIn" Name="Remote Port" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="Sfl0PZ5Kzv4L2lPxBwQuZG" Name="Apply" Kind="InputPin" />
+                      <Pin Id="IFnTf3jMXPgPeAVPmJa0Qt" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Node Bounds="563,408,95,26" Id="H2FmqcB03cxMi5RsmJL5BQ">
+                      <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArraySegment" LastDependency="VL.CoreLib.vl" OverloadStrategy="AllPinsThatAreNotCommon">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <FullNameCategoryReference ID="Collections.Mutable.MutableArraySegment" />
+                        <Choice Kind="OperationCallFlag" Name="Slice" />
+                        <PinReference Kind="InputPin" Name="Count" />
+                      </p:NodeReference>
+                      <Pin Id="FaeWb9ZhfAoPZTXZRtsSMf" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="OELOFQdJfMiLaDoFgTjbcT" Name="Index" Kind="InputPin" />
+                      <Pin Id="Pr6nWAayrvuPkt8lbDsAR9" Name="Count" Kind="InputPin" />
+                      <Pin Id="Lko8CCFzVpKOtX1HjHT0A0" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="GpJSLtb74KEPKpy212q21e" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="520,497,25,19" Id="BJ46245REj1OBdt6Nd14Fu">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="+" />
+                      </p:NodeReference>
+                      <Pin Id="KBlFGjwPS5DNK8pPXOZe9W" Name="Input" Kind="InputPin" />
+                      <Pin Id="QEaHJNM1NklQHjtl4kPVDS" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="AiW3zLZptakPD6TEt35DTv" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="628,238,33,19" Id="GoB8LBI0WzSObcMS3Xx4HB">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Min" />
+                      </p:NodeReference>
+                      <Pin Id="U0RZ86xyXqCPwjkbj2QxDA" Name="Input" Kind="InputPin" />
+                      <Pin Id="NFziPtvJdtkQBdVeG3mOKG" Name="Input 2" Kind="InputPin" DefaultValue="1" />
+                      <Pin Id="KgoL52ZOqWlQDygfh2Mx6l" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Pad Id="CkO5wcnUy0cOGSS4lKqhFr" Bounds="420,450,223,19" ShowValueBox="true" isIOBox="true" Value="TODO break when taken all channels">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="String" />
+                      </p:TypeAnnotation>
+                      <p:ValueBoxSettings>
+                        <p:fontsize p:Type="Int32">9</p:fontsize>
+                        <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                      </p:ValueBoxSettings>
+                    </Pad>
+                  </Patch>
+                  <ControlPoint Id="Kza4QzfUMyNN2vGNhXG99H" Bounds="522,216" Name="Current Start Index" Alignment="Top" />
+                  <ControlPoint Id="Fi9LUKan8XhLB73BluEldD" Bounds="522,540" Name="Current Start Index" Alignment="Bottom" />
+                  <ControlPoint Id="N8Du8En6cboNCnNGsX8wNq" Bounds="630,216" Alignment="Top" />
+                </Node>
+                <ControlPoint Id="AjYFsTMaPEGPdXg32Ecits" Bounds="39,30" />
+                <ControlPoint Id="LfoD9IJd85dLIWck4M3isk" Bounds="130,30" />
+                <ControlPoint Id="DrkCyLbfz0MPCNwkgF2v4A" Bounds="218,30" />
+                <ControlPoint Id="Tq9q1rKoDMaO84rmvmQA9m" Bounds="275,30" />
+                <ControlPoint Id="M4J6Odq5jdBQQloEuRfEqA" Bounds="346,30" />
+                <ControlPoint Id="UvNEnTrhzF3OXN1LxBU8bC" Bounds="400,30" />
+                <ControlPoint Id="FpDgjHnPnT2Le2JERlB1CK" Bounds="34,563" />
+                <Node Bounds="444,90,25,19" Id="NRbFId1Oj1jPUeuuacmBsB">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="&gt;" />
+                  </p:NodeReference>
+                  <Pin Id="ASF9XgssnlWLk2uwWJhCiT" Name="Input" Kind="InputPin" />
+                  <Pin Id="SE2h2mGc2sGN6F33tEai3k" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="RsZzxGTlPUpNv6j54xFGid" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="OnujnsJPGBaPJhRDQBG5eW" Comment="Universes" Bounds="198,590,35,80" ShowValueBox="true" isIOBox="true" Value="0" />
+                <Pad Id="SYM4G2A6lXxPKdveyyS7w8" Comment="Universe Start Channel" Bounds="316,590,35,80" ShowValueBox="true" isIOBox="true" Value="0" />
+                <Pad Id="NJCDuEipFcYMsPjLz3pdGz" Comment="" Bounds="458,620,643,391" ShowValueBox="true" isIOBox="true">
+                  <p:Value>
+                    <Item></Item>
+                  </p:Value>
+                </Pad>
+                <Node Bounds="589,120,46,19" Id="CtDPPtsn3ysPnC6MuiqIEE">
+                  <p:NodeReference LastCategoryFullName="IO.ArtNet" LastDependency="VL.IO.ArtNet.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="ArtNet" />
+                    <Choice Kind="ProcessAppFlag" Name="ArtNet" />
+                  </p:NodeReference>
+                  <Pin Id="Cbt81YiyJidOia8taYReVv" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="DgzpcWBuKb1QP7XeVSUtA4" Name="Local Address" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="RCLXmGPjNACPZQZ3xrqoBD" Name="Local Port" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="Ij9YHIUC0z1MejEILOGDRc" Name="Remote Host" Kind="InputPin" />
+                  <Pin Id="ChMQfoY0EOsN5pqxlUk8Ui" Name="Remote Port" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="BoI2jBRGf29LQUNavSSxCG" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="Gpdqhs1LKitMY4vtAhnAgt" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="JXiZXsuyaYAPt0dut4UdtP" Name="Data" Kind="OutputPin" />
+                  <Pin Id="A22UcBQwjzEOD1KlYWi4NO" Name="Is Open" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="728,140,91,26" Id="PPRLUZEbhk9LZgUVeBJRSj">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="GetInternalArray" />
+                  </p:NodeReference>
+                  <Pin Id="LYbFg6db3h9MRHAM3fc3wn" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="GQ7Gt76EMbrNCXG7TtifWx" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="728,184,95,26" Id="D1gvRWI9NrVNtjDJMeWsET">
+                  <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArraySegment" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Collections.Mutable.MutableArraySegment" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="F17Xjc50CCYNrkfw9C9v4Z" Name="Array" Kind="InputPin" />
+                  <Pin Id="SRlFsg4CJqEOD443vtILsE" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="PIlWXVEhq2vMINKlaLvTPg" Bounds="699,60,35,34" ShowValueBox="true" isIOBox="true" Value="512">
+                  <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Spread" />
+                    <p:TypeArguments>
+                      <TypeReference>
+                        <Choice Kind="TypeFlag" Name="Integer32" />
+                      </TypeReference>
+                    </p:TypeArguments>
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="EJKxMQMJ87YPP8QJE3IcDa" Bounds="112,150,167,19" ShowValueBox="true" isIOBox="true" Value="TODO repeat enough times">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                  <p:ValueBoxSettings>
+                    <p:fontsize p:Type="Int32">9</p:fontsize>
+                    <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                  </p:ValueBoxSettings>
+                </Pad>
+              </Canvas>
+              <ProcessDefinition Id="VXT81wOv1oWPH8yKKFZx5h">
+                <Fragment Id="ErwM4u6DtohNY06DndnKVK" Patch="OCIktTz3O8qMi0qhoxhf2B" Enabled="true" />
+                <Fragment Id="HGalBh6CjKkPssdhpYIbFF" Patch="BgwS3MgVaVqMo6kJsm2H9c" Enabled="true" />
+              </ProcessDefinition>
+              <Link Id="NRtQbtHVm0qMmDbxwPXcmG" Ids="MULsW59NbhTPl5NpUdwvD2,PVMnQ8ELJmKQZsBnqWq32m" />
+              <Link Id="FEo2ERBT7MUOwbj2DQ7sgk" Ids="He10zjGXlwRNMwTOMIEen2,Gg1Vowk7IJWPJBSNrNgDJr" />
+              <Link Id="NkmtzNoHLdyLHrYcsBQZIC" Ids="EQUzhhouklUL6eG7l9zX1W,RTwmynU01E9MExe9dZZX8j" />
+              <Link Id="IMBIKgE2FM8NjGROtHoWL0" Ids="NRd9meMZuaJMYPCZ0htjAc,ASbQipIUJ1UPBjJEv7E6Sc" />
+              <Link Id="KHH25bpfJoBO7jkPEqNkP8" Ids="PjgGnjPZBkDLrk6A2b6zMw,P5tHn5RshD8QDQJOHD2iOS" IsHidden="true" />
+              <Link Id="EHXE1YSpEdhK9ySfPzOTLW" Ids="TYlj16oJZuBNqlOuTYsKVe,AjYFsTMaPEGPdXg32Ecits" IsHidden="true" />
+              <Link Id="HLkQVictdzkPXMjpU3j89X" Ids="R5ejzGwMfGzMjAII7BwiS3,LfoD9IJd85dLIWck4M3isk" IsHidden="true" />
+              <Link Id="HqMurkQnMhZN3dGw1IZgFR" Ids="UONcyr0Gbr9N28qbcuMyQV,DrkCyLbfz0MPCNwkgF2v4A" IsHidden="true" />
+              <Link Id="Dyucc7RyEZENoOYU9kv7Ih" Ids="O5ALwcWyzbcLHwMkQnes5N,Tq9q1rKoDMaO84rmvmQA9m" IsHidden="true" />
+              <Link Id="KJvSDbkeSFUNZ9QXiDr0Fu" Ids="IFWdLKsbSRBLH0EBQWOdX3,M4J6Odq5jdBQQloEuRfEqA" IsHidden="true" />
+              <Link Id="OkXMOyNepvgN1Av8vZyb2p" Ids="Ra55X8Jx9OpK9wmXiQaDHw,UvNEnTrhzF3OXN1LxBU8bC" IsHidden="true" />
+              <Link Id="TuaxzRt5nnLLKrLtJZoNI0" Ids="FpDgjHnPnT2Le2JERlB1CK,GO3GMTqBODWLXatqfl5Q5a" IsHidden="true" />
+              <Patch Id="OCIktTz3O8qMi0qhoxhf2B" Name="Create" />
+              <Patch Id="BgwS3MgVaVqMo6kJsm2H9c" Name="Update">
+                <Pin Id="TYlj16oJZuBNqlOuTYsKVe" Name="Remote Host" Kind="InputPin" />
+                <Pin Id="R5ejzGwMfGzMjAII7BwiS3" Name="Remote Port" Kind="InputPin" />
+                <Pin Id="UONcyr0Gbr9N28qbcuMyQV" Name="Value" Kind="InputPin" />
+                <Pin Id="O5ALwcWyzbcLHwMkQnes5N" Name="Universe" Kind="InputPin" />
+                <Pin Id="IFWdLKsbSRBLH0EBQWOdX3" Name="Send" Kind="InputPin" />
+                <Pin Id="Ra55X8Jx9OpK9wmXiQaDHw" Name="Enabled" Kind="InputPin" />
+                <Pin Id="GO3GMTqBODWLXatqfl5Q5a" Name="Is Open" Kind="OutputPin" Bounds="160,397" />
+              </Patch>
+              <Link Id="MJgbcdbyr0BM1dKMHd8qYJ" Ids="P5tHn5RshD8QDQJOHD2iOS,PbcWbDIlrcjMex7Rw90WeV" />
+              <Link Id="VcHW3oeSOUnQHiGrxjELvx" Ids="Tq9q1rKoDMaO84rmvmQA9m,RY2CvbhN9RvNVr4vtiyWCA" />
+              <Link Id="EmlPGvkZlRBPfTzV6Qm5wn" Ids="DrkCyLbfz0MPCNwkgF2v4A,OW4BsW4GVcdMvwtX15OMfu" />
+              <Link Id="Tn9JcqL4prRLU7WlBjfT7w" Ids="N6hiDeLJbvNLjskehnF0Qp,EPmSQWuUtZHNd4q4NsipmX" />
+              <Link Id="UIr2c4qt1RhLQuP5D1fOvB" Ids="N6hiDeLJbvNLjskehnF0Qp,ASF9XgssnlWLk2uwWJhCiT" />
+              <Link Id="TMbWwUC2ecSMS3jc9qPPUo" Ids="MULsW59NbhTPl5NpUdwvD2,SE2h2mGc2sGN6F33tEai3k" />
+              <Link Id="LFdDq5Lo0t7Oe7e8Mmjti0" Ids="PbEviLGp44nMd3w3kcKKxr,Ky9oWjx3Q4BN6f1eBddSkG" />
+              <Link Id="Af6XFZM4nMeNyg3DXfjWBZ" Ids="Ky9oWjx3Q4BN6f1eBddSkG,OnujnsJPGBaPJhRDQBG5eW" />
+              <Link Id="AlUSZVpDmGpOU9o0qYodzA" Ids="P5tHn5RshD8QDQJOHD2iOS,REZlphdifWVMx9ME8X9Cyx" />
+              <Link Id="QJTtGtLVtI8LKQQRceOAB6" Ids="MULsW59NbhTPl5NpUdwvD2,Sv76AlGr65mO8UB84LByvh" />
+              <Link Id="Tq24Hjq2SoGPS0OZu7FVtH" Ids="HKrag6LULqYN9nQFDNTFWk,SYM4G2A6lXxPKdveyyS7w8" />
+              <Link Id="BlTfTLvOR4QNzl13DPj4qy" Ids="LjZBvd0sFbwLwbrEtB1LyZ,NJCDuEipFcYMsPjLz3pdGz" />
+              <Link Id="QMGQaKjP6WSMIpk2qXHZrq" Ids="DgLQWLgwfRGO4MMXQ1da9f,DLmGQgmsjDJLoBeu8Ay8q5" />
+              <Link Id="RolXGYSyi6nN6IpfH2vrZ9" Ids="AjYFsTMaPEGPdXg32Ecits,Ij9YHIUC0z1MejEILOGDRc" />
+              <Link Id="SGQgwIDvKFxOe811lrx0ZT" Ids="UvNEnTrhzF3OXN1LxBU8bC,BoI2jBRGf29LQUNavSSxCG" />
+              <Link Id="Sy9kDC0uHgeOC8GNDJpvWD" Ids="Gpdqhs1LKitMY4vtAhnAgt,ND68dKXHlWlOETo0ccAA6i" />
+              <Link Id="GvTMdsVinK7LrBvCEHUxd5" Ids="GQ7Gt76EMbrNCXG7TtifWx,F17Xjc50CCYNrkfw9C9v4Z" />
+              <Link Id="U29Dwoi9zX2LRoVJ1JxkqJ" Ids="SRlFsg4CJqEOD443vtILsE,FaeWb9ZhfAoPZTXZRtsSMf" />
+              <Link Id="EHxiflvNRNvLmdZpUHWNP3" Ids="DrkCyLbfz0MPCNwkgF2v4A,LYbFg6db3h9MRHAM3fc3wn" />
+              <Link Id="Na5DpG6Wg5DOTgTPbM96I9" Ids="Kza4QzfUMyNN2vGNhXG99H,Fi9LUKan8XhLB73BluEldD" IsFeedback="true" />
+              <Link Id="ExyaPCrayyJPBOBbwED8Ju" Ids="Kza4QzfUMyNN2vGNhXG99H,KBlFGjwPS5DNK8pPXOZe9W" />
+              <Link Id="H6BcnOvHr9dPsWdCpiYIRu" Ids="PIlWXVEhq2vMINKlaLvTPg,N8Du8En6cboNCnNGsX8wNq" />
+              <Link Id="JSy5c7dqQioPpNSdo5Xxo5" Ids="AiW3zLZptakPD6TEt35DTv,Fi9LUKan8XhLB73BluEldD" />
+              <Link Id="NKoEu1umwcrMF7On51LLkx" Ids="N8Du8En6cboNCnNGsX8wNq,U0RZ86xyXqCPwjkbj2QxDA" />
+              <Link Id="OzkGgxvnntnNAj3LUdHZ7j" Ids="KgoL52ZOqWlQDygfh2Mx6l,QEaHJNM1NklQHjtl4kPVDS" />
+              <Link Id="BlRDvPDPIlbL9YeByW0Y3z" Ids="Kza4QzfUMyNN2vGNhXG99H,OELOFQdJfMiLaDoFgTjbcT" />
+              <Link Id="Imfsh8P4UhHOYhLCA6iAwz" Ids="KgoL52ZOqWlQDygfh2Mx6l,Pr6nWAayrvuPkt8lbDsAR9" />
+              <Link Id="Ss432ZFfjrYNBh0hD1X5qX" Ids="GpJSLtb74KEPKpy212q21e,MLyV4i2WAFpNUdTorH1tAQ" />
+              <Link Id="MnFS6xFB20yM4xQLFiTCd8" Ids="UvNEnTrhzF3OXN1LxBU8bC,Sfl0PZ5Kzv4L2lPxBwQuZG" />
+              <Link Id="KibtXgxwUJAL6G4RIXS4TE" Ids="PbEviLGp44nMd3w3kcKKxr,UWs5Sh4MePwLuNoUN1ugIX" />
+              <Link Id="D1CtCqjenPGMB6HsKr4rn6" Ids="Kza4QzfUMyNN2vGNhXG99H,HKrag6LULqYN9nQFDNTFWk" />
+              <Link Id="PjK589wdY9jMCJNf81XGr7" Ids="GpJSLtb74KEPKpy212q21e,LjZBvd0sFbwLwbrEtB1LyZ" />
+              <Link Id="Szy1aGUZC8FOr1NLL2onar" Ids="A22UcBQwjzEOD1KlYWi4NO,FpDgjHnPnT2Le2JERlB1CK" />
+            </Patch>
+          </Node>
         </Canvas>
       </Canvas>
       <Canvas Id="CwingQD1aw5LzoN5nZU4L4" Name="Tests" Position="393,343">

--- a/Main/vl/Plugins/ArtNetOutput/Schema.Plugins.ArtNetOutput.vl
+++ b/Main/vl/Plugins/ArtNetOutput/Schema.Plugins.ArtNetOutput.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="CNc0glbSb7RQBeL7GQ8HbV" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="CNc0glbSb7RQBeL7GQ8HbV" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Eny9LQLNx9uLh7Foc0vhnV">
     <Canvas Id="RzIPJGd57R3QRCbNzjSDjn" DefaultCategory="Schema.Plugins.ArtNetOutput" CanvasType="FullCategory">
       <!--
@@ -246,6 +246,7 @@
                 <Pin Id="S5DiOL6lcZ2P1bnzMdOGRr" Name="Universe Count" Kind="InputPin" />
                 <Pin Id="VhS51MC3EbHNhnLTmb19N8" Name="Split" Kind="ApplyPin" />
                 <Pin Id="IDYiOwCptuZLSshtPwsiUJ" Name="Reload" Kind="ApplyPin" />
+                <Pin Id="Tp1enIAUhXLOnR3V7tTWzB" Name="State Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="AmuZqic5cyKLp95JsAyAMt" Name="Output" Kind="OutputPin" />
                 <Pin Id="QIfwIfZn6xEQWURtOUUwB2" Name="Supported Models" Kind="OutputPin" />
                 <Pin Id="B4f4nrJw21mL9c0rTfE5xw" Name="Status" Kind="OutputPin" />
@@ -507,6 +508,7 @@
                     <Pin Id="AzXriLZBseuPgTyyvyH6s2" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="LZ5InOwCG2oPWlyE6RjuMG" Name="Messages" Kind="InputPin" />
                     <Pin Id="CzyD02wxtJpLm9uOCt3XBx" Name="Reset" Kind="InputPin" />
+                    <Pin Id="OHvKhzfWoKgMKJlqf5vLPO" Name="Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="TxFN3lISa3CO9IIiZh6cO7" Name="Result" Kind="OutputPin" />
                     <Patch Id="I5NHtM0FuqGNLQkq6PAXUZ" ManuallySortedPins="true">
                       <Patch Id="HJmEDIWBY9NMltRS2hThkP" Name="Create" ManuallySortedPins="true" />
@@ -1205,7 +1207,6 @@
     </Node>
   </Patch>
   <DocumentDependency Id="SMtEvYqQ0XBNcOrpsTh0oI" Location="../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="ULkdtBZTTq5PNxOQrRYqVY" Location="ncalc" Version="1.3.8" />
   <DocumentDependency Id="Hhe6QFox9lIOM4DkseNEL1" Location="../DMXOutput/Schema.Plugins.DMXOutput.vl" />
-  <NugetDependency Id="Th4Wrbgb75JOkqjNFFufWF" Location="VL.IO.ArtNet" Version="1.0.2" />
+  <NugetDependency Id="Th4Wrbgb75JOkqjNFFufWF" Location="VL.IO.ArtNet" Version="2.1.2" />
 </Document>

--- a/Main/vl/Plugins/DMXOutput/Schema.Plugins.DMXOutput.vl
+++ b/Main/vl/Plugins/DMXOutput/Schema.Plugins.DMXOutput.vl
@@ -3379,7 +3379,7 @@
                 <Pin Id="HXn6uEMsbaqMN6DVPiE1Q6" Name="Result" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="AFx7aPY5epHPbLCxZorFnv" Bounds="321,28" />
-              <Node Bounds="388,218,142,153" Id="FjWLZG3GSsdMPcEc7JPS6Y">
+              <Node Bounds="388,207,148,164" Id="FjWLZG3GSsdMPcEc7JPS6Y">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -3390,18 +3390,17 @@
                   <Patch Id="L7H1WHuZqWYPVl8o1ro5Kt" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Ot1EZJulLJYQYMIKahvjoB" Name="Update" ManuallySortedPins="true" />
                   <Patch Id="L7OtumwW5oeLWhoK6LiMSJ" Name="Dispose" ManuallySortedPins="true" />
-                  <Node Bounds="404,250,75,22" Id="N0TggRgGYVbLBDI1gDHL1f">
-                    <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
+                  <Node Bounds="404,230,120,26" Id="N0TggRgGYVbLBDI1gDHL1f">
+                    <p:NodeReference LastCategoryFullName="NCalc.ExpressionBase`1" LastDependency="NCalc.Core.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                      <CategoryReference Kind="AssemblyCategory" Name="NCalc" />
-                      <CategoryReference Kind="AssemblyCategory" Name="Expression" />
+                      <CategoryReference Kind="AssemblyCategory" Name="ExpressionBase`1" NeedsToBeDirectParent="true" />
                       <Choice Kind="OperationCallFlag" Name="SetParameters" />
                     </p:NodeReference>
                     <Pin Id="OhHObkyRV2OM8Nnx7QMHGm" Name="Input" Kind="StateInputPin" />
                     <Pin Id="Q34L8qDHdPAOYXWa4CRFkp" Name="Value" Kind="InputPin" />
                     <Pin Id="IT7irqKvcdrPia2g5bVc2X" Name="Output" Kind="StateOutputPin" />
                   </Node>
-                  <Node Bounds="404,288,48,22" Id="UYGprPN54pNLJDkTB3VH8C">
+                  <Node Bounds="404,288,55,26" Id="UYGprPN54pNLJDkTB3VH8C">
                     <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Evaluate" />
@@ -3419,11 +3418,21 @@
                     <Pin Id="UxMeVot1OsGQEnnaCJTqVI" Name="Defaultvalue" Kind="InputPin" />
                     <Pin Id="VP5QbOXWXuHQdJiezNPsmC" Name="Result" Kind="OutputPin" />
                   </Node>
+                  <Node Bounds="404,260,48,19" Id="RJimhpHut7mP6EzSUXiIXV">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="CastAs" />
+                    </p:NodeReference>
+                    <Pin Id="SBGh6otVVX6N6DUtO1tqZe" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="MljNKa2hEuBOqq1C53997l" Name="Default" Kind="InputPin" />
+                    <Pin Id="EjhbbvxIXoEOxzapI7q68c" Name="Result" Kind="OutputPin" />
+                    <Pin Id="QKEuz40Su6WOtYGLNXhO4i" Name="Success" Kind="OutputPin" />
+                  </Node>
                 </Patch>
-                <ControlPoint Id="GewIfxO9qxrLIw57lYLpSP" Bounds="402,224" Alignment="Top" />
+                <ControlPoint Id="GewIfxO9qxrLIw57lYLpSP" Bounds="402,213" Alignment="Top" />
                 <ControlPoint Id="FVbQaEynVIhM5IgONPKSXt" Bounds="448,365" Alignment="Bottom" />
               </Node>
-              <Node Bounds="307,65,72,86" Id="PdwLjcx9h9cMfAUFiImUDF">
+              <Node Bounds="307,65,79,86" Id="PdwLjcx9h9cMfAUFiImUDF">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -3434,7 +3443,7 @@
                   <Patch Id="KJSJ0xSWIJnOEeF2wUHUJ6" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="Ez1vY7WHHs2NXp2VhdsQZx" Name="Update" ManuallySortedPins="true" />
                   <Patch Id="OrsezMQNFFiPsIBB1hANGK" Name="Dispose" ManuallySortedPins="true" />
-                  <Node Bounds="319,95,48,22" Id="OYCzAl7z1OZPVlfsjYmVhf">
+                  <Node Bounds="319,95,55,26" Id="OYCzAl7z1OZPVlfsjYmVhf">
                     <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="AssemblyCategory" Name="NCalc" />
@@ -3450,6 +3459,7 @@
                     <Pin Id="UsPpuVDwMhIMfIP33FRB9G" Name="Expression" Kind="InputPin" />
                     <Pin Id="AWtVRPgKemMPNUggmk6TUe" Name="Options" Kind="InputPin" />
                     <Pin Id="HLKMz9rcDeBN3QbK0fyk4X" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="GZyQZLHLxW6NJ1Vxca8J0S" Name="Culture Info" Kind="InputPin" />
                   </Node>
                 </Patch>
                 <ControlPoint Id="FXV9bJa8qLROKEJLJ4Igre" Bounds="323,71" Alignment="Top" />
@@ -3620,11 +3630,12 @@
             <Link Id="PIrWl6ZSOx1NZzGFKQQi5K" Ids="Q9KwbZDdOdbOSHIRfwgAJK,ESE0z8XSJQrPW05Ou2sbsQ" />
             <Link Id="VfpUEEzdPqfMUSMyqy6Ir8" Ids="OcbUrv2OH3JO2PLeloRBBd,AcQYg6fe3GyN86uKhkwcPQ" />
             <Link Id="PgMeQewi2ugMwOIOnI3mfa" Ids="Ow1Dz5AIkokPupMpoCVTLh,Al7Ml1QRKMgM70ISCvVGmo" />
-            <Link Id="UsLhZNiykhCLl9zuyFDktj" Ids="IT7irqKvcdrPia2g5bVc2X,OBOxORItaYSNBtwafxUD12" />
+            <Link Id="UsLhZNiykhCLl9zuyFDktj" Ids="IT7irqKvcdrPia2g5bVc2X,SBGh6otVVX6N6DUtO1tqZe" />
             <Link Id="ILHNQXQMTj6LKjgTAdMxln" Ids="FVbQaEynVIhM5IgONPKSXt,CnjkIjYJ10IQPTQSTVehlE" />
             <Link Id="KpYDQjZTHZKMAynH3EUgKA" Ids="CnjkIjYJ10IQPTQSTVehlE,FtlvFng5gjuOWnYZNasWP9" IsHidden="true" />
             <Link Id="ByU6v69KPdAPEnXEwVtxt6" Ids="C6Lwo9LzeaLL1KRkGvR0Af,MfgApo6xtFNQWOYrqXVU6U" />
             <Link Id="NjT0e3YaNgDMM0MymbQQn5" Ids="VP5QbOXWXuHQdJiezNPsmC,FVbQaEynVIhM5IgONPKSXt" />
+            <Link Id="Ibw9LujFpZPQduDJFV0kTp" Ids="EjhbbvxIXoEOxzapI7q68c,OBOxORItaYSNBtwafxUD12" />
           </Patch>
         </Node>
         <!--
@@ -12936,6 +12947,7 @@
                     <Pin Id="TD7iy6fdFDuN2CDg0UAP4r" Name="Expression" Kind="InputPin" />
                     <Pin Id="IEgwviB6qP5NKLaX0FbYkG" Name="Options" Kind="InputPin" />
                     <Pin Id="SNXVfFwTA2qOXiOr8Qweup" Name="Output" Kind="StateOutputPin" />
+                    <Pin Id="ExvYoG0pwaEOSYUicpCt9h" Name="Culture Info" Kind="InputPin" />
                   </Node>
                 </Patch>
                 <ControlPoint Id="U5tfegFVGOcOhwEfKCiLma" Bounds="352,32" Alignment="Top" />
@@ -13700,18 +13712,18 @@
                       <Patch Id="Eu2AQra5YSQLxYBWdIIdei" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="F30koS9olaTNZhwtttW2Z8" Name="Update" ManuallySortedPins="true" />
                       <Patch Id="RwxX4LCQC7xNyPkBiXYvzZ" Name="Dispose" ManuallySortedPins="true" />
-                      <Node Bounds="419,276,81,26" Id="JGTlfvWtaOkNSd5wyqkYqX">
-                        <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
+                      <Node Bounds="419,276,81,19" Id="JGTlfvWtaOkNSd5wyqkYqX">
+                        <p:NodeReference LastCategoryFullName="NCalc.ExpressionBase`1" LastDependency="NCalc.Core.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <CategoryReference Kind="AssemblyCategory" Name="NCalc" />
-                          <CategoryReference Kind="AssemblyCategory" Name="Expression" />
+                          <CategoryReference Kind="AssemblyCategory" Name="ExpressionBase`1" NeedsToBeDirectParent="true" />
                           <Choice Kind="OperationCallFlag" Name="SetParameters" />
                         </p:NodeReference>
                         <Pin Id="KB7Xlf5pe8gPrV1exsgZCK" Name="Input" Kind="StateInputPin" />
                         <Pin Id="H4Xja1sGtwCO1HKRlUJE9f" Name="Value" Kind="InputPin" />
                         <Pin Id="KaVm4svbTBpOUCpX2TzUDd" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="419,314,55,26" Id="OEadjQ1gKS5OKSrZ7WKGxV">
+                      <Node Bounds="419,350,55,26" Id="OEadjQ1gKS5OKSrZ7WKGxV">
                         <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Evaluate" />
@@ -13741,6 +13753,16 @@
                           </p:TypeAnnotation>
                         </Pin>
                         <Pin Id="DHLl483jx6eM2AYuP2VEI2" Name="Output" Kind="OutputPin" />
+                      </Node>
+                      <Node Bounds="419,320,48,19" Id="QSAROe1sAdNNxuWNnSZJN5">
+                        <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="CastAs" />
+                        </p:NodeReference>
+                        <Pin Id="QXzpryb35aZLMQhC7Mnk0r" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="VcwhHEVFkLtN2OaN7Yuvdv" Name="Default" Kind="InputPin" />
+                        <Pin Id="QwQuJrJwCJlMTtja06EdfQ" Name="Result" Kind="OutputPin" />
+                        <Pin Id="PQtPwzqStm1NDasNnRl7q0" Name="Success" Kind="OutputPin" />
                       </Node>
                     </Patch>
                   </Node>
@@ -13946,7 +13968,7 @@
             <Link Id="KND6V28ZJPGL9zmjed778I" Ids="H23CatMrA1oOp1RtUfHjax,S8opUYSe1whQVu0FpUA0lc" />
             <Link Id="PLULEAcByqXN6lI04JDTUd" Ids="TPmNOrB2IAsPTQrsVwf5H6,Rwns1hB0zUOLXlEpTY4aWl" IsHidden="true" />
             <Link Id="ShnJaHYPTYHMdyen1A6pXj" Ids="Q86Ox44j9XZQOytB4aoXE5,KB7Xlf5pe8gPrV1exsgZCK" />
-            <Link Id="LCeatc8PaDfLrO6WdZ2ebL" Ids="KaVm4svbTBpOUCpX2TzUDd,VMb6IejZUqoPIT6XpsNScY" />
+            <Link Id="LCeatc8PaDfLrO6WdZ2ebL" Ids="KaVm4svbTBpOUCpX2TzUDd,QXzpryb35aZLMQhC7Mnk0r" />
             <Link Id="Tb82aivPeAYPV5NlFGrvAV" Ids="BaZxNWl0IezMxqva4Qpr7U,RrZjXSyFNt2NjKVnHGxPtL" />
             <Link Id="Fosf2fzoJhZMsXaDr6eopN" Ids="GmIMEQ3QDqcPJXJnDmQqJM,Ox6IAReaBFfPPyVzyucTX8" />
             <Link Id="BeVos4lIzF4NLpyu9zivfq" Ids="DHLl483jx6eM2AYuP2VEI2,RMRmJht0l3ULjEpRsbNa6J" />
@@ -13959,6 +13981,7 @@
             <Link Id="Bpdw3jIDL7EMXd3pMGYCRT" Ids="PB6Qc2CnuBkNGMgmfAevel,H4Xja1sGtwCO1HKRlUJE9f" />
             <Link Id="KzT13adgDJ9QcnSn51keEU" Ids="VDmoQxn2VR5PDlGyWkItTD,SHqFGoxCWYhPxdOUcVaLJB" />
             <Link Id="UXysysmfgR9LMCPpHVU8QM" Ids="UJkSshwkKFpOvt0PGMTJhz,RKVsMc1SU0cMtroByjz6p8" />
+            <Link Id="Fe1xKGZBwgBOGRo3c75HIV" Ids="QwQuJrJwCJlMTtja06EdfQ,VMb6IejZUqoPIT6XpsNScY" />
           </Patch>
         </Node>
         <!--
@@ -16486,5 +16509,6 @@
     </Node>
   </Patch>
   <DocumentDependency Id="SMtEvYqQ0XBNcOrpsTh0oI" Location="../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="ULkdtBZTTq5PNxOQrRYqVY" Location="ncalc" Version="1.3.8" />
+  <NugetDependency Id="FaC3wPhvcbSPH6FSdJE4cL" Location="NCalc.Core" Version="5.2.2" />
+  <NugetDependency Id="J6A5ozAjUxMPW8ZuzbHPSQ" Location="NCalcSync" Version="5.2.2" />
 </Document>

--- a/Main/vl/Plugins/DMXOutput/Schema.Plugins.DMXOutput.vl
+++ b/Main/vl/Plugins/DMXOutput/Schema.Plugins.DMXOutput.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Mjo9Ogd5Q5rNQreT6qXqfD" LanguageVersion="2024.6.4" Version="0.128">
-  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2024.6.4" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="Mjo9Ogd5Q5rNQreT6qXqfD" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Eny9LQLNx9uLh7Foc0vhnV">
     <Canvas Id="RzIPJGd57R3QRCbNzjSDjn" DefaultCategory="Schema.Plugins.DMXOutput" CanvasType="FullCategory">
       <Canvas Id="CVPzQyfaWS0NA2uMaYWZM6" Name="Output" Position="391,297">
@@ -13010,7 +13010,7 @@
                     <Pin Id="I3jJHLjXtZzPznDw9ZnYCE" Name="Blue" Kind="OutputPin" />
                     <Pin Id="IMaW3cWN4l7Ph4UTMwCgH8" Name="Alpha" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1340,-41,52,26" Id="J5uVoFU0aJ1MxVyf8J1dkM">
+                  <Node Bounds="1340,-41,52,19" Id="J5uVoFU0aJ1MxVyf8J1dkM">
                     <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -13316,7 +13316,7 @@
     ************************ SetItemCoarseFine ************************
 
 -->
-              <Node Name="SetItemCoarseFine" Bounds="745,-9,213,394" Id="RXRAqkHgmuXLFg4M83Wigp">
+              <Node Name="SetItemCoarseFine" Bounds="745,-9,213,536" Id="RXRAqkHgmuXLFg4M83Wigp">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                   <Choice Kind="OperationDefinition" Name="Operation" />
                 </p:NodeReference>
@@ -13340,7 +13340,7 @@
                   <Link Id="JMB9UUdg5jbLpAL1Sh9ywL" Ids="BDS8og66KeJOjwn7SHIQyM,PBZPU3sMKErMH124utBYeP" />
                   <ControlPoint Id="KM2DqVMUUOVO8KzlBo7CaQ" Bounds="868,9" />
                   <Link Id="K9SMBQjM6Z7N9rs3kZYQqd" Ids="TgXlpaDUZYLN5cNW2Fesgg,KM2DqVMUUOVO8KzlBo7CaQ" IsHidden="true" />
-                  <ControlPoint Id="KqFj9ioqOSENLXkjtgvk3m" Bounds="759,368" />
+                  <ControlPoint Id="KqFj9ioqOSENLXkjtgvk3m" Bounds="759,510" />
                   <Link Id="P4dOflsdsfcPJeDoEEleWG" Ids="KqFj9ioqOSENLXkjtgvk3m,QZ4FdQdd6XfNKmshUDr4Qa" IsHidden="true" />
                   <Node Bounds="860,30,86,19" Id="Smb1fOdV0kbOQIfERmQtbN">
                     <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
@@ -13376,7 +13376,6 @@
                     <Pin Id="Ro4M3Fjn960P1SMogFg1CU" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <Link Id="QjBmAr0nTaBMubTEBQDd7H" Ids="GwNwtYF2SEhNKA8mSphAta,VEfHzV6CtN2LCrnaOkMbHT" />
-                  <Link Id="BAf8a44LLzcNS6dWIxH1PY" Ids="Ro4M3Fjn960P1SMogFg1CU,KqFj9ioqOSENLXkjtgvk3m" />
                   <Link Id="NSRdMHkaXL3LYcZ4JduIA8" Ids="LbGPBXwLTezPihRaAvdSiI,GEv4z39CgZaOsTXp6XFhFa" />
                   <Link Id="H7Z2VeGI1cGQBESIwVpmYi" Ids="Sln7wDytQZmQD0thh8dPCB,Crw9y5n7R34NpqtiQ76QBl" />
                   <Node Bounds="900,238,25,19" Id="VgUHYa7src9OQHvSJjnDya">
@@ -13423,6 +13422,31 @@
                   <Pin Id="LtCnnOK5LPfONuETjOFZeV" Name="Key" Kind="InputPin" />
                   <Pin Id="TgXlpaDUZYLN5cNW2Fesgg" Name="Value" Kind="InputPin" />
                   <Pin Id="QZ4FdQdd6XfNKmshUDr4Qa" Name="Output" Kind="OutputPin" />
+                  <Node Bounds="827,380,25,19" Id="JRJXej8skbvLqw90DwyyJP">
+                    <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="+" />
+                    </p:NodeReference>
+                    <Pin Id="JBiswiAN4EWNpnFhOfoL8L" Name="Input" Kind="InputPin" />
+                    <Pin Id="MTEjR6jo81MLrYogHIlEgJ" Name="Input 2" Kind="InputPin" DefaultValue="1" />
+                    <Pin Id="GYdREjyZ6YWOI3Jw6SyOuZ" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="757,430,146,26" Id="C2fovuhxsEWNgcs77gqosa">
+                    <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="MutableDictionary" />
+                      <Choice Kind="OperationCallFlag" Name="SetItem" />
+                    </p:NodeReference>
+                    <Pin Id="TC6Sype24cNLyiYQD3CkND" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="ULmSvgfzveuQRcWt8mvJ6W" Name="Key" Kind="InputPin" />
+                    <Pin Id="OIKNBUlORxMM5hP73trvj9" Name="Value" Kind="InputPin" />
+                    <Pin Id="O7Uvbz5Vf5wLTHuYFbWNQL" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Link Id="F0cVmFGitYNNfPTUEKlGgD" Ids="Ro4M3Fjn960P1SMogFg1CU,TC6Sype24cNLyiYQD3CkND" />
+                  <Link Id="KE6fZfOvpzHNvu1wavdbEJ" Ids="O7Uvbz5Vf5wLTHuYFbWNQL,KqFj9ioqOSENLXkjtgvk3m" />
+                  <Link Id="AeQ9i4EhRHVO6SMbk7ka8j" Ids="BDS8og66KeJOjwn7SHIQyM,JBiswiAN4EWNpnFhOfoL8L" />
+                  <Link Id="NHbWXFrZBuVOFVLu9UHf7D" Ids="GYdREjyZ6YWOI3Jw6SyOuZ,ULmSvgfzveuQRcWt8mvJ6W" />
+                  <Link Id="UbFRNVfkAaTQKEkjCR9vQX" Ids="KM2DqVMUUOVO8KzlBo7CaQ,OIKNBUlORxMM5hP73trvj9" />
                 </Patch>
               </Node>
               <Node Bounds="495,20,128,19" Id="FsPl22F9EbBQFmXKDQdy98">
@@ -13553,7 +13577,7 @@
     ************************ SetStrobeParameters ************************
 
 -->
-              <Node Name="SetStrobeParameters" Bounds="1591,598,223,203" Id="NF3202Gc9zzPgXN2gphGeR">
+              <Node Name="SetStrobeParameters" Bounds="1591,598,236,203" Id="NF3202Gc9zzPgXN2gphGeR">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
                   <Choice Kind="OperationDefinition" Name="Operation" />
                 </p:NodeReference>
@@ -13602,7 +13626,7 @@
                     </p:TypeAnnotation>
                   </Pad>
                   <ControlPoint Id="M7ggi3mLktnP2Q1MY0qNcP" Bounds="1745,784" />
-                  <Node Bounds="1744,686,58,19" Id="Ec4xRbtwcRGMVt3hFJTxJx">
+                  <Node Bounds="1744,686,71,19" Id="Ec4xRbtwcRGMVt3hFJTxJx">
                     <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetDuration" />
@@ -13721,7 +13745,6 @@
                     </Patch>
                   </Node>
                 </Patch>
-                <Pin Id="EcoMlmF3U5RLSOZvjazU9w" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="DwQtlrxAETwOkOHmMJJtr2" Name="Default Output" Kind="InputPin" />
                 <Pin Id="Ezb4P1Iy2u6MfU6vSq43PC" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
                 <Pin Id="AZ0sUFlJGgDQYq3roxCxAW" Name="Result" Kind="OutputPin" />
@@ -13765,7 +13788,7 @@
                     <Pin Id="VbmYIsuLrSxOWUuZW2KTqA" Name="Value" Kind="InputPin" />
                     <Pin Id="O1od0F2uw4pLWbtTH2xMJT" Name="Output" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="1989,636,65,19" Id="U5OJaImnLD9LihSWIalg81">
+                  <Node Bounds="1989,636,90,19" Id="U5OJaImnLD9LihSWIalg81">
                     <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetTemperature" />
@@ -13872,7 +13895,7 @@
                   <Pin Id="P8PnvOF0CEeNfmgXRREYfX" Name="State" Kind="OutputPin" Bounds="1229,795" />
                 </Patch>
               </Node>
-              <Node Bounds="495,167,25,19" Id="OaeyZcUl8zhOkcBmtkQAT4">
+              <Node Bounds="495,167,106,19" Id="OaeyZcUl8zhOkcBmtkQAT4">
                 <p:NodeReference LastCategoryFullName="Schema.Plugins.DMXOutput.Output.GenericExpressionMapping" LastDependency="Schema.Plugins.DMXOutput.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="SetValueParameters" />

--- a/Main/vl/Plugins/EnttecDMXUSBProOutput/Schema.Plugins.EnttecDMXUSBProOutput.vl
+++ b/Main/vl/Plugins/EnttecDMXUSBProOutput/Schema.Plugins.EnttecDMXUSBProOutput.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="OlfxEDBnxriMZXNWcLXZbH" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="OlfxEDBnxriMZXNWcLXZbH" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Eny9LQLNx9uLh7Foc0vhnV">
     <Canvas Id="RzIPJGd57R3QRCbNzjSDjn" DefaultCategory="Schema.Plugins.EnttecDMXUSBProOutput" CanvasType="FullCategory">
       <!--
@@ -116,6 +116,7 @@
                 <Pin Id="Qz8U6qshpCoMNO5sqeHDVV" Name="Universe Count" Kind="InputPin" />
                 <Pin Id="VhS51MC3EbHNhnLTmb19N8" Name="Split" Kind="ApplyPin" />
                 <Pin Id="IDYiOwCptuZLSshtPwsiUJ" Name="Reload" Kind="ApplyPin" />
+                <Pin Id="LN6FyvHFWvtOJss2oVwL56" Name="State Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="AmuZqic5cyKLp95JsAyAMt" Name="Output" Kind="OutputPin" />
                 <Pin Id="QIfwIfZn6xEQWURtOUUwB2" Name="Supported Models" Kind="OutputPin" />
                 <Pin Id="B4f4nrJw21mL9c0rTfE5xw" Name="Status" Kind="OutputPin" />
@@ -137,6 +138,7 @@
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pin>
+                <Pin Id="AIc4AlYeLVVLkhDpul9Rwc" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="GvPfYMAxQCUPzwbguVaZ0A" Name="Is Open" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="IJXH0H5n4q8NXgGYgBb2Jw" Bounds="48,157" />
@@ -272,9 +274,8 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="VedtIDoRe4uNPx3COdWpHC" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="VedtIDoRe4uNPx3COdWpHC" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="SMtEvYqQ0XBNcOrpsTh0oI" Location="../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="ULkdtBZTTq5PNxOQrRYqVY" Location="ncalc" Version="1.3.8" />
   <DocumentDependency Id="Hhe6QFox9lIOM4DkseNEL1" Location="../DMXOutput/Schema.Plugins.DMXOutput.vl" />
   <NugetDependency Id="PnfAbRPJGQLMDV9JwvegDG" Location="VL.Devices.ENTTEC" Version="0.0.1-alpha" />
 </Document>

--- a/Main/vl/Plugins/MovingHeads/Schema.MovingHeads.vl
+++ b/Main/vl/Plugins/MovingHeads/Schema.MovingHeads.vl
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="GYQRxByCsDmPMQRDQzAXX7" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="IxRJTUrIVHXPzhR6dKwDtX" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="GYQRxByCsDmPMQRDQzAXX7" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="OGClmF9GOEbLuKWTMa9azL">
-    <Canvas Id="N3FirfCkh1PLCvG4sivs1X" DefaultCategory="Main" CanvasType="FullCategory">
+    <Canvas Id="N3FirfCkh1PLCvG4sivs1X" DefaultCategory="Schema.Plugins.MovingHeads" CanvasType="FullCategory">
       <!--
 
     ************************ MovingHeadBlocks ************************
@@ -877,8 +876,8 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="CAb0MnMPuhpOARru69GU8l" Location="VL.Skia" Version="2024.6.2" />
   <DocumentDependency Id="TbsONl3y8w9Ppr43nNeZV9" Location="./Blocks/Schema.MovingHeads.Blocks.vl" />
   <DocumentDependency Id="GqJjyxiaWTpMzvlvXzupBa" Location="../../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="CvLGG3dX7K2MMaWY1QYg3c" Location="./Blocks/Source/Rotation/Schema.MovingHeads.Blocks.Source.Rotation.RotPTFollowBee.vl" />
+  <NugetDependency Id="RQtlwPIHqf8NzCAJyc4pKk" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/vl/Plugins/OSCReceiver/Schema.Plugins.OSCReceiver.vl
+++ b/Main/vl/Plugins/OSCReceiver/Schema.Plugins.OSCReceiver.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Hx4gA59Ae2GPzYPte94HbC" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="Hx4gA59Ae2GPzYPte94HbC" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Th8hpfHvBF4Lk6VOwDCc9D">
     <Canvas Id="NtZT52Xp5qNOXK0fF2H7kv" DefaultCategory="Schema.Plugins.OSCReceiver" CanvasType="FullCategory">
       <!--
@@ -72,6 +72,7 @@
                         <CategoryReference Kind="ClassType" Name="OSCValueSource" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
                       <Pin Id="LSmsdlmYVfsPYyYEJNqLbv" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="OP2kATcjP4tObr5A04GCyy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     </Node>
                   </Patch>
                 </Node>
@@ -108,6 +109,7 @@
                         <CategoryReference Kind="ClassType" Name="OSCReceivedValueSource" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
                       <Pin Id="SAHuA5EPzcJNvaZ9Sl0kRW" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="Kgdw9U4NRZkPJdSc3CkF7x" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     </Node>
                   </Patch>
                 </Node>
@@ -138,6 +140,7 @@
                         <CategoryReference Kind="ClassType" Name="OSCColorSource" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
                       <Pin Id="LLYoe7EEjzaMb6FAKqeaoF" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="Iwbl5YcaiQtPELc5gs35Ti" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     </Node>
                   </Patch>
                 </Node>
@@ -218,6 +221,7 @@
                         <CategoryReference Kind="RecordType" Name="Dictionary" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
                       <Pin Id="PyNdGSuW1WoMRdtmMKMbmy" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="R7v324HstrYOPBqeYRxEPD" Name="Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="JwtwOfYmrK7O2ojvGK5IgV" Name="Keys" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="1098,407,83,26" Id="KyIK5prTXXjNboCLDuf5zH">
@@ -396,9 +400,9 @@
                 </p:Interfaces>
                 <Patch Id="NCiPhxc5yYeMAlNe8JB3YR">
                   <Canvas Id="EojPK1HY1u9Mfs9CNs5flS" CanvasType="Group">
-                    <ControlPoint Id="CtiU9Tc0LErL07xdh2OyqF" Bounds="144,668" />
-                    <ControlPoint Id="PbcdHkBiaVCNsnlNFSNcKG" Bounds="146,137" />
-                    <Node Bounds="145,167,54,19" Id="AQvScIx0aamLyVJY6GXBba">
+                    <ControlPoint Id="CtiU9Tc0LErL07xdh2OyqF" Bounds="360,588" />
+                    <ControlPoint Id="PbcdHkBiaVCNsnlNFSNcKG" Bounds="361,61" />
+                    <Node Bounds="359,100,54,19" Id="AQvScIx0aamLyVJY6GXBba">
                       <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Merge" />
@@ -407,7 +411,7 @@
                       <Pin Id="LSEXmYukRqQNQihOq72xaR" Name="Input" Kind="InputPin" />
                       <Pin Id="KLfytae3zJkPcjs0iYUrJf" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="143,634,65,19" Id="KsYxOKHVSe7OrWc4NBNwjj">
+                    <Node Bounds="359,554,65,19" Id="KsYxOKHVSe7OrWc4NBNwjj">
                       <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="SetValue" />
@@ -417,13 +421,13 @@
                       <Pin Id="O4Ay7Vla8LNLbpChZeMdAr" Name="Value" Kind="InputPin" />
                       <Pin Id="UuuV8gGg6zkOUZEw3D9ZJF" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Pad Id="CiT20CzN7PrPKZYsW0KkTR" Comment="Key" Bounds="-72,66,133,20" ShowValueBox="true" isIOBox="true" Value="Name">
+                    <Pad Id="CiT20CzN7PrPKZYsW0KkTR" Comment="Key" Bounds="62,50,133,20" ShowValueBox="true" isIOBox="true" Value="Name">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="String" />
                       </p:TypeAnnotation>
                     </Pad>
-                    <ControlPoint Id="MMFRKlUJJPiQGIl0ykxjCM" Bounds="-102,438" />
-                    <Node Bounds="-174,190,89,19" Id="T1TxuJPbgHgOQq5H5zrjjV">
+                    <ControlPoint Id="MMFRKlUJJPiQGIl0ykxjCM" Bounds="114,358" />
+                    <Node Bounds="40,110,89,19" Id="T1TxuJPbgHgOQq5H5zrjjV">
                       <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="CreateDefault" />
@@ -431,7 +435,7 @@
                       </p:NodeReference>
                       <Pin Id="SVCWK6tvaqfOjyRNB9IUTO" Name="Output" Kind="StateOutputPin" />
                     </Node>
-                    <Node Bounds="-176,393,77,26" Id="UDWG7gfkEPKMtnhNx7sJbw">
+                    <Node Bounds="40,310,77,26" Id="UDWG7gfkEPKMtnhNx7sJbw">
                       <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ToImmutable" />
@@ -441,16 +445,16 @@
                       <Pin Id="CowJfNft66nOBuReuXhhXD" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="SmGKPBpYNChOmsCrL4lVMm" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="-4,188,87,19" Id="PW1c9cRdHmPL5jnlBnpxjo">
+                    <Node Bounds="140,110,87,19" Id="PW1c9cRdHmPL5jnlBnpxjo">
                       <p:NodeReference LastCategoryFullName="Schema.Plugins.OSCReceiver.OSCReceiverPlugin" LastDependency="Schema.Plugins.OSCReceiver.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationNode" Name="OSCPluginKey" />
                       </p:NodeReference>
                       <Pin Id="KEPHz1YiPhFMkqlREWMlri" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <ControlPoint Id="SxlrTogjqrJQCuelVOxvs4" Bounds="-37,163" />
-                    <ControlPoint Id="UF8NVrTH3lWMpExsqVWgK5" Bounds="259,149" />
-                    <Node Bounds="255,190,119,26" Id="P3WP6RbvUUDMA9wEzDpZvw">
+                    <ControlPoint Id="SxlrTogjqrJQCuelVOxvs4" Bounds="182,150" />
+                    <ControlPoint Id="UF8NVrTH3lWMpExsqVWgK5" Bounds="472,61" />
+                    <Node Bounds="470,100,119,26" Id="P3WP6RbvUUDMA9wEzDpZvw">
                       <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="GetObjectDictionary" />
@@ -460,14 +464,14 @@
                       <Pin Id="UH4X8Egn6rpPcyIz5G5Fad" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="EnNaeCbWIDpQY7Zgxargjw" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="368,152,90,19" Id="NioEGYF11iJOLrFq9eqUwU">
+                    <Node Bounds="584,50,90,19" Id="NioEGYF11iJOLrFq9eqUwU">
                       <p:NodeReference LastCategoryFullName="Schema.Plugins.OSCReceiver.OSCReceiverPlugin" LastDependency="Schema.Plugins.OSCReceiver.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationNode" Name="OSCPluginKey" />
                       </p:NodeReference>
                       <Pin Id="JoQSI79Q272ObEeEPxWHhR" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="371,229,71,26" Id="JXlmXOOA1XJNhOO6hPPIRJ">
+                    <Node Bounds="323,220,71,26" Id="JXlmXOOA1XJNhOO6hPPIRJ">
                       <p:NodeReference LastCategoryFullName="Collections.Dictionary" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="TryGetValue" />
@@ -479,48 +483,12 @@
                       <Pin Id="OXdo8mvS6wlN0a2rpMJdJB" Name="Result" Kind="OutputPin" />
                       <Pin Id="Cm45yahFIzlQSU0aUFL4u8" Name="Value" Kind="OutputPin" />
                     </Node>
-                    <Pad Id="Id8E1cC9vGgNfciGOmbLN3" Comment="Key" Bounds="-51,98,54,19" ShowValueBox="true" isIOBox="true" Value="Default">
+                    <Pad Id="Id8E1cC9vGgNfciGOmbLN3" Comment="Key" Bounds="82,80,54,19" ShowValueBox="true" isIOBox="true" Value="Default">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="String" />
                       </p:TypeAnnotation>
                     </Pad>
-                    <Node Bounds="189,544,74,62" Id="FQQnsadqZAmOurEMjtDjdD">
-                      <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                        <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                        <CategoryReference Kind="Category" Name="Primitive" />
-                      </p:NodeReference>
-                      <Pin Id="SapStS7uie5LtpHuRp4fik" Name="Condition" Kind="InputPin" />
-                      <ControlPoint Id="UEAcqy6vtVYQW9sUqYkCIM" Bounds="205,600" Alignment="Bottom" />
-                      <ControlPoint Id="F7QdjoLANuBMeYEC1Cg4Vw" Bounds="203,550" Alignment="Top">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="Float32" />
-                        </p:TypeAnnotation>
-                      </ControlPoint>
-                      <Patch Id="P3FB3GLFZYOLURqCjgdJ8k" ManuallySortedPins="true">
-                        <Patch Id="CpfSUb2WankPiFTp49BF6Z" Name="Create" ManuallySortedPins="true" />
-                        <Patch Id="LkM0ckAuScuNHcMYBt0IOP" Name="Then" ManuallySortedPins="true" />
-                        <Node Bounds="203,567,48,19" Id="JKvfbNsExmIOtw3RZi4GYE">
-                          <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="CastAs" />
-                          </p:NodeReference>
-                          <Pin Id="VTU2ZnNWmEzMuolN92Lx0L" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="BECY9zbYAF7MSFoPdsHCSN" Name="Default" Kind="InputPin" />
-                          <Pin Id="O4nOuXGThBfOLhHPcFSDzn" Name="Result" Kind="OutputPin" />
-                          <Pin Id="OmzfekrQq1XLPEYCnunxpd" Name="Success" Kind="OutputPin" />
-                        </Node>
-                      </Patch>
-                    </Node>
-                    <Node Bounds="189,457,37,19" Id="L9AmlMvtZrqMVRFqkxPrk9">
-                      <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="NOT" />
-                      </p:NodeReference>
-                      <Pin Id="RjAendwbOcDO5RABOSq7uL" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="Oy2Lxo9M5uMN91dK8TcbBf" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                    <Node Bounds="-176,247,145,19" Id="AGeA0Ok1vj9QPfTXdtqQ1b">
+                    <Node Bounds="40,160,145,19" Id="AGeA0Ok1vj9QPfTXdtqQ1b">
                       <p:NodeReference LastCategoryFullName="Schema.PropertyDefinition.Helpers" LastDependency="Schema.PropertyDefinition.Helpers.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="String" />
@@ -542,7 +510,7 @@
                       <Pin Id="GLigchX0Y6qPKnKlUHo9lk" Name="Output" Kind="OutputPin" />
                       <Pin Id="KKqEVkCImxrMMMgQLJH1FA" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="-176,287,185,19" Id="JSUqGAL8wiAMOTLoeGhgFD">
+                    <Node Bounds="40,210,185,19" Id="JSUqGAL8wiAMOTLoeGhgFD">
                       <p:NodeReference LastCategoryFullName="Schema.PropertyDefinition.Helpers" LastDependency="Schema.PropertyDefinition.Helpers.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="Float32" />
@@ -566,19 +534,7 @@
                       <Pin Id="IcyLXeQHR4vMxbgfe4V4cH" Name="Output" Kind="OutputPin" />
                       <Pin Id="GeEj5VpYeouQMTner6APF4" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="201,420,52,19" Id="GG2CBUr0bUsN9eQNptjxz4">
-                      <p:NodeReference LastCategoryFullName="Schema.Plugins.OSCReceiver" LastDependency="Schema.Plugins.OSCReceiver.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="GetSlice (Object Spread)" />
-                      </p:NodeReference>
-                      <Pin Id="NS062vwNIUfPjFsX7vbnXz" Name="Input" Kind="InputPin" />
-                      <Pin Id="FtTgdf39qPUPll6p99eXZ2" Name="Default Value" Kind="InputPin" />
-                      <Pin Id="Pk8dCLrjOLzOE48ur0Y0W2" Name="Index" Kind="InputPin" />
-                      <Pin Id="MwuTXjczEZjNjWsHTcIUZ5" Name="Result" Kind="OutputPin" />
-                      <Pin Id="FYaJkzEN67XPdYpdj4VmyX" Name="Success" Kind="OutputPin" />
-                      <Pin Id="J9gVfF02x3CQdqU6plr3cS" Name="Object" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="-173,337,225,19" Id="MgcKfi39UxKNcwBKjMQiiR">
+                    <Node Bounds="40,260,225,19" Id="MgcKfi39UxKNcwBKjMQiiR">
                       <p:NodeReference LastCategoryFullName="Schema.PropertyDefinition.Helpers" LastDependency="Schema.PropertyDefinition.Helpers.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="Integer32" />
@@ -604,38 +560,97 @@
                       <Pin Id="FATFdlFP6zSPqbFa5tMBjV" Name="Output" Kind="OutputPin" />
                       <Pin Id="BQOb0HvkQnhPEaiwPOFSlR" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="225,379,25,19" Id="G2od2ALvFQdMFII2ElGt5P">
-                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="&gt;" />
+                    <Node Bounds="419,502,175,41" Id="Efc31XvJaN0O9BNg44BHPv">
+                      <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="TypeSwitch3" />
                       </p:NodeReference>
-                      <Pin Id="QlHPdJvGs6qNnV12nQ41qL" Name="Input" Kind="InputPin" />
-                      <Pin Id="KHQnNLEQTcVO1ydCzMKa5w" Name="Input 2" Kind="InputPin" DefaultValue="0.5">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="Float32" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="NKfTgU3DPf2MYAA5eipSPh" Name="Result" Kind="OutputPin" />
+                      <Pin Id="F5RoPPzgvGAOqmqfMxjhsH" Name="Input" Kind="InputPin" />
+                      <Pin Id="S6tNg85VXY2LOmyG7fhXPO" Name="Defaultvalue" Kind="InputPin" />
+                      <Pin Id="QAHNlnVj7VsOIiER3Gf5Sz" Name="Result" Kind="OutputPin" />
+                      <Patch Id="SWcmZ8qDGD1LyccG52d1Ik" Name="Match Func 1" ManuallySortedPins="true">
+                        <Pin Id="Ft8DFkjln3TNGPocsiKxwI" Name="Input" Kind="InputPin">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="TypeFlag" Name="Boolean" />
+                          </p:TypeAnnotation>
+                        </Pin>
+                        <Pin Id="GTa6s92br0hMBydxk9iVio" Name="Result" Kind="OutputPin" />
+                        <ControlPoint Id="Qkw2mKL5wFpNgNpYd8XoNV" Bounds="423,510" />
+                        <ControlPoint Id="V00UAjr4dZuQdjEDXycNmY" Bounds="423,536" />
+                      </Patch>
+                      <Patch Id="Ptcp1HsuN5WN1V41wVeNE1" Name="Match Func 2" ManuallySortedPins="true">
+                        <Pin Id="JPBi5bfpVesMVk8u166diq" Name="Input" Kind="InputPin">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="TypeFlag" Name="Integer32" />
+                          </p:TypeAnnotation>
+                        </Pin>
+                        <Pin Id="DXH93j3r33mMpArwvMYbeY" Name="Result" Kind="OutputPin" />
+                        <ControlPoint Id="D2DRbUqyu8yLVFC2ftCdS2" Bounds="483,510" />
+                        <ControlPoint Id="DI3FFTRK0N0NRcRWXNIu5k" Bounds="483,536" />
+                      </Patch>
+                      <Patch Id="PMFiiLJifRRMqd3BwYjssB" Name="Match Func 3" ManuallySortedPins="true">
+                        <Pin Id="Kg1Zw5eokwVOcJJc4XAkZM" Name="Input" Kind="InputPin">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="TypeFlag" Name="Float32" />
+                          </p:TypeAnnotation>
+                        </Pin>
+                        <Pin Id="Vk2a4hzo5rtLQfPS60VHb6" Name="Result" Kind="OutputPin" />
+                        <ControlPoint Id="JaW38PDAahLK9g2Pu7harz" Bounds="543,510" />
+                        <ControlPoint Id="UPAQARqjkeLOv8xzh6yv4A" Bounds="543,536" />
+                      </Patch>
                     </Node>
-                    <Pad Id="BeRqblEqJpkLGYUEQPHfbB" Comment="" Bounds="203,501,35,35" ShowValueBox="true" isIOBox="true" />
-                    <Pad Id="Cp6CzrPHZHfOE0QoF1fCLy" Bounds="259,426,144,19" ShowValueBox="true" isIOBox="true" Value="Handle boolean inputs">
+                    <Node Bounds="419,399,52,19" Id="JxvSXcFSJZRMWO2aM2b831">
+                      <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="GetSlice" />
+                      </p:NodeReference>
+                      <Pin Id="M67FLX5AYUhOuUTctotEpl" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="Hu2PXpU5vMTNA0vyKzJSMd" Name="Default Value" Kind="InputPin" />
+                      <Pin Id="QPtmENibhMwOpnSWSBDTDO" Name="Index" Kind="InputPin" />
+                      <Pin Id="KvSkYfPZf33Mgefne4NAvW" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Pad Id="AL8UjRinnQ9MAUVUZWSbTf" Comment="Default Value" Bounds="445,320,35,15" ShowValueBox="true" isIOBox="true">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
+                        <Choice Kind="ImmutableTypeFlag" Name="Float32" />
                       </p:TypeAnnotation>
-                      <p:ValueBoxSettings>
-                        <p:fontsize p:Type="Int32">9</p:fontsize>
-                        <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-                      </p:ValueBoxSettings>
                     </Pad>
-                    <Pad Id="NCVWxoKQHsfQZ7WyldcojH" Bounds="266,577,184,19" ShowValueBox="true" isIOBox="true" Value="Handle float inputs otherwise">
+                    <Pad Id="V7lzXzficEmLs2oMXTB8h4" Comment="" Bounds="421,439,35,15" ShowValueBox="true" isIOBox="true">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
+                        <Choice Kind="TypeFlag" Name="Object" />
                       </p:TypeAnnotation>
-                      <p:ValueBoxSettings>
-                        <p:fontsize p:Type="Int32">9</p:fontsize>
-                        <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-                      </p:ValueBoxSettings>
                     </Pad>
+                    <Node Bounds="443,350,48,19" Id="AwZgPUMgmfzPyEfeZwcMAR">
+                      <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="CastAs" />
+                      </p:NodeReference>
+                      <Pin Id="Eep9C0sxq1POySYiuYqDDY" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="CgkWv9EQbEDMFODQ7EF2uS" Name="Default" Kind="InputPin" />
+                      <Pin Id="USJI2OZkn74LwMbQpLOGD4" Name="Result" Kind="OutputPin" />
+                      <Pin Id="O7AKk9c1eqzPZffWVSjMx6" Name="Success" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="389,349,48,19" Id="FB0MDEUyF62NCJMtPXOP75">
+                      <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="CastAs" />
+                      </p:NodeReference>
+                      <Pin Id="CRe9icr8LHaPzG31EdVruc" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="NKFuP303nmTORZaKXwhjs7" Name="Default" Kind="InputPin" />
+                      <Pin Id="Oo1e0K8lJPsLL4vr1KPbd1" Name="Result" Kind="OutputPin" />
+                      <Pin Id="HfyTLMDFdIiOOKLdndR2nu" Name="Success" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="589,470,48,19" Id="GXcLqtEuUX7MGb7XV4gmak">
+                      <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="CastAs" />
+                      </p:NodeReference>
+                      <Pin Id="CIXi8HxPJOCNlVwvoxIJgI" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="RpnysAmnjXAMDZuA3DnmAh" Name="Default" Kind="InputPin" />
+                      <Pin Id="OjUBUEAMdRQOQ63VkGcq6l" Name="Result" Kind="OutputPin" />
+                      <Pin Id="G4xs0uADJUiO5hnAbO4YGT" Name="Success" Kind="OutputPin" />
+                    </Node>
+                    <ControlPoint Id="CcEv0EFjTPeNyOatfOPe8S" Bounds="82,196" />
                   </Canvas>
                   <Patch Id="Jln9DJrURcSOKGXyOEoaCZ" Name="Create" />
                   <ProcessDefinition Id="EpOAJdnLkUuLcqmJugKTRd" IsHidden="true">
@@ -667,30 +682,38 @@
                   <Link Id="B76OA99JKJDOLhglyNvwPx" Ids="UF8NVrTH3lWMpExsqVWgK5,IXQJMtBl4wDMzI3dRwFvaH" />
                   <Link Id="FeP9LeMVYukNRhcmB88ad3" Ids="JoQSI79Q272ObEeEPxWHhR,O7kAPahIT0PM5NU0te4KoM" />
                   <Link Id="ML5pMadA6NvLHe6gXpPBWZ" Ids="EnNaeCbWIDpQY7Zgxargjw,QgfHqo3b8sZN2BTfSIbjUp" />
-                  <Link Id="DaKHEQBraLFLOOumKjGInG" Ids="F7QdjoLANuBMeYEC1Cg4Vw,UEAcqy6vtVYQW9sUqYkCIM" IsFeedback="true" />
-                  <Link Id="MfrV90lgRizQdXKKLVlZg9" Ids="UEAcqy6vtVYQW9sUqYkCIM,O4Ay7Vla8LNLbpChZeMdAr" />
-                  <Link Id="PwHdmbdTrHKOwUtG9x1dbz" Ids="Oy2Lxo9M5uMN91dK8TcbBf,SapStS7uie5LtpHuRp4fik" />
                   <Link Id="LqM6Qq0I8KkMpsmpAymtvH" Ids="MezDae0MMUmMt8U5UFXwEn,VrjCSV0FBiUNm8QE7wvua2" />
                   <Link Id="KlXhWRApuYvNOGgPVj16B1" Ids="SVCWK6tvaqfOjyRNB9IUTO,JSuXyQEaZWcM1oxOhRNPjx" />
                   <Link Id="AXQuJxP7XC5MsYCJDBtRod" Ids="KEPHz1YiPhFMkqlREWMlri,PGtbf3l2LErQWC7RouOCJx" />
-                  <Link Id="T7UD6omd8oqPley8ADvGR1" Ids="Id8E1cC9vGgNfciGOmbLN3,Sw0G50YY2pBQBKgT8bOo90" />
+                  <Link Id="T7UD6omd8oqPley8ADvGR1" Ids="Id8E1cC9vGgNfciGOmbLN3,CcEv0EFjTPeNyOatfOPe8S,Sw0G50YY2pBQBKgT8bOo90" />
                   <Link Id="RV1tvLXSeQoQQTe6C2uUhc" Ids="CiT20CzN7PrPKZYsW0KkTR,DHwdMx6Ke2RMhVwwBZuuDc" />
                   <Link Id="IORj7ahyw5yOtxlF1oA1KV" Ids="SxlrTogjqrJQCuelVOxvs4,HdaljOfnrzDNH6gZY4NgMN" />
                   <Link Id="J1NeIyoTAnnOFlWQz3Mh9x" Ids="GLigchX0Y6qPKnKlUHo9lk,JLrjeTw4xrzPYrO2icYnG4" />
                   <Link Id="QgdXq8Q2ZpjNiRzmLMO2cO" Ids="KKqEVkCImxrMMMgQLJH1FA,Lni62JsPYNTLDu8EezpR9A" />
-                  <Link Id="Ss25OoP1Y8dP9oWB4Hx0Px" Ids="Cm45yahFIzlQSU0aUFL4u8,NS062vwNIUfPjFsX7vbnXz" />
                   <Link Id="A5QhgKAs1rxLG3HnzwTFMp" Ids="P5PEPKKyjuHM0XFDy4TVrR,P68gbriPo4JP14TF0KRIeA" />
                   <Link Id="MrMnu5XswrmOuonGKD96qZ" Ids="Una4nHr72oNOK0BtHwo3WK,ET0FgDjoCNNPg3OAtEmcIU" />
-                  <Link Id="IFVQKObtNQkPp20xxvc6qP" Ids="BQOb0HvkQnhPEaiwPOFSlR,Pk8dCLrjOLzOE48ur0Y0W2" />
                   <Link Id="IEGMPkIvjBvNvSB9S3FKZw" Ids="IcyLXeQHR4vMxbgfe4V4cH,A2XR12z7QbnPYKd8cFAlRN" />
-                  <Link Id="TsEMgQGA3MeOKUjLZkHKLm" Ids="MwuTXjczEZjNjWsHTcIUZ5,BeRqblEqJpkLGYUEQPHfbB" />
-                  <Link Id="GOeeAAhYbSzN7I8QvkDujo" Ids="FYaJkzEN67XPdYpdj4VmyX,RjAendwbOcDO5RABOSq7uL" />
-                  <Link Id="ArjBBTZKhVSOnmuhJjMm6d" Ids="J9gVfF02x3CQdqU6plr3cS,VTU2ZnNWmEzMuolN92Lx0L" />
-                  <Link Id="UPlyk2c3lWbN46QZNc1Og6" Ids="NKfTgU3DPf2MYAA5eipSPh,FtTgdf39qPUPll6p99eXZ2" />
-                  <Link Id="Hhlz7tfKHMJNdrGZsUSEO1" Ids="GeEj5VpYeouQMTner6APF4,QlHPdJvGs6qNnV12nQ41qL" />
-                  <Link Id="N3Y46bLu1peN9whk8e08iY" Ids="BeRqblEqJpkLGYUEQPHfbB,F7QdjoLANuBMeYEC1Cg4Vw" />
-                  <Link Id="Ri7YfYk8IlZMim7yAJ6GW0" Ids="O4nOuXGThBfOLhHPcFSDzn,UEAcqy6vtVYQW9sUqYkCIM" />
-                  <Link Id="DOfB2U5QGK3N74J75mIzHR" Ids="GeEj5VpYeouQMTner6APF4,BECY9zbYAF7MSFoPdsHCSN" />
+                  <Link Id="IgRIdz0xHz2O0lI8NiDynz" Ids="Ft8DFkjln3TNGPocsiKxwI,Qkw2mKL5wFpNgNpYd8XoNV" IsHidden="true" />
+                  <Link Id="Ljdyb2M5D68PoFLE19aPCm" Ids="V00UAjr4dZuQdjEDXycNmY,GTa6s92br0hMBydxk9iVio" IsHidden="true" />
+                  <Link Id="Q41CivCMGocMwJJhtRKlbP" Ids="JPBi5bfpVesMVk8u166diq,D2DRbUqyu8yLVFC2ftCdS2" IsHidden="true" />
+                  <Link Id="Vz9OtnOAgOlM70P1iE2RqY" Ids="DI3FFTRK0N0NRcRWXNIu5k,DXH93j3r33mMpArwvMYbeY" IsHidden="true" />
+                  <Link Id="BlpaHd7B5v1PUyoajNCoC1" Ids="Kg1Zw5eokwVOcJJc4XAkZM,JaW38PDAahLK9g2Pu7harz" IsHidden="true" />
+                  <Link Id="UUfdKr7Bh3qMSkryOtAT32" Ids="UPAQARqjkeLOv8xzh6yv4A,Vk2a4hzo5rtLQfPS60VHb6" IsHidden="true" />
+                  <Link Id="IMyxOVgKGhfQPWKhlYA3Bt" Ids="KvSkYfPZf33Mgefne4NAvW,V7lzXzficEmLs2oMXTB8h4" />
+                  <Link Id="PLCQzNLalTeNDuzvskXRXv" Ids="BQOb0HvkQnhPEaiwPOFSlR,QPtmENibhMwOpnSWSBDTDO" />
+                  <Link Id="JAz8TJRUhPKMFOOZIky2ux" Ids="JaW38PDAahLK9g2Pu7harz,UPAQARqjkeLOv8xzh6yv4A" />
+                  <Link Id="T2OA7AYu4XEOpXx0oyhWjs" Ids="D2DRbUqyu8yLVFC2ftCdS2,DI3FFTRK0N0NRcRWXNIu5k" />
+                  <Link Id="RVrAWUSXr2aN7TiWPcshyJ" Ids="Qkw2mKL5wFpNgNpYd8XoNV,V00UAjr4dZuQdjEDXycNmY" />
+                  <Link Id="AniE78Ui8QCO5BRf37ZhMS" Ids="AL8UjRinnQ9MAUVUZWSbTf,Eep9C0sxq1POySYiuYqDDY" />
+                  <Link Id="MnFX1qhU7rDP2NMWbzvKV6" Ids="V7lzXzficEmLs2oMXTB8h4,F5RoPPzgvGAOqmqfMxjhsH" />
+                  <Link Id="S1TMOJqmBi2M1tWpxpOBQY" Ids="USJI2OZkn74LwMbQpLOGD4,Hu2PXpU5vMTNA0vyKzJSMd" />
+                  <Link Id="N9us2UP5SwxNsrwVDoBo91" Ids="Oo1e0K8lJPsLL4vr1KPbd1,M67FLX5AYUhOuUTctotEpl" />
+                  <Link Id="SMqavIAmPGJPEJAZT4T1IK" Ids="Cm45yahFIzlQSU0aUFL4u8,CRe9icr8LHaPzG31EdVruc" />
+                  <Link Id="SVhkIlMRT7UP0AXqCmEKTj" Ids="QAHNlnVj7VsOIiER3Gf5Sz,O4Ay7Vla8LNLbpChZeMdAr" />
+                  <Link Id="Lew1mLmqYdvMF1SdUWl0FD" Ids="OjUBUEAMdRQOQ63VkGcq6l,S6tNg85VXY2LOmyG7fhXPO" />
+                  <Link Id="TJoa2cJC0IONxKHAYRHoS8" Ids="V7lzXzficEmLs2oMXTB8h4,CIXi8HxPJOCNlVwvoxIJgI" />
+                  <Link Id="A44ptIgGPrPMP7T7xHmZxO" Ids="AL8UjRinnQ9MAUVUZWSbTf,RpnysAmnjXAMDZuA3DnmAh" />
+                  <Link Id="Ekr9gn1nCW0LLvHL1fNUMQ" Ids="GeEj5VpYeouQMTner6APF4,AL8UjRinnQ9MAUVUZWSbTf" />
                 </Patch>
               </Node>
               <!--
@@ -1467,7 +1490,7 @@
                   <Patch Id="SsKZtXykjggNOPomqnbYxp" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="AHZvKPYFld7LZ85nBcWgtH" Name="Update" ManuallySortedPins="true" />
                   <Patch Id="NZvI8l3vPoHMa4WIZov5zs" Name="Dispose" ManuallySortedPins="true" />
-                  <Node Bounds="688,152,450,371" Id="OjcRknndE6JPtixNMcjw7w">
+                  <Node Bounds="699,152,439,371" Id="OjcRknndE6JPtixNMcjw7w">
                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -1612,7 +1635,7 @@
                         <Pin Id="DkNb2OnKYGaO94jVz9Rvks" Name="TypeTags" Kind="OutputPin" />
                         <Pin Id="GTjvrxZiGS1LHSmbr9jQNP" Name="Arguments" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="876,364,87,19" Id="QOeVnnG7DePP1gh8GgIYGq">
+                      <Node Bounds="876,340,87,19" Id="QOeVnnG7DePP1gh8GgIYGq">
                         <p:NodeReference LastCategoryFullName="IO.OSC" LastDependency="VL.IO.OSC.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ParseByTypetag" />
@@ -1649,12 +1672,13 @@
                   <Choice Kind="ProcessAppFlag" Name="Sampler" />
                 </p:NodeReference>
                 <Pin Id="NgpoIlEArD9Ny02Z0hn9oP" Name="Async Notifications" Kind="InputPin" />
+                <Pin Id="Mf723ARW2RzN8SGgpeqp46" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="LhflWM3PkNaQIrD2BqYlPs" Name="Notifications" Kind="OutputPin" />
                 <Pin Id="Alq2MbGvluFL2H8ysnVdlx" Name="On Data" Kind="OutputPin" />
               </Node>
               <Pad Id="PgOyIIBS1UjO81xz7MFfx4" SlotId="MTyH8tiTnBIPsK3HvkBiCl" Bounds="865,85" />
               <Pad Id="RdX4q23FTMOLOsmBrKH2EL" SlotId="MTyH8tiTnBIPsK3HvkBiCl" Bounds="852,611" />
-              <Node Bounds="826,672,231,164" Id="E5cgCOuStztLVZq5QfPCgX">
+              <Node Bounds="826,672,215,164" Id="E5cgCOuStztLVZq5QfPCgX">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -1699,7 +1723,7 @@
                     <Pin Id="DQukzf0OZhwLS5oqreSUWW" Name="Result" Kind="OutputPin" />
                     <Pin Id="QbQYzkSl8ZPNSUZeosCef8" Name="Success" Kind="OutputPin" />
                   </Node>
-                  <Pad Id="OozqFhg9hfEPfQisdcLNnY" Comment="" Bounds="899,760,127,15" ShowValueBox="true" isIOBox="true">
+                  <Pad Id="OozqFhg9hfEPfQisdcLNnY" Comment="" Bounds="907,770,103,41" ShowValueBox="true" isIOBox="true">
                     <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Object" />
                     </p:TypeAnnotation>
@@ -2211,5 +2235,5 @@
   </Patch>
   <DocumentDependency Id="VfR0N0EgIyQNqB5IA1Jntc" Location="../../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="ETiJvGx8i15OnhOUbS6eRy" Location="../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
-  <NugetDependency Id="NoltsMIQwKdPmftFcfiiKS" Location="VL.IO.OSC" Version="1.1.1" />
+  <NugetDependency Id="NoltsMIQwKdPmftFcfiiKS" Location="VL.IO.OSC" Version="2.0.4" />
 </Document>

--- a/Main/vl/Plugins/OpenDMXOutput/Schema.Plugins.OpenDMXOutput.vl
+++ b/Main/vl/Plugins/OpenDMXOutput/Schema.Plugins.OpenDMXOutput.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="D6SdF81yeDdNJsrQrJhOUy" LanguageVersion="2024.6.4" Version="0.128">
-  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2024.6.4" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="D6SdF81yeDdNJsrQrJhOUy" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Eny9LQLNx9uLh7Foc0vhnV">
     <Canvas Id="RzIPJGd57R3QRCbNzjSDjn" DefaultCategory="Schema.Plugins.OpenDMXOutput" CanvasType="FullCategory">
       <!--
@@ -116,6 +116,7 @@
                 <Pin Id="Md6fQDOMOBsQLcLjJvNdfe" Name="Universe Count" Kind="InputPin" />
                 <Pin Id="VhS51MC3EbHNhnLTmb19N8" Name="Split" Kind="ApplyPin" />
                 <Pin Id="IDYiOwCptuZLSshtPwsiUJ" Name="Reload" Kind="ApplyPin" />
+                <Pin Id="OjYitIuf4RkOQldRDDfFAP" Name="State Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="AmuZqic5cyKLp95JsAyAMt" Name="Output" Kind="OutputPin" />
                 <Pin Id="QIfwIfZn6xEQWURtOUUwB2" Name="Supported Models" Kind="OutputPin" />
                 <Pin Id="B4f4nrJw21mL9c0rTfE5xw" Name="Status" Kind="OutputPin" />
@@ -202,9 +203,8 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="VedtIDoRe4uNPx3COdWpHC" Location="VL.Skia" Version="2024.6.4" />
+  <NugetDependency Id="VedtIDoRe4uNPx3COdWpHC" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="SMtEvYqQ0XBNcOrpsTh0oI" Location="../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="ULkdtBZTTq5PNxOQrRYqVY" Location="ncalc" Version="1.3.8" />
   <DocumentDependency Id="Hhe6QFox9lIOM4DkseNEL1" Location="../DMXOutput/Schema.Plugins.DMXOutput.vl" />
   <DocumentDependency Id="Ecf33yKFz5vL0Qp7y0mjJO" Location="./lib/VL.Devices.OpenDMX.vl" />
 </Document>

--- a/Main/vl/Plugins/Sequences/Blocks/Source/Reference/Schema.Blocks.Source.Reference.SequenceOffset.vl
+++ b/Main/vl/Plugins/Sequences/Blocks/Source/Reference/Schema.Blocks.Source.Reference.SequenceOffset.vl
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="JFf2m4xZUZhLDk9CEGXSVI" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="K7KoVqx0LG1PkX9QH1ggrF" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="JFf2m4xZUZhLDk9CEGXSVI" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="KTeFIGtkG4oPcz7mKAN7u2">
     <Canvas Id="OI1LCR9Jcm4LUrEyi5e002" DefaultCategory="Schema.Plugins.Sequences.Blocks.Source.Reference" CanvasType="FullCategory">
       <!--
@@ -244,9 +243,9 @@
     </Node>
   </Patch>
   <DocumentDependency Id="UlBcYzWobVGQB6LMrLpO2R" Location="../../../../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="LABeGGm7fKVNB748wygc3O" Location="VL.Audio" Version="1.5.0" />
   <DocumentDependency Id="MOFX1NkmOUKNZYEkJlKcFm" Location="../../../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
   <DocumentDependency Id="Khu1uVQJ2mlL1lYYvGhrm8" Location="../../../../../Blocks/Source/Reference/Schema.Blocks.Source.Reference.Fixture.vl" />
   <DocumentDependency Id="FmX6ml7pD1fMagVRM7z6xI" Location="../../../Schema.Plugins.Sequences.vl" />
   <DocumentDependency Id="MySLk7yNIRzPgomganIK2t" Location="../../../Schema.Plugins.Sequences.Common.vl" />
+  <NugetDependency Id="DZbGEtTC91BM719h6ssExx" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/vl/Plugins/Sequences/Blocks/Source/Value/Schema.Blocks.Source.Value.SequenceIndex.vl
+++ b/Main/vl/Plugins/Sequences/Blocks/Source/Value/Schema.Blocks.Source.Value.SequenceIndex.vl
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="GJX6bytUTeIN317b48geNT" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="K7KoVqx0LG1PkX9QH1ggrF" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="GJX6bytUTeIN317b48geNT" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="KTeFIGtkG4oPcz7mKAN7u2">
     <Canvas Id="OI1LCR9Jcm4LUrEyi5e002" DefaultCategory="Schema.Plugins.Sequences.Blocks.Source.Value" CanvasType="FullCategory">
       <!--
@@ -234,9 +233,9 @@
     </Node>
   </Patch>
   <DocumentDependency Id="UlBcYzWobVGQB6LMrLpO2R" Location="../../../../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="LABeGGm7fKVNB748wygc3O" Location="VL.Audio" Version="1.5.0" />
   <DocumentDependency Id="MOFX1NkmOUKNZYEkJlKcFm" Location="../../../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
   <DocumentDependency Id="Khu1uVQJ2mlL1lYYvGhrm8" Location="../../../../../Blocks/Source/Reference/Schema.Blocks.Source.Reference.Fixture.vl" />
   <DocumentDependency Id="FmX6ml7pD1fMagVRM7z6xI" Location="../../../Schema.Plugins.Sequences.vl" />
   <DocumentDependency Id="MySLk7yNIRzPgomganIK2t" Location="../../../Schema.Plugins.Sequences.Common.vl" />
+  <NugetDependency Id="RRHN7H53Z0aObZovo4MCZS" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/vl/Plugins/Sequences/Schema.Plugins.Sequences.vl
+++ b/Main/vl/Plugins/Sequences/Schema.Plugins.Sequences.vl
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="BzPliSG8Tf2MB0xlTZ2wZL" LanguageVersion="2023.5.2" Version="0.128">
-  <NugetDependency Id="DthQJVJ4TnfOcFPMtK9KM2" Location="VL.CoreLib" Version="2023.5.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="BzPliSG8Tf2MB0xlTZ2wZL" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="OTpflJZ8ILoMOTgJ92i3Ck">
     <Canvas Id="MJjcxhV0fIPO8xra3hrfRj" DefaultCategory="Schema.Plugins.Sequences" CanvasType="FullCategory">
       <!--
@@ -176,4 +175,5 @@
   <DocumentDependency Id="CxAgz9QxuUYONuf9h23jkO" Location="../../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="GFIEHXrxcsqOxtmPlg3qLr" Location="./Blocks/Schema.Plugins.Sequences.Blocks.vl" />
   <DocumentDependency Id="SZrFMg23Z4xOLdMcbmLwRW" Location="./Schema.Plugins.Sequences.Common.vl" />
+  <NugetDependency Id="Ni2b524fWFqLIr64ScSbg5" Location="VL.CoreLib" Version="2025.7.0" />
 </Document>

--- a/Main/vl/Plugins/Surfaces/Blocks/Schema.Plugins.Surfaces.Blocks.Combine.Multiply.vl
+++ b/Main/vl/Plugins/Surfaces/Blocks/Schema.Plugins.Surfaces.Blocks.Combine.Multiply.vl
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="Fzxg2JYPLLCMXcpNzHe8v7" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <Patch Id="RazQeVk0O8NPlx2jSpnjPs">
+    <Canvas Id="AjHpOANzdO0PFqJri2Qoxt" DefaultCategory="Schema.Plugins.Surfaces.Blocks.Combine.Texture" CanvasType="FullCategory">
+      <!--
+
+    ************************ MultiplyTextureCombine ************************
+
+-->
+      <Node Name="MultiplyTextureCombine" Bounds="98,100" Id="Fc6DLwrUtiLMlxP9xAJa44">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+          <Choice Kind="ClassDefinition" Name="Class" />
+        </p:NodeReference>
+        <p:Interfaces>
+          <TypeReference LastCategoryFullName="VVVV.Beehive" LastDependency="VVVV.domj.Chapeau.vl">
+            <Choice Kind="InterfaceTypeFlag" Name="IBee" />
+          </TypeReference>
+        </p:Interfaces>
+        <Patch Id="BDHssC6XktqQGKSM6HNBpK">
+          <Canvas Id="HBgC199RIyjO4IUMDLUlaw" CanvasType="Group">
+            <ControlPoint Id="G6uTxjSgdy8LzMBWl5fS80" Bounds="446,63" />
+            <ControlPoint Id="L9iqnvw7ta6O702E9ExuBN" Bounds="448,338" />
+            <Node Bounds="445,112,74,19" Id="OfuGsEizYL4PfRZMlu1rgZ">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Merge" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="CmV9lcdXtJLQds3zPSLZuD" Name="Input" Kind="StateInputPin" />
+              <Pin Id="QabA9zZRcpGMGIHfNtQpiT" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <ControlPoint Id="RNPxVDUPgjiLZqh3HxEqxy" Bounds="223,60" />
+            <Node Bounds="445,275,65,19" Id="KsU04diN57IOHKzmp4uSFw">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Extensions.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Extensions.ResourceMode.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetTexture" />
+              </p:NodeReference>
+              <Pin Id="RQ3RLh37m95OhbyPIs4rv3" Name="Input" Kind="InputPin" />
+              <Pin Id="Uzj396EMeeqMouxAmXTw8t" Name="Value" Kind="InputPin" />
+              <Pin Id="DdZ5HH3152oNSyQx4PQ7ya" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="578,109,193,123" Id="MBdvXEtbKJ3LLKRMNRa2ve">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+              </p:NodeReference>
+              <Pin Id="REH2rMK0iKSLGMFiAy5jYx" Name="Break" Kind="OutputPin" />
+              <Patch Id="Slr2HgK5B0VLqhM8b7ACIc" ManuallySortedPins="true">
+                <Patch Id="BTkQP9huXAsPkOUUnu90Cz" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="V8UIAQdk34oLOSj5WkfjwC" Name="Update" ManuallySortedPins="true">
+                  <Pin Id="OdbdkPNMuWwMfYOZLbd9D7" Name="Index" Kind="InputPin" />
+                </Patch>
+                <Patch Id="Vjf386M6rOKQINLyjySwOz" Name="Dispose" ManuallySortedPins="true" />
+                <Node Bounds="618,141,67,19" Id="MqKiIIzAs7iLCTcqnTs535">
+                  <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Extensions.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Extensions.ResourceMode.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="GetTexture" />
+                  </p:NodeReference>
+                  <Pin Id="JPenNMHxePALVDOUX5RK4S" Name="Input" Kind="InputPin" />
+                  <Pin Id="HJkNy1Fn7koPAjtcxjxWWy" Name="Default" Kind="InputPin" />
+                  <Pin Id="DzVyJOU8Wx5MQtiwu4Ly9Z" Name="Output" Kind="OutputPin" />
+                  <Pin Id="FDZwTqeWOmvMzdce4kDarW" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="645,193,85,19" Id="D5pKuD2cNzcOlKhptcF8lo">
+                  <p:NodeReference LastCategoryFullName="Stride.Textures.Mixer" LastDependency="VL.Stride.TextureFX.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Stride" />
+                    <CategoryReference Kind="Category" Name="Textures" />
+                    <CategoryReference Kind="Category" Name="Mixer" />
+                    <Choice Kind="ProcessAppFlag" Name="Blend" />
+                  </p:NodeReference>
+                  <Pin Id="PoeYZY5IVaXQYuo4MdCbU3" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="Ao2J2EqEQAHLLjHUa4a76T" Name="Input" Kind="InputPin" />
+                  <Pin Id="QEAcGqmsa8ZNXjbZPyM0AE" Name="Sampler" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="TAM3t8Va68eOx5iDC9hpEu" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="JyngaXnC5BiMwyzCRLH1EA" Name="Sampler 2" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="AkG2LKeAkqmMRBlZTlt9yB" Name="Blend Operation" Kind="InputPin" DefaultValue="Multiply" />
+                  <Pin Id="Afd5msHPhyuQRvpyVj9dsx" Name="Fader" Kind="InputPin" />
+                  <Pin Id="IUYGNdXCCRfQd5Fv7TQehw" Name="Output Texture" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="JDSmcylrlxfOYgIReKYQO8" Name="Output Size" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="PlkuiiO8weCONzdAGRfph1" Name="Output Format" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="FqtIDEP0qMlN3yZmEMe1Oi" Name="Apply" Kind="InputPin" />
+                  <Pin Id="FIyHddLJsAKOM0HXUyAc8k" Name="Output" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="BM1WWD2XZprN25sHmYS3FR" Bounds="722,146" />
+                <Node Bounds="729,161,27,19" Id="HjQe74DhMyTL2j1LwkH2tP">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="!=" />
+                  </p:NodeReference>
+                  <Pin Id="Dsl0dxvcOgcM2LKOf7xVre" Name="Input" Kind="InputPin" />
+                  <Pin Id="IzYucCvUYcTO9rdgwVsMPb" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="NWbe749OsB4Os5yFLqruv2" Name="Result" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="Aqq1TVQFWKELxf9kyLNXq4" Bounds="592,115" Alignment="Top" />
+              <ControlPoint Id="IWNiGMt8vfZO97actZw5P8" Bounds="648,115" Alignment="Top" />
+              <ControlPoint Id="KCyh3AZM3IOND8OZjn8OL6" Bounds="648,226" Alignment="Bottom" />
+            </Node>
+          </Canvas>
+          <Patch Id="FQblJsNf0WLN4USmEVCqJV" Name="Create" />
+          <ProcessDefinition Id="E2Iof7VH3UVOk0JZFYtqHh" IsHidden="true">
+            <Fragment Id="T29JRlNH08xOmMOzGMqTVd" Patch="FQblJsNf0WLN4USmEVCqJV" Enabled="true" />
+            <Fragment Id="HuYvaCf27zAPa6Z5x9DS95" Patch="AoVhwrdwm2nOkUlg6sznYr" Enabled="true" />
+            <Fragment Id="BEHuDYBIoEjOxNitKYQW7M" Patch="VAUcp89XjDoQVecTtuvgti" Enabled="true" />
+            <Fragment Id="IPkdWrx3jLfOayNzdO7ahN" Patch="JYvD36hCiwdN6MiC4EKj64" Enabled="true" />
+            <Fragment Id="OWWwBlPo1hrMOeEN1w9hGE" Patch="JYdLEQ7YLCxPKb3dMajeQx" Enabled="true" />
+          </ProcessDefinition>
+          <Patch Id="AoVhwrdwm2nOkUlg6sznYr" Name="Update">
+            <Pin Id="DxdorEBEingNsOO7BaT1c4" Name="Setup" Kind="InputPin" />
+            <Pin Id="QWOi5hvziurOfuGUT1QlQo" Name="State" Kind="InputPin" />
+            <Pin Id="ViJp3Uv0TMKN5BuTpL8xy0" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="Nwgsnm5200DQFlKeSFg8wV" Name="Global" Kind="InputPin" />
+            <Pin Id="ESi9XHEKJojQcu4iwg7CjG" Name="Properties" Kind="InputPin" />
+            <Pin Id="PgrSN9EUZwHQLufYEZ8eMW" Name="New State" Kind="OutputPin" />
+            <Pin Id="Nd7iFLuuhi6QCqi3ocRdqE" Name="Node Operation" Kind="OutputPin" />
+          </Patch>
+          <Link Id="ERBjnyf2XwHLi16tFgaaLw" Ids="QWOi5hvziurOfuGUT1QlQo,G6uTxjSgdy8LzMBWl5fS80" IsHidden="true" />
+          <Link Id="Jzr2xovRSBYNlh9fLYy93q" Ids="L9iqnvw7ta6O702E9ExuBN,PgrSN9EUZwHQLufYEZ8eMW" IsHidden="true" />
+          <Link Id="FPrCzPKyOQ7PhA3p63HlIH" Ids="G6uTxjSgdy8LzMBWl5fS80,CmV9lcdXtJLQds3zPSLZuD" />
+          <Patch Id="VAUcp89XjDoQVecTtuvgti" Name="Provides">
+            <Pin Id="ExsY2VF3UOVMZpMPIngKci" Name="Color" Kind="OutputPin" />
+            <Pin Id="CXLCTtNitTUNmvTGACDh2Y" Name="Pick" Kind="OutputPin" />
+            <Pin Id="GEAUEAxzC0qOAtKb6xFj0z" Name="Gate" Kind="OutputPin" />
+            <Pin Id="OMB4nWdTJtNPBXTnuVdi4L" Name="Own Color" Kind="OutputPin" />
+            <Pin Id="Qfueb2xMViOMgIbDVWlgzH" Name="Text" Kind="OutputPin" />
+            <Pin Id="Vf9zIHA16m3PUh2cVZh2j5" Name="Progress" Kind="OutputPin" />
+            <Pin Id="ASkd2AXjPLHMbZ1OF5gtgq" Name="Levels" Kind="OutputPin" />
+            <Pin Id="G1TAb9DKLEnMPfbjXXj6EF" Name="Active Levels" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYvD36hCiwdN6MiC4EKj64" Name="GetColor">
+            <Pin Id="KU7IpArLZeNMkQNWjtr6ZD" Name="Color" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYdLEQ7YLCxPKb3dMajeQx" Name="GetPropertyDefinitions">
+            <Pin Id="Ese2ztGBvEaOamqQIbKuBX" Name="Properties" Kind="OutputPin" />
+          </Patch>
+          <Link Id="LakvuEkHA85L9BzSZZvhGq" Ids="ESi9XHEKJojQcu4iwg7CjG,RNPxVDUPgjiLZqh3HxEqxy" IsHidden="true" />
+          <Link Id="H8G23UWxFdSO0BX8z5jH1q" Ids="QabA9zZRcpGMGIHfNtQpiT,RQ3RLh37m95OhbyPIs4rv3" />
+          <Link Id="Bv3ePCJsnczOYHLWO7m1WB" Ids="DdZ5HH3152oNSyQx4PQ7ya,L9iqnvw7ta6O702E9ExuBN" />
+          <Link Id="VqCmrnRKcFEPKLmINBaTZQ" Ids="G6uTxjSgdy8LzMBWl5fS80,Aqq1TVQFWKELxf9kyLNXq4" />
+          <Link Id="EnuvKsvbx5XMLfril8llF4" Ids="Aqq1TVQFWKELxf9kyLNXq4,JPenNMHxePALVDOUX5RK4S" />
+          <Link Id="I3gUMq4PBi4OYetr5nEsiL" Ids="OdbdkPNMuWwMfYOZLbd9D7,BM1WWD2XZprN25sHmYS3FR" IsHidden="true" />
+          <Link Id="SS2Aea0Ag2yLbYnMkBn0xr" Ids="BM1WWD2XZprN25sHmYS3FR,Dsl0dxvcOgcM2LKOf7xVre" />
+          <Link Id="NuTtF8tvm6QPUKCmbIpTHP" Ids="NWbe749OsB4Os5yFLqruv2,FqtIDEP0qMlN3yZmEMe1Oi" />
+          <Link Id="Em8UveY5cVCLVnJfG7A528" Ids="IWNiGMt8vfZO97actZw5P8,KCyh3AZM3IOND8OZjn8OL6" IsFeedback="true" />
+          <Link Id="QQ9cNyKuW9BPGURiWjk9AJ" Ids="FIyHddLJsAKOM0HXUyAc8k,KCyh3AZM3IOND8OZjn8OL6" />
+          <Link Id="Pxcu6sA06tZLtkDZmOrRHF" Ids="KCyh3AZM3IOND8OZjn8OL6,Uzj396EMeeqMouxAmXTw8t" />
+          <Link Id="JR33UWXZIwiQVrKlSKWaSe" Ids="FDZwTqeWOmvMzdce4kDarW,Ao2J2EqEQAHLLjHUa4a76T" />
+          <Link Id="CDjEmFpAAgUO2LDlE3s1Jl" Ids="IWNiGMt8vfZO97actZw5P8,TAM3t8Va68eOx5iDC9hpEu" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="RCKiHBrLdcZPG7jFRmFgin">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="K6NpIgswrghPmoVYMiy9VS">
+        <Canvas Id="Dz992g9vlFnOPw1v4Uwqj8" CanvasType="Group" />
+        <Patch Id="ES9epZJHgV1PILstcerFrF" Name="Create" />
+        <Patch Id="GZtpz52P0agNh112TUU7yP" Name="Update" />
+        <ProcessDefinition Id="BzfKXFFCeF4Mr3Mvpz7Zke">
+          <Fragment Id="SSlvRu502zqNI2XNqdlj35" Patch="ES9epZJHgV1PILstcerFrF" Enabled="true" />
+          <Fragment Id="EMaCNGaAWgLLSWSrUBE1mL" Patch="GZtpz52P0agNh112TUU7yP" Enabled="true" />
+          <Fragment Id="O3jGv7VXNhhLoeikprCF7f" Patch="RA7eMM0t8g8Ln8KI3q9jBH" Enabled="true" />
+        </ProcessDefinition>
+        <Patch Id="RA7eMM0t8g8Ln8KI3q9jBH" Name="GetPropertyDefinitions" />
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="K4GyEFI8eHdNHJSouTEzpo" Location="../../../VVVV.Schema.Core.vl" />
+  <NugetDependency Id="Je7zHyD3zlJNmV09l4msvM" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <DocumentDependency Id="NogtWOJFOafOzfi7419iNE" Location="../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
+  <DocumentDependency Id="Ly2zG77hs3BPAaSo3tPRRb" Location="../Extensions/Schema.Plugins.Surfaces.Extensions.ResourceMode.vl" />
+  <NugetDependency Id="BpgT2EmMVWiQVceFZXpcAh" Location="VL.Stride.TextureFX" Version="2025.7.0-0002-g93330f7cea" />
+</Document>

--- a/Main/vl/Plugins/Surfaces/Blocks/Schema.Plugins.Surfaces.Blocks.Source.Texture.Color.vl
+++ b/Main/vl/Plugins/Surfaces/Blocks/Schema.Plugins.Surfaces.Blocks.Source.Texture.Color.vl
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="FWH2d3gizlxLVqHhAjqFWI" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <Patch Id="RazQeVk0O8NPlx2jSpnjPs">
+    <Canvas Id="AjHpOANzdO0PFqJri2Qoxt" DefaultCategory="Schema.Plugins.Surfaces.Blocks.Source.Texture" CanvasType="FullCategory">
+      <!--
+
+    ************************ ColorTextureSource ************************
+
+-->
+      <Node Name="ColorTextureSource" Bounds="98,100" Id="Fc6DLwrUtiLMlxP9xAJa44">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+          <Choice Kind="ClassDefinition" Name="Class" />
+        </p:NodeReference>
+        <p:Interfaces>
+          <TypeReference LastCategoryFullName="VVVV.Beehive" LastDependency="VVVV.domj.Chapeau.vl">
+            <Choice Kind="InterfaceTypeFlag" Name="IBee" />
+          </TypeReference>
+        </p:Interfaces>
+        <Patch Id="BDHssC6XktqQGKSM6HNBpK">
+          <Canvas Id="HBgC199RIyjO4IUMDLUlaw" CanvasType="Group">
+            <ControlPoint Id="G6uTxjSgdy8LzMBWl5fS80" Bounds="446,63" />
+            <ControlPoint Id="L9iqnvw7ta6O702E9ExuBN" Bounds="448,227" />
+            <Node Bounds="445,112,74,19" Id="OfuGsEizYL4PfRZMlu1rgZ">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Merge" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="CmV9lcdXtJLQds3zPSLZuD" Name="Input" Kind="StateInputPin" />
+              <Pin Id="QabA9zZRcpGMGIHfNtQpiT" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <ControlPoint Id="RNPxVDUPgjiLZqh3HxEqxy" Bounds="223,60" />
+            <ControlPoint Id="HdTwQ7z47aDLaXFWG5NuAE" Bounds="62,252" />
+            <Node Bounds="59,97,79,19" Id="AtIRIirfVYtNeAQ8kYjtGH">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CreateDefault" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="Fzgiv19aVodOOJ0RLpiEyt" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="61,193,77,26" Id="R8tEY2E5DjEMioPo2504WI">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToImmutable" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="OVyi8O1xbw7Py4qRzLz1ds" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MngPL5tU0AgMjgAzZrafNA" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="LROiZ31V07oOOJv9xe2rO8" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="61,150,165,19" Id="VfykYysDrZpO6ezQGdXxzn">
+              <p:NodeReference LastCategoryFullName="Schema.PropertyDefinition.Helpers" LastDependency="Schema.PropertyDefinition.Helpers.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Schema" />
+                <CategoryReference Kind="Category" Name="PropertyDefinition" />
+                <CategoryReference Kind="Category" Name="Helpers" />
+                <Choice Kind="ProcessAppFlag" Name="Color" />
+              </p:NodeReference>
+              <Pin Id="U0dK2U0n3WJQJu1G8Fpfa3" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="RkH1rtViVdGOjuNwPlfwBe" Name="Input" Kind="InputPin" />
+              <Pin Id="IrLMmj9IPNuLGAkqV0nZOG" Name="Key" Kind="InputPin" />
+              <Pin Id="KiTc6RSjNfiMYMLzKHlzVz" Name="Default" Kind="InputPin" />
+              <Pin Id="SYGCi9qzBJxMAtWTqxY9Hc" Name="Min" Kind="InputPin" />
+              <Pin Id="SdtruMGbKIvQARfGwNWgWu" Name="Max" Kind="InputPin" />
+              <Pin Id="AT9rPF0bdHeOpbAXNbnd8m" Name="Step" Kind="InputPin" />
+              <Pin Id="PEj8t5kzIN5O2oSmaxVvbs" Name="Tooltip" Kind="InputPin" />
+              <Pin Id="PbdI1vc1ZSVPPOEfcCqvPq" Name="Properties" Kind="InputPin" />
+              <Pin Id="QWthdPfoNKVPwOaNJfwfTf" Name="Properties" Kind="OutputPin" />
+              <Pin Id="Up5LzKadD8CL4XFy00q4V5" Name="Output" Kind="OutputPin" />
+              <Pin Id="IPOEPQ07THbMDHOhtV26cs" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="445,164,65,19" Id="KsU04diN57IOHKzmp4uSFw">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Extensions.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Extensions.ResourceMode.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetTexture" />
+              </p:NodeReference>
+              <Pin Id="RQ3RLh37m95OhbyPIs4rv3" Name="Input" Kind="InputPin" />
+              <Pin Id="Uzj396EMeeqMouxAmXTw8t" Name="Value" Kind="InputPin" />
+              <Pin Id="DdZ5HH3152oNSyQx4PQ7ya" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="505,139,45,19" Id="CL1xi7Po950MT6ruewSQzA">
+              <p:NodeReference LastCategoryFullName="Stride.Textures.Source" LastDependency="VL.Stride.TextureFX.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Source" />
+                <Choice Kind="ProcessNode" Name="Color" />
+              </p:NodeReference>
+              <Pin Id="NsumhHD6MaGOre0n01wf3m" Name="Color" Kind="InputPin" />
+              <Pin Id="TYmhs9IwigkM5WvSh8ANAs" Name="Output Size" Kind="InputPin" />
+              <Pin Id="OGpBHYcGi1XORipBY7SfUD" Name="Output Format" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Qcnfpk0SfkkPNVT5dbreNQ" Name="Render Format" Kind="InputPin" IsHidden="true" />
+              <Pin Id="AIyFnUN1mgPNkCIzJJjXaG" Name="Output Texture" Kind="InputPin" IsHidden="true" />
+              <Pin Id="JOYtKThZLJBMAUgx6Xwkzx" Name="Enabled" Kind="InputPin" />
+              <Pin Id="VgRZIJNzXqpMZHGmzwAsbI" Name="Output" Kind="OutputPin" />
+            </Node>
+          </Canvas>
+          <Patch Id="FQblJsNf0WLN4USmEVCqJV" Name="Create" />
+          <ProcessDefinition Id="E2Iof7VH3UVOk0JZFYtqHh" IsHidden="true">
+            <Fragment Id="T29JRlNH08xOmMOzGMqTVd" Patch="FQblJsNf0WLN4USmEVCqJV" Enabled="true" />
+            <Fragment Id="HuYvaCf27zAPa6Z5x9DS95" Patch="AoVhwrdwm2nOkUlg6sznYr" Enabled="true" />
+            <Fragment Id="BEHuDYBIoEjOxNitKYQW7M" Patch="VAUcp89XjDoQVecTtuvgti" Enabled="true" />
+            <Fragment Id="IPkdWrx3jLfOayNzdO7ahN" Patch="JYvD36hCiwdN6MiC4EKj64" Enabled="true" />
+            <Fragment Id="OWWwBlPo1hrMOeEN1w9hGE" Patch="JYdLEQ7YLCxPKb3dMajeQx" Enabled="true" />
+          </ProcessDefinition>
+          <Patch Id="AoVhwrdwm2nOkUlg6sznYr" Name="Update">
+            <Pin Id="DxdorEBEingNsOO7BaT1c4" Name="Setup" Kind="InputPin" />
+            <Pin Id="QWOi5hvziurOfuGUT1QlQo" Name="State" Kind="InputPin" />
+            <Pin Id="ViJp3Uv0TMKN5BuTpL8xy0" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="Nwgsnm5200DQFlKeSFg8wV" Name="Global" Kind="InputPin" />
+            <Pin Id="ESi9XHEKJojQcu4iwg7CjG" Name="Properties" Kind="InputPin" />
+            <Pin Id="PgrSN9EUZwHQLufYEZ8eMW" Name="New State" Kind="OutputPin" />
+            <Pin Id="Nd7iFLuuhi6QCqi3ocRdqE" Name="Node Operation" Kind="OutputPin" />
+          </Patch>
+          <Link Id="ERBjnyf2XwHLi16tFgaaLw" Ids="QWOi5hvziurOfuGUT1QlQo,G6uTxjSgdy8LzMBWl5fS80" IsHidden="true" />
+          <Link Id="Jzr2xovRSBYNlh9fLYy93q" Ids="L9iqnvw7ta6O702E9ExuBN,PgrSN9EUZwHQLufYEZ8eMW" IsHidden="true" />
+          <Link Id="FPrCzPKyOQ7PhA3p63HlIH" Ids="G6uTxjSgdy8LzMBWl5fS80,CmV9lcdXtJLQds3zPSLZuD" />
+          <Patch Id="VAUcp89XjDoQVecTtuvgti" Name="Provides">
+            <Pin Id="ExsY2VF3UOVMZpMPIngKci" Name="Color" Kind="OutputPin" />
+            <Pin Id="CXLCTtNitTUNmvTGACDh2Y" Name="Pick" Kind="OutputPin" />
+            <Pin Id="GEAUEAxzC0qOAtKb6xFj0z" Name="Gate" Kind="OutputPin" />
+            <Pin Id="OMB4nWdTJtNPBXTnuVdi4L" Name="Own Color" Kind="OutputPin" />
+            <Pin Id="Qfueb2xMViOMgIbDVWlgzH" Name="Text" Kind="OutputPin" />
+            <Pin Id="Vf9zIHA16m3PUh2cVZh2j5" Name="Progress" Kind="OutputPin" />
+            <Pin Id="ASkd2AXjPLHMbZ1OF5gtgq" Name="Levels" Kind="OutputPin" />
+            <Pin Id="G1TAb9DKLEnMPfbjXXj6EF" Name="Active Levels" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYvD36hCiwdN6MiC4EKj64" Name="GetColor">
+            <Pin Id="KU7IpArLZeNMkQNWjtr6ZD" Name="Color" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYdLEQ7YLCxPKb3dMajeQx" Name="GetPropertyDefinitions">
+            <Pin Id="LO8eH78NDSkMrj1WAy6tqK" Name="Properties" Kind="OutputPin" />
+          </Patch>
+          <Link Id="LakvuEkHA85L9BzSZZvhGq" Ids="ESi9XHEKJojQcu4iwg7CjG,RNPxVDUPgjiLZqh3HxEqxy" IsHidden="true" />
+          <Link Id="P9OpklLGJgJL9WMi74LUqG" Ids="LROiZ31V07oOOJv9xe2rO8,HdTwQ7z47aDLaXFWG5NuAE" />
+          <Link Id="SoRqhHyOjfoMawj0jncGpt" Ids="HdTwQ7z47aDLaXFWG5NuAE,LO8eH78NDSkMrj1WAy6tqK" IsHidden="true" />
+          <Link Id="CHssp7DzwtoP2osMzj7RKA" Ids="Fzgiv19aVodOOJ0RLpiEyt,RkH1rtViVdGOjuNwPlfwBe" />
+          <Link Id="Dw4v6YP1EH2OOOQ2HvUSQ6" Ids="QWthdPfoNKVPwOaNJfwfTf,OVyi8O1xbw7Py4qRzLz1ds" />
+          <Link Id="OGPnnoCwOl9NCQLFz4qFlR" Ids="VgRZIJNzXqpMZHGmzwAsbI,Uzj396EMeeqMouxAmXTw8t" />
+          <Link Id="H8G23UWxFdSO0BX8z5jH1q" Ids="QabA9zZRcpGMGIHfNtQpiT,RQ3RLh37m95OhbyPIs4rv3" />
+          <Link Id="Bv3ePCJsnczOYHLWO7m1WB" Ids="DdZ5HH3152oNSyQx4PQ7ya,L9iqnvw7ta6O702E9ExuBN" />
+          <Link Id="JNJIJw1RrrkNaAO6e8CA4u" Ids="RNPxVDUPgjiLZqh3HxEqxy,PbdI1vc1ZSVPPOEfcCqvPq" />
+          <Link Id="SJwFW3MHLm5PlG8WixqEtS" Ids="IPOEPQ07THbMDHOhtV26cs,NsumhHD6MaGOre0n01wf3m" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="RCKiHBrLdcZPG7jFRmFgin">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="K6NpIgswrghPmoVYMiy9VS">
+        <Canvas Id="Dz992g9vlFnOPw1v4Uwqj8" CanvasType="Group" />
+        <Patch Id="ES9epZJHgV1PILstcerFrF" Name="Create" />
+        <Patch Id="GZtpz52P0agNh112TUU7yP" Name="Update" />
+        <ProcessDefinition Id="BzfKXFFCeF4Mr3Mvpz7Zke">
+          <Fragment Id="SSlvRu502zqNI2XNqdlj35" Patch="ES9epZJHgV1PILstcerFrF" Enabled="true" />
+          <Fragment Id="EMaCNGaAWgLLSWSrUBE1mL" Patch="GZtpz52P0agNh112TUU7yP" Enabled="true" />
+          <Fragment Id="O3jGv7VXNhhLoeikprCF7f" Patch="RA7eMM0t8g8Ln8KI3q9jBH" Enabled="true" />
+        </ProcessDefinition>
+        <Patch Id="RA7eMM0t8g8Ln8KI3q9jBH" Name="GetPropertyDefinitions" />
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="K4GyEFI8eHdNHJSouTEzpo" Location="../../../VVVV.Schema.Core.vl" />
+  <NugetDependency Id="Je7zHyD3zlJNmV09l4msvM" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <DocumentDependency Id="NogtWOJFOafOzfi7419iNE" Location="../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
+  <DocumentDependency Id="Ly2zG77hs3BPAaSo3tPRRb" Location="../Extensions/Schema.Plugins.Surfaces.Extensions.ResourceMode.vl" />
+  <NugetDependency Id="BpgT2EmMVWiQVceFZXpcAh" Location="VL.Stride.TextureFX" Version="2025.7.0-0002-g93330f7cea" />
+</Document>

--- a/Main/vl/Plugins/Surfaces/Blocks/Schema.Plugins.Surfaces.Blocks.Source.Texture.Noise.vl
+++ b/Main/vl/Plugins/Surfaces/Blocks/Schema.Plugins.Surfaces.Blocks.Source.Texture.Noise.vl
@@ -1,0 +1,191 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="HnnCI67Uc15PHirZRsV50L" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <Patch Id="RazQeVk0O8NPlx2jSpnjPs">
+    <Canvas Id="AjHpOANzdO0PFqJri2Qoxt" DefaultCategory="Schema.Plugins.Surfaces.Blocks.Source.Texture" CanvasType="FullCategory">
+      <!--
+
+    ************************ NoiseTextureSource ************************
+
+-->
+      <Node Name="NoiseTextureSource" Bounds="98,100" Id="Fc6DLwrUtiLMlxP9xAJa44">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+          <Choice Kind="ClassDefinition" Name="Class" />
+        </p:NodeReference>
+        <p:Interfaces>
+          <TypeReference LastCategoryFullName="VVVV.Beehive" LastDependency="VVVV.domj.Chapeau.vl">
+            <Choice Kind="InterfaceTypeFlag" Name="IBee" />
+          </TypeReference>
+        </p:Interfaces>
+        <Patch Id="BDHssC6XktqQGKSM6HNBpK">
+          <Canvas Id="HBgC199RIyjO4IUMDLUlaw" CanvasType="Group">
+            <ControlPoint Id="G6uTxjSgdy8LzMBWl5fS80" Bounds="446,63" />
+            <ControlPoint Id="L9iqnvw7ta6O702E9ExuBN" Bounds="448,279" />
+            <Node Bounds="445,112,74,19" Id="OfuGsEizYL4PfRZMlu1rgZ">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Merge" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="CmV9lcdXtJLQds3zPSLZuD" Name="Input" Kind="StateInputPin" />
+              <Pin Id="QabA9zZRcpGMGIHfNtQpiT" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <ControlPoint Id="RNPxVDUPgjiLZqh3HxEqxy" Bounds="223,60" />
+            <ControlPoint Id="HdTwQ7z47aDLaXFWG5NuAE" Bounds="62,252" />
+            <Node Bounds="59,97,79,19" Id="AtIRIirfVYtNeAQ8kYjtGH">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CreateDefault" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="Fzgiv19aVodOOJ0RLpiEyt" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Node Bounds="61,193,77,26" Id="R8tEY2E5DjEMioPo2504WI">
+              <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToImmutable" />
+                <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="OVyi8O1xbw7Py4qRzLz1ds" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MngPL5tU0AgMjgAzZrafNA" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="LROiZ31V07oOOJv9xe2rO8" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="61,150,185,19" Id="VfykYysDrZpO6ezQGdXxzn">
+              <p:NodeReference LastCategoryFullName="Schema.PropertyDefinition.Helpers" LastDependency="Schema.PropertyDefinition.Helpers.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Schema" />
+                <CategoryReference Kind="Category" Name="PropertyDefinition" />
+                <CategoryReference Kind="Category" Name="Helpers" />
+                <Choice Kind="ProcessAppFlag" Name="Float32" />
+              </p:NodeReference>
+              <Pin Id="U0dK2U0n3WJQJu1G8Fpfa3" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="RkH1rtViVdGOjuNwPlfwBe" Name="Input" Kind="InputPin" />
+              <Pin Id="IrLMmj9IPNuLGAkqV0nZOG" Name="Key" Kind="InputPin" />
+              <Pin Id="KiTc6RSjNfiMYMLzKHlzVz" Name="Default" Kind="InputPin" />
+              <Pin Id="SYGCi9qzBJxMAtWTqxY9Hc" Name="Min" Kind="InputPin" />
+              <Pin Id="SdtruMGbKIvQARfGwNWgWu" Name="Max" Kind="InputPin" />
+              <Pin Id="AT9rPF0bdHeOpbAXNbnd8m" Name="Step" Kind="InputPin" />
+              <Pin Id="LGocIzIqq46MRoM7haRt82" Name="Type" Kind="InputPin" />
+              <Pin Id="PEj8t5kzIN5O2oSmaxVvbs" Name="Tooltip" Kind="InputPin" />
+              <Pin Id="Q6SSSHoTa7OMcnQH9YzPBh" Name="Unit" Kind="InputPin" />
+              <Pin Id="PbdI1vc1ZSVPPOEfcCqvPq" Name="Properties" Kind="InputPin" />
+              <Pin Id="QWthdPfoNKVPwOaNJfwfTf" Name="Properties" Kind="OutputPin" />
+              <Pin Id="Up5LzKadD8CL4XFy00q4V5" Name="Output" Kind="OutputPin" />
+              <Pin Id="IPOEPQ07THbMDHOhtV26cs" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="445,216,65,19" Id="KsU04diN57IOHKzmp4uSFw">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Extensions.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Extensions.ResourceMode.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SetTexture" />
+              </p:NodeReference>
+              <Pin Id="RQ3RLh37m95OhbyPIs4rv3" Name="Input" Kind="InputPin" />
+              <Pin Id="Uzj396EMeeqMouxAmXTw8t" Name="Value" Kind="InputPin" />
+              <Pin Id="DdZ5HH3152oNSyQx4PQ7ya" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="505,191,125,19" Id="CL1xi7Po950MT6ruewSQzA">
+              <p:NodeReference LastCategoryFullName="Stride.Textures.Source" LastDependency="VL.Stride.TextureFX.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Source" />
+                <Choice Kind="ProcessNode" Name="Noise" />
+              </p:NodeReference>
+              <Pin Id="LlLtDoTNujNLChE5HJ0jPZ" Name="Type" Kind="InputPin" />
+              <Pin Id="UETAza13jr0Lii5DU7MPqh" Name="Scale" Kind="InputPin" />
+              <Pin Id="ChfD4qp6LpnMxiFOfkOTBe" Name="Offset" Kind="InputPin" />
+              <Pin Id="F7a0PjIRgSSM4Sqn8EcquZ" Name="Z" Kind="InputPin" />
+              <Pin Id="TYmhs9IwigkM5WvSh8ANAs" Name="Output Size" Kind="InputPin" />
+              <Pin Id="OGpBHYcGi1XORipBY7SfUD" Name="Output Format" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Qcnfpk0SfkkPNVT5dbreNQ" Name="Render Format" Kind="InputPin" IsHidden="true" />
+              <Pin Id="AIyFnUN1mgPNkCIzJJjXaG" Name="Output Texture" Kind="InputPin" IsHidden="true" />
+              <Pin Id="JOYtKThZLJBMAUgx6Xwkzx" Name="Enabled" Kind="InputPin" />
+              <Pin Id="VgRZIJNzXqpMZHGmzwAsbI" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="553,156,46,19" Id="UCBk8HNIdhlLB1LU4t7Pbf">
+              <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="4043309057" Name="Vector2" />
+                <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+              </p:NodeReference>
+              <Pin Id="QF9bfuh2dILP9vieDq4T5t" Name="X" Kind="InputPin" />
+              <Pin Id="PGbLh6jbbY6PU7cJccXZD9" Name="Y" Kind="InputPin" />
+              <Pin Id="NqGyAsAWK69NMQhuSjbcNz" Name="Output" Kind="StateOutputPin" />
+            </Node>
+          </Canvas>
+          <Patch Id="FQblJsNf0WLN4USmEVCqJV" Name="Create" />
+          <ProcessDefinition Id="E2Iof7VH3UVOk0JZFYtqHh" IsHidden="true">
+            <Fragment Id="T29JRlNH08xOmMOzGMqTVd" Patch="FQblJsNf0WLN4USmEVCqJV" Enabled="true" />
+            <Fragment Id="HuYvaCf27zAPa6Z5x9DS95" Patch="AoVhwrdwm2nOkUlg6sznYr" Enabled="true" />
+            <Fragment Id="BEHuDYBIoEjOxNitKYQW7M" Patch="VAUcp89XjDoQVecTtuvgti" Enabled="true" />
+            <Fragment Id="IPkdWrx3jLfOayNzdO7ahN" Patch="JYvD36hCiwdN6MiC4EKj64" Enabled="true" />
+            <Fragment Id="OWWwBlPo1hrMOeEN1w9hGE" Patch="JYdLEQ7YLCxPKb3dMajeQx" Enabled="true" />
+          </ProcessDefinition>
+          <Patch Id="AoVhwrdwm2nOkUlg6sznYr" Name="Update">
+            <Pin Id="DxdorEBEingNsOO7BaT1c4" Name="Setup" Kind="InputPin" />
+            <Pin Id="QWOi5hvziurOfuGUT1QlQo" Name="State" Kind="InputPin" />
+            <Pin Id="ViJp3Uv0TMKN5BuTpL8xy0" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="Nwgsnm5200DQFlKeSFg8wV" Name="Global" Kind="InputPin" />
+            <Pin Id="ESi9XHEKJojQcu4iwg7CjG" Name="Properties" Kind="InputPin" />
+            <Pin Id="PgrSN9EUZwHQLufYEZ8eMW" Name="New State" Kind="OutputPin" />
+            <Pin Id="Nd7iFLuuhi6QCqi3ocRdqE" Name="Node Operation" Kind="OutputPin" />
+          </Patch>
+          <Link Id="ERBjnyf2XwHLi16tFgaaLw" Ids="QWOi5hvziurOfuGUT1QlQo,G6uTxjSgdy8LzMBWl5fS80" IsHidden="true" />
+          <Link Id="Jzr2xovRSBYNlh9fLYy93q" Ids="L9iqnvw7ta6O702E9ExuBN,PgrSN9EUZwHQLufYEZ8eMW" IsHidden="true" />
+          <Link Id="FPrCzPKyOQ7PhA3p63HlIH" Ids="G6uTxjSgdy8LzMBWl5fS80,CmV9lcdXtJLQds3zPSLZuD" />
+          <Patch Id="VAUcp89XjDoQVecTtuvgti" Name="Provides">
+            <Pin Id="ExsY2VF3UOVMZpMPIngKci" Name="Color" Kind="OutputPin" />
+            <Pin Id="CXLCTtNitTUNmvTGACDh2Y" Name="Pick" Kind="OutputPin" />
+            <Pin Id="GEAUEAxzC0qOAtKb6xFj0z" Name="Gate" Kind="OutputPin" />
+            <Pin Id="OMB4nWdTJtNPBXTnuVdi4L" Name="Own Color" Kind="OutputPin" />
+            <Pin Id="Qfueb2xMViOMgIbDVWlgzH" Name="Text" Kind="OutputPin" />
+            <Pin Id="Vf9zIHA16m3PUh2cVZh2j5" Name="Progress" Kind="OutputPin" />
+            <Pin Id="ASkd2AXjPLHMbZ1OF5gtgq" Name="Levels" Kind="OutputPin" />
+            <Pin Id="G1TAb9DKLEnMPfbjXXj6EF" Name="Active Levels" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYvD36hCiwdN6MiC4EKj64" Name="GetColor">
+            <Pin Id="KU7IpArLZeNMkQNWjtr6ZD" Name="Color" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JYdLEQ7YLCxPKb3dMajeQx" Name="GetPropertyDefinitions">
+            <Pin Id="LO8eH78NDSkMrj1WAy6tqK" Name="Properties" Kind="OutputPin" />
+          </Patch>
+          <Link Id="LakvuEkHA85L9BzSZZvhGq" Ids="ESi9XHEKJojQcu4iwg7CjG,RNPxVDUPgjiLZqh3HxEqxy" IsHidden="true" />
+          <Link Id="P9OpklLGJgJL9WMi74LUqG" Ids="LROiZ31V07oOOJv9xe2rO8,HdTwQ7z47aDLaXFWG5NuAE" />
+          <Link Id="SoRqhHyOjfoMawj0jncGpt" Ids="HdTwQ7z47aDLaXFWG5NuAE,LO8eH78NDSkMrj1WAy6tqK" IsHidden="true" />
+          <Link Id="CHssp7DzwtoP2osMzj7RKA" Ids="Fzgiv19aVodOOJ0RLpiEyt,RkH1rtViVdGOjuNwPlfwBe" />
+          <Link Id="Dw4v6YP1EH2OOOQ2HvUSQ6" Ids="QWthdPfoNKVPwOaNJfwfTf,OVyi8O1xbw7Py4qRzLz1ds" />
+          <Link Id="OGPnnoCwOl9NCQLFz4qFlR" Ids="VgRZIJNzXqpMZHGmzwAsbI,Uzj396EMeeqMouxAmXTw8t" />
+          <Link Id="H8G23UWxFdSO0BX8z5jH1q" Ids="QabA9zZRcpGMGIHfNtQpiT,RQ3RLh37m95OhbyPIs4rv3" />
+          <Link Id="Bv3ePCJsnczOYHLWO7m1WB" Ids="DdZ5HH3152oNSyQx4PQ7ya,L9iqnvw7ta6O702E9ExuBN" />
+          <Link Id="JNJIJw1RrrkNaAO6e8CA4u" Ids="RNPxVDUPgjiLZqh3HxEqxy,PbdI1vc1ZSVPPOEfcCqvPq" />
+          <Link Id="MEEqcQmqwGDLG4F58H2ETR" Ids="NqGyAsAWK69NMQhuSjbcNz,ChfD4qp6LpnMxiFOfkOTBe" />
+          <Link Id="JEHn77BnBGRN06ddpQQHjc" Ids="IPOEPQ07THbMDHOhtV26cs,QF9bfuh2dILP9vieDq4T5t" />
+          <Link Id="GAZcOojI7xGPZFPSLJeumB" Ids="IPOEPQ07THbMDHOhtV26cs,PGbLh6jbbY6PU7cJccXZD9" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="RCKiHBrLdcZPG7jFRmFgin">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="K6NpIgswrghPmoVYMiy9VS">
+        <Canvas Id="Dz992g9vlFnOPw1v4Uwqj8" CanvasType="Group" />
+        <Patch Id="ES9epZJHgV1PILstcerFrF" Name="Create" />
+        <Patch Id="GZtpz52P0agNh112TUU7yP" Name="Update" />
+        <ProcessDefinition Id="BzfKXFFCeF4Mr3Mvpz7Zke">
+          <Fragment Id="SSlvRu502zqNI2XNqdlj35" Patch="ES9epZJHgV1PILstcerFrF" Enabled="true" />
+          <Fragment Id="EMaCNGaAWgLLSWSrUBE1mL" Patch="GZtpz52P0agNh112TUU7yP" Enabled="true" />
+          <Fragment Id="O3jGv7VXNhhLoeikprCF7f" Patch="RA7eMM0t8g8Ln8KI3q9jBH" Enabled="true" />
+        </ProcessDefinition>
+        <Patch Id="RA7eMM0t8g8Ln8KI3q9jBH" Name="GetPropertyDefinitions" />
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="K4GyEFI8eHdNHJSouTEzpo" Location="../../../VVVV.Schema.Core.vl" />
+  <NugetDependency Id="Je7zHyD3zlJNmV09l4msvM" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <DocumentDependency Id="NogtWOJFOafOzfi7419iNE" Location="../../../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />
+  <DocumentDependency Id="Ly2zG77hs3BPAaSo3tPRRb" Location="../Extensions/Schema.Plugins.Surfaces.Extensions.ResourceMode.vl" />
+  <NugetDependency Id="BpgT2EmMVWiQVceFZXpcAh" Location="VL.Stride.TextureFX" Version="2025.7.0-0002-g93330f7cea" />
+</Document>

--- a/Main/vl/Plugins/Surfaces/Extensions/Schema.Plugins.Surfaces.Extensions.ResourceMode.vl
+++ b/Main/vl/Plugins/Surfaces/Extensions/Schema.Plugins.Surfaces.Extensions.ResourceMode.vl
@@ -1,0 +1,176 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="FpwuPBHwwQcNnwwHomSVJo" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <NugetDependency Id="C7lbNl8C2CiPVCICEvzsZ6" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <Patch Id="SmiZ4qIFqUpPxBBl9TE8hu">
+    <Canvas Id="UINZfJfW9xRPGA0r1xxS6H" DefaultCategory="Schema.Plugins.Surfaces.Extensions" CanvasType="FullCategory">
+      <Canvas Id="HrUaE5MJZOqNHEuUxoPGWA" Name="PropertyBank" Position="79,109">
+        <!--
+
+    ************************ GetTexture ************************
+
+-->
+        <Node Name="GetTexture" Bounds="51,90,252,156" Id="Uq1AJMAmsYxNWI3QXt7N8Y">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" Name="Operation" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="RVzs1DQGm92MRVdzbcyygY">
+            <Node Bounds="68,163,86,26" Id="M1BNjzxBa1nQC6pRD3jUSr">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                    </p:OuterCategoryReference>
+                  </p:OuterCategoryReference>
+                </CategoryReference>
+                <Choice Kind="OperationCallFlag" Name="GetObject" />
+              </p:NodeReference>
+              <Pin Id="UyDWaMlYgJDO9EbNgAuDVH" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MZwGzYLQb1bMGqwjl4swN7" Name="Key" Kind="InputPin" />
+              <Pin Id="TlyTsZG4JyPLREkI81gwzq" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="IEwBUyjLGEkQcoPcXTeCnT" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="EJeuEImvWlQNlX2Ty43YZz" Bounds="65,120" />
+            <Link Id="T9ZoYxL2QM5O8eeO55rUB4" Ids="EJeuEImvWlQNlX2Ty43YZz,UyDWaMlYgJDO9EbNgAuDVH" />
+            <Link Id="BfVxBp9tuSuOWZHSZUS4sl" Ids="H5AvHajfYLAL6aJG64GvLS,EJeuEImvWlQNlX2Ty43YZz" IsHidden="true" />
+            <ControlPoint Id="UqELs29gJGiMM9a3bAFoLl" Bounds="151,229" />
+            <Link Id="S8m9dfW4UWfPcbo191rPgE" Ids="IEwBUyjLGEkQcoPcXTeCnT,VhbrJSs30kzPH2erH66KPO" />
+            <Link Id="UtJfpWGDmKBP4WIMi68FuI" Ids="UqELs29gJGiMM9a3bAFoLl,OzOjIL0Fgz8QYzAxf4WUeQ" IsHidden="true" />
+            <ControlPoint Id="OZH6GqUAdmlNl95vk8dKFz" Bounds="71,229" />
+            <Link Id="UyXWyabsKbFLr19r4YF1b1" Ids="TlyTsZG4JyPLREkI81gwzq,OZH6GqUAdmlNl95vk8dKFz" />
+            <Link Id="EkMhQHmnIicLErfEHskhuk" Ids="OZH6GqUAdmlNl95vk8dKFz,UKcXtz0p4lVMkZKwQz99Bo" IsHidden="true" />
+            <Pin Id="H5AvHajfYLAL6aJG64GvLS" Name="Input" Kind="InputPin" Bounds="1145,-39" />
+            <Pin Id="UKcXtz0p4lVMkZKwQz99Bo" Name="Output" Kind="OutputPin" Bounds="1173,65" />
+            <Pin Id="OzOjIL0Fgz8QYzAxf4WUeQ" Name="Result" Kind="OutputPin" Bounds="1285,68">
+              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
+                <Choice Kind="TypeFlag" Name="Texture" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Node Bounds="148,113,68,19" Id="RgahvzSYf8GOGJJRUdAXLi">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Output.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="TextureKey" />
+              </p:NodeReference>
+              <Pin Id="Kefp7zYIhrzMSeLLkN15H8" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Link Id="UR9x8SZiM7UMHXoGFhzK3L" Ids="Kefp7zYIhrzMSeLLkN15H8,MZwGzYLQb1bMGqwjl4swN7" />
+            <Node Bounds="149,196,48,19" Id="Sk1WAhDCqPBNi2hcnVqQfn">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CastAs" />
+              </p:NodeReference>
+              <Pin Id="VhbrJSs30kzPH2erH66KPO" Name="Input" Kind="StateInputPin" />
+              <Pin Id="FPHDRzP4FbaOMEg5G58FI5" Name="Default" Kind="InputPin" />
+              <Pin Id="H8orRlchpkQNYJZiavgTye" Name="Result" Kind="OutputPin" />
+              <Pin Id="Me72AWCgkmhPYljYfoOLBN" Name="Success" Kind="OutputPin" />
+            </Node>
+            <Link Id="M81MI6xTz2rP4KVdN0DT8P" Ids="H8orRlchpkQNYJZiavgTye,UqELs29gJGiMM9a3bAFoLl" />
+            <ControlPoint Id="TRwIjd6UNECMSrnwwICpA1" Bounds="247,119" />
+            <Link Id="K2RZKHRFCJLPCuZStal3jH" Ids="TRwIjd6UNECMSrnwwICpA1,FPHDRzP4FbaOMEg5G58FI5" />
+            <Pin Id="NA4I0JPkt9iMU5DwfAVDZ7" Name="Default" Kind="InputPin" />
+            <Link Id="PM5IUc2UMLmLExgDiC3jhh" Ids="NA4I0JPkt9iMU5DwfAVDZ7,TRwIjd6UNECMSrnwwICpA1" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ TextureKey ************************
+
+-->
+        <Node Name="TextureKey" Bounds="334,107,177,82" Id="RbDe3qj3EiEMr3LbvlPLO4">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" />
+          </p:NodeReference>
+          <Patch Id="NvByVOVTK1MOEvS2ZIphzd">
+            <Pad Id="SEbFbgbml9oPpJ2zS8GhVN" Bounds="363,144,117,15" ShowValueBox="true" isIOBox="true" Value="Surfaces.Texture">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="ImmutableTypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pad>
+            <ControlPoint Id="JK8I9AoytBhOG0XI6ywmpR" Bounds="361,172" />
+            <Link Id="J0XrlS8z6f4LqJgh8YUbT3" Ids="SEbFbgbml9oPpJ2zS8GhVN,JK8I9AoytBhOG0XI6ywmpR" />
+            <Pin Id="CyjQe1rBOSsNRrwokK63p0" Name="Output" Kind="OutputPin" />
+            <Link Id="PcyfrAQkbLRLxoqdTdXqY0" Ids="JK8I9AoytBhOG0XI6ywmpR,CyjQe1rBOSsNRrwokK63p0" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ SetTexture ************************
+
+-->
+        <Node Name="SetTexture" Bounds="108,333,230,157" Id="P36nvRZXV5rMJ5a4vkgrzL">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" Name="Operation" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="ABPffXCyooMP8vRKiHEP6V">
+            <Node Bounds="125,407,86,19" Id="PAb2V0fZpoHOikXMqNuiQ6">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                    </p:OuterCategoryReference>
+                  </p:OuterCategoryReference>
+                </CategoryReference>
+                <Choice Kind="OperationCallFlag" Name="SetObject" />
+              </p:NodeReference>
+              <Pin Id="AJ69NRW1reBMhiVf5sXoHx" Name="Input" Kind="StateInputPin" />
+              <Pin Id="N0YIFxH4zTKLtsymlxM6zu" Name="Key" Kind="InputPin" />
+              <Pin Id="KFFHlScOnHiMC6JaA3MUXv" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="LyeWo9mDipiNaUJIDDgoGE" Name="Value" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="CleRjST5S4FPCzkuDGru5z" Bounds="122,364" />
+            <Link Id="Mq0ifF2o4ZULMi6L9NdPu7" Ids="CleRjST5S4FPCzkuDGru5z,AJ69NRW1reBMhiVf5sXoHx" />
+            <Link Id="K2zqL5SJW7vMtReFnRId5n" Ids="LtE5mi6JknvLFwK8qQvxqQ,CleRjST5S4FPCzkuDGru5z" IsHidden="true" />
+            <ControlPoint Id="GoVQovmwcPuLuu28bDFCTm" Bounds="128,473" />
+            <Link Id="BpRt8ISWeQDMaElxnq3Rty" Ids="KFFHlScOnHiMC6JaA3MUXv,GoVQovmwcPuLuu28bDFCTm" />
+            <Link Id="FJf8J48gZ9YOVuDZxCVQAX" Ids="GoVQovmwcPuLuu28bDFCTm,GBMTECzdVmyQZ7QVxcJA0T" IsHidden="true" />
+            <Pin Id="LtE5mi6JknvLFwK8qQvxqQ" Name="Input" Kind="InputPin" Bounds="1145,-39" />
+            <Pin Id="GBMTECzdVmyQZ7QVxcJA0T" Name="Output" Kind="OutputPin" Bounds="1173,65" />
+            <Node Bounds="176,356,68,19" Id="Qztrk1dr6paNJ5IzdSv1tF">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Output.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="TextureKey" />
+              </p:NodeReference>
+              <Pin Id="VO49PVlIZE5PACPsx5zCZu" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Link Id="G5WdUFfYpv2N3qIwsxHtRD" Ids="VO49PVlIZE5PACPsx5zCZu,N0YIFxH4zTKLtsymlxM6zu" />
+            <ControlPoint Id="GCKSvYozS3INaOONoW8Pr3" Bounds="290,366" />
+            <Link Id="Poz7Ffd3i5APINSTky90ON" Ids="GCKSvYozS3INaOONoW8Pr3,LyeWo9mDipiNaUJIDDgoGE" />
+            <Pin Id="GT7MCez84iiLLwkSHtgvNo" Name="Value" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
+                <Choice Kind="TypeFlag" Name="Texture" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Link Id="EiX9xtYahUjPLVJ3QlaMAR" Ids="GT7MCez84iiLLwkSHtgvNo,GCKSvYozS3INaOONoW8Pr3" IsHidden="true" />
+          </Patch>
+        </Node>
+      </Canvas>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="JTWOyZM1gNqMwD2hJdMNLg">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="LIImrxspRMINzMJD467S1L">
+        <Canvas Id="PgSkm6hPzjtMZcMTFriZsk" CanvasType="Group" />
+        <Patch Id="Vf5PHuCgRFpLj4TDwRKrJ5" Name="Create" />
+        <Patch Id="MGROrUPkym9QC8b3u30FmK" Name="Update" />
+        <ProcessDefinition Id="CNncCwKA5mXL3i0xnw8HFG">
+          <Fragment Id="KycLiD2TYWzO0uqYipLTtt" Patch="Vf5PHuCgRFpLj4TDwRKrJ5" Enabled="true" />
+          <Fragment Id="KxDSwf91hWnP1WWibKukJw" Patch="MGROrUPkym9QC8b3u30FmK" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="KPDlMSPA2uVQBgrM6DbkQR" Location="../../../VVVV.Schema.Core.vl" />
+  <NugetDependency Id="LYOClR7PbWqPdAhKsW18D8" Location="VL.Stride" Version="2025.7.0-0002-g93330f7cea" />
+</Document>

--- a/Main/vl/Plugins/Surfaces/Extensions/Schema.Plugins.Surfaces.Extensions.Texture.vl
+++ b/Main/vl/Plugins/Surfaces/Extensions/Schema.Plugins.Surfaces.Extensions.Texture.vl
@@ -1,0 +1,176 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="FpwuPBHwwQcNnwwHomSVJo" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <NugetDependency Id="C7lbNl8C2CiPVCICEvzsZ6" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <Patch Id="SmiZ4qIFqUpPxBBl9TE8hu">
+    <Canvas Id="UINZfJfW9xRPGA0r1xxS6H" DefaultCategory="Schema.Plugins.Surfaces.Extensions" CanvasType="FullCategory">
+      <Canvas Id="HrUaE5MJZOqNHEuUxoPGWA" Name="PropertyBank" Position="79,109">
+        <!--
+
+    ************************ GetTexture ************************
+
+-->
+        <Node Name="GetTexture" Bounds="51,90,252,156" Id="Uq1AJMAmsYxNWI3QXt7N8Y">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" Name="Operation" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="RVzs1DQGm92MRVdzbcyygY">
+            <Node Bounds="68,163,86,26" Id="M1BNjzxBa1nQC6pRD3jUSr">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                    </p:OuterCategoryReference>
+                  </p:OuterCategoryReference>
+                </CategoryReference>
+                <Choice Kind="OperationCallFlag" Name="GetObject" />
+              </p:NodeReference>
+              <Pin Id="UyDWaMlYgJDO9EbNgAuDVH" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MZwGzYLQb1bMGqwjl4swN7" Name="Key" Kind="InputPin" />
+              <Pin Id="TlyTsZG4JyPLREkI81gwzq" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="IEwBUyjLGEkQcoPcXTeCnT" Name="Result" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="EJeuEImvWlQNlX2Ty43YZz" Bounds="65,120" />
+            <Link Id="T9ZoYxL2QM5O8eeO55rUB4" Ids="EJeuEImvWlQNlX2Ty43YZz,UyDWaMlYgJDO9EbNgAuDVH" />
+            <Link Id="BfVxBp9tuSuOWZHSZUS4sl" Ids="H5AvHajfYLAL6aJG64GvLS,EJeuEImvWlQNlX2Ty43YZz" IsHidden="true" />
+            <ControlPoint Id="UqELs29gJGiMM9a3bAFoLl" Bounds="151,229" />
+            <Link Id="S8m9dfW4UWfPcbo191rPgE" Ids="IEwBUyjLGEkQcoPcXTeCnT,VhbrJSs30kzPH2erH66KPO" />
+            <Link Id="UtJfpWGDmKBP4WIMi68FuI" Ids="UqELs29gJGiMM9a3bAFoLl,OzOjIL0Fgz8QYzAxf4WUeQ" IsHidden="true" />
+            <ControlPoint Id="OZH6GqUAdmlNl95vk8dKFz" Bounds="71,229" />
+            <Link Id="UyXWyabsKbFLr19r4YF1b1" Ids="TlyTsZG4JyPLREkI81gwzq,OZH6GqUAdmlNl95vk8dKFz" />
+            <Link Id="EkMhQHmnIicLErfEHskhuk" Ids="OZH6GqUAdmlNl95vk8dKFz,UKcXtz0p4lVMkZKwQz99Bo" IsHidden="true" />
+            <Pin Id="H5AvHajfYLAL6aJG64GvLS" Name="Input" Kind="InputPin" Bounds="1145,-39" />
+            <Pin Id="UKcXtz0p4lVMkZKwQz99Bo" Name="Output" Kind="OutputPin" Bounds="1173,65" />
+            <Pin Id="OzOjIL0Fgz8QYzAxf4WUeQ" Name="Result" Kind="OutputPin" Bounds="1285,68">
+              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
+                <Choice Kind="TypeFlag" Name="Texture" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Node Bounds="148,113,68,19" Id="RgahvzSYf8GOGJJRUdAXLi">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Output.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="TextureKey" />
+              </p:NodeReference>
+              <Pin Id="Kefp7zYIhrzMSeLLkN15H8" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Link Id="UR9x8SZiM7UMHXoGFhzK3L" Ids="Kefp7zYIhrzMSeLLkN15H8,MZwGzYLQb1bMGqwjl4swN7" />
+            <Node Bounds="149,196,48,19" Id="Sk1WAhDCqPBNi2hcnVqQfn">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="CastAs" />
+              </p:NodeReference>
+              <Pin Id="VhbrJSs30kzPH2erH66KPO" Name="Input" Kind="StateInputPin" />
+              <Pin Id="FPHDRzP4FbaOMEg5G58FI5" Name="Default" Kind="InputPin" />
+              <Pin Id="H8orRlchpkQNYJZiavgTye" Name="Result" Kind="OutputPin" />
+              <Pin Id="Me72AWCgkmhPYljYfoOLBN" Name="Success" Kind="OutputPin" />
+            </Node>
+            <Link Id="M81MI6xTz2rP4KVdN0DT8P" Ids="H8orRlchpkQNYJZiavgTye,UqELs29gJGiMM9a3bAFoLl" />
+            <ControlPoint Id="TRwIjd6UNECMSrnwwICpA1" Bounds="247,119" />
+            <Link Id="K2RZKHRFCJLPCuZStal3jH" Ids="TRwIjd6UNECMSrnwwICpA1,FPHDRzP4FbaOMEg5G58FI5" />
+            <Pin Id="NA4I0JPkt9iMU5DwfAVDZ7" Name="Default" Kind="InputPin" />
+            <Link Id="PM5IUc2UMLmLExgDiC3jhh" Ids="NA4I0JPkt9iMU5DwfAVDZ7,TRwIjd6UNECMSrnwwICpA1" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ TextureKey ************************
+
+-->
+        <Node Name="TextureKey" Bounds="334,107,177,82" Id="RbDe3qj3EiEMr3LbvlPLO4">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" />
+          </p:NodeReference>
+          <Patch Id="NvByVOVTK1MOEvS2ZIphzd">
+            <Pad Id="SEbFbgbml9oPpJ2zS8GhVN" Bounds="363,144,117,15" ShowValueBox="true" isIOBox="true" Value="Surfaces.Texture">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="ImmutableTypeFlag" Name="String" />
+              </p:TypeAnnotation>
+            </Pad>
+            <ControlPoint Id="JK8I9AoytBhOG0XI6ywmpR" Bounds="361,172" />
+            <Link Id="J0XrlS8z6f4LqJgh8YUbT3" Ids="SEbFbgbml9oPpJ2zS8GhVN,JK8I9AoytBhOG0XI6ywmpR" />
+            <Pin Id="CyjQe1rBOSsNRrwokK63p0" Name="Output" Kind="OutputPin" />
+            <Link Id="PcyfrAQkbLRLxoqdTdXqY0" Ids="JK8I9AoytBhOG0XI6ywmpR,CyjQe1rBOSsNRrwokK63p0" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ SetTexture ************************
+
+-->
+        <Node Name="SetTexture" Bounds="108,333,230,157" Id="P36nvRZXV5rMJ5a4vkgrzL">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" Name="Operation" />
+            <FullNameCategoryReference ID="Primitive" />
+          </p:NodeReference>
+          <Patch Id="ABPffXCyooMP8vRKiHEP6V">
+            <Node Bounds="125,407,86,19" Id="PAb2V0fZpoHOikXMqNuiQ6">
+              <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                    </p:OuterCategoryReference>
+                  </p:OuterCategoryReference>
+                </CategoryReference>
+                <Choice Kind="OperationCallFlag" Name="SetObject" />
+              </p:NodeReference>
+              <Pin Id="AJ69NRW1reBMhiVf5sXoHx" Name="Input" Kind="StateInputPin" />
+              <Pin Id="N0YIFxH4zTKLtsymlxM6zu" Name="Key" Kind="InputPin" />
+              <Pin Id="KFFHlScOnHiMC6JaA3MUXv" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="LyeWo9mDipiNaUJIDDgoGE" Name="Value" Kind="InputPin" />
+            </Node>
+            <ControlPoint Id="CleRjST5S4FPCzkuDGru5z" Bounds="122,364" />
+            <Link Id="Mq0ifF2o4ZULMi6L9NdPu7" Ids="CleRjST5S4FPCzkuDGru5z,AJ69NRW1reBMhiVf5sXoHx" />
+            <Link Id="K2zqL5SJW7vMtReFnRId5n" Ids="LtE5mi6JknvLFwK8qQvxqQ,CleRjST5S4FPCzkuDGru5z" IsHidden="true" />
+            <ControlPoint Id="GoVQovmwcPuLuu28bDFCTm" Bounds="128,473" />
+            <Link Id="BpRt8ISWeQDMaElxnq3Rty" Ids="KFFHlScOnHiMC6JaA3MUXv,GoVQovmwcPuLuu28bDFCTm" />
+            <Link Id="FJf8J48gZ9YOVuDZxCVQAX" Ids="GoVQovmwcPuLuu28bDFCTm,GBMTECzdVmyQZ7QVxcJA0T" IsHidden="true" />
+            <Pin Id="LtE5mi6JknvLFwK8qQvxqQ" Name="Input" Kind="InputPin" Bounds="1145,-39" />
+            <Pin Id="GBMTECzdVmyQZ7QVxcJA0T" Name="Output" Kind="OutputPin" Bounds="1173,65" />
+            <Node Bounds="176,356,68,19" Id="Qztrk1dr6paNJ5IzdSv1tF">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Output.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="TextureKey" />
+              </p:NodeReference>
+              <Pin Id="VO49PVlIZE5PACPsx5zCZu" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Link Id="G5WdUFfYpv2N3qIwsxHtRD" Ids="VO49PVlIZE5PACPsx5zCZu,N0YIFxH4zTKLtsymlxM6zu" />
+            <ControlPoint Id="GCKSvYozS3INaOONoW8Pr3" Bounds="290,366" />
+            <Link Id="Poz7Ffd3i5APINSTky90ON" Ids="GCKSvYozS3INaOONoW8Pr3,LyeWo9mDipiNaUJIDDgoGE" />
+            <Pin Id="GT7MCez84iiLLwkSHtgvNo" Name="Value" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.vl">
+                <Choice Kind="TypeFlag" Name="Texture" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Link Id="EiX9xtYahUjPLVJ3QlaMAR" Ids="GT7MCez84iiLLwkSHtgvNo,GCKSvYozS3INaOONoW8Pr3" IsHidden="true" />
+          </Patch>
+        </Node>
+      </Canvas>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="JTWOyZM1gNqMwD2hJdMNLg">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="LIImrxspRMINzMJD467S1L">
+        <Canvas Id="PgSkm6hPzjtMZcMTFriZsk" CanvasType="Group" />
+        <Patch Id="Vf5PHuCgRFpLj4TDwRKrJ5" Name="Create" />
+        <Patch Id="MGROrUPkym9QC8b3u30FmK" Name="Update" />
+        <ProcessDefinition Id="CNncCwKA5mXL3i0xnw8HFG">
+          <Fragment Id="KycLiD2TYWzO0uqYipLTtt" Patch="Vf5PHuCgRFpLj4TDwRKrJ5" Enabled="true" />
+          <Fragment Id="KxDSwf91hWnP1WWibKukJw" Patch="MGROrUPkym9QC8b3u30FmK" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <DocumentDependency Id="KPDlMSPA2uVQBgrM6DbkQR" Location="../../../VVVV.Schema.Core.vl" />
+  <NugetDependency Id="LYOClR7PbWqPdAhKsW18D8" Location="VL.Stride" Version="2025.7.0-0002-g93330f7cea" />
+</Document>

--- a/Main/vl/Plugins/Surfaces/Output/Schema.Plugins.Surfaces.Output.vl
+++ b/Main/vl/Plugins/Surfaces/Output/Schema.Plugins.Surfaces.Output.vl
@@ -1,0 +1,522 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="DoXYDh0ZsziMcH65hIcwBz" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <NugetDependency Id="PNWZnU1bdjnLxLhpkwTmob" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <Patch Id="E155STev0OPQLuasvZyDUN">
+    <Canvas Id="UDUlsodRg1jQP7wECPJ4fS" DefaultCategory="Schema.Plugins.Surfaces.Output" CanvasType="FullCategory">
+      <!--
+
+    ************************ SurfacesOutput ************************
+
+-->
+      <Node Name="SurfacesOutput" Bounds="82,78" Id="TrbyNqcKeSDQCQkZacclxL">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
+          <Choice Kind="ClassDefinition" Name="Class" />
+        </p:NodeReference>
+        <p:Interfaces>
+          <TypeReference LastCategoryFullName="VVVV.Schema.Output" LastDependency="VVVV.Schema.Core.vl">
+            <Choice Kind="InterfaceTypeFlag" Name="IOutput" />
+          </TypeReference>
+        </p:Interfaces>
+        <Patch Id="SGZIdvoWnauOmC0Z9Wx9pW">
+          <Canvas Id="BoyovernrdaNKruwXvGLaD" CanvasType="Group">
+            <ControlPoint Id="O3gLuYB9TwwMZo9bw7DWC5" Bounds="197,70" />
+            <ControlPoint Id="Gved0wdQbdEQMTwEqfObFN" Bounds="58,206" />
+            <Node Bounds="47,63,51,19" Id="Qps2UN7Ht0cPRJckPo3yOz">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+                <PinReference Kind="InputPin" Name="Message">
+                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:DataTypeReference>
+                </PinReference>
+              </p:NodeReference>
+              <Pin Id="Imm2zpRZjsuO856GLmuO0h" Name="Message" Kind="InputPin" DefaultValue="Surfaces Output: Create">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pin>
+            </Node>
+            <Pad Id="MhoZYuxusA3MiqIXNWLlzG" Comment="" Bounds="59,151,57,34" ShowValueBox="true" isIOBox="true">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Spread" />
+                <p:TypeArguments>
+                  <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </TypeReference>
+                </p:TypeArguments>
+              </p:TypeAnnotation>
+              <p:Value>
+                <Item>Surface</Item>
+              </p:Value>
+            </Pad>
+            <Node Bounds="195,100,120,19" Id="Tp16Mw7CkU9MVsZhAssjFB">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output" LastDependency="Schema.Plugins.Surfaces.Output.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="SortFixturesByDistance" />
+              </p:NodeReference>
+              <Pin Id="JSDnFKpTtZMPAB7YtuBJUK" Name="Input" Kind="InputPin" />
+              <Pin Id="AGGsO6dY4dPPf93UKkgtSs" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="469,286,185,19" Id="Fc4Iaa8ZlSfMaqvdMWHonc">
+              <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="TextureWindow" />
+              </p:NodeReference>
+              <Pin Id="QgdvUXLmvOAPRQKjxla76m" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Onv7RvdrPHFM5rl79hVEm4" Name="Bounds" Kind="InputPin" DefaultValue="841.3333, -699.3333, 638.6667, 666.6667" IsHidden="true" />
+              <Pin Id="Ds78Lu9ODopOLP5ocJx1ev" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+              <Pin Id="KsSmDtJDfd0PIwLFous6ph" Name="Back Buffer Format" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Qm9hQRjVDFaPiWO4YdQnFn" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+              <Pin Id="TnxrsTHk11wMyUuNlCTHkv" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+              <Pin Id="LdPtCUUEWR1L0QaSeM6sZV" Name="Input" Kind="InputPin" />
+              <Pin Id="OC6LCTr8NjpLDF2LW1Mq6C" Name="Title" Kind="InputPin" />
+              <Pin Id="BkFd9O3oSgKNIAfgVk1NqI" Name="Clear Color" Kind="InputPin" />
+              <Pin Id="TDSAUiiMKXSL9rzV33Fp9Q" Name="Clear" Kind="InputPin" />
+              <Pin Id="NZtesnH9iEcLzlJcmZaQ0z" Name="Is Premultiplied Alpha" Kind="InputPin" />
+              <Pin Id="FrKZLACDUn8QAu0u9Jj9PY" Name="Scaling Mode" Kind="InputPin" />
+              <Pin Id="QLO9i57gE8aNlxBmrIPnFf" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
+              <Pin Id="EYvgKGuV23pMhg7mNJBov5" Name="Enabled" Kind="InputPin" />
+              <Pin Id="H5MxSWEDKwfLY6xf5LSYFT" Name="Show Info String" Kind="InputPin" />
+              <Pin Id="LSDJy7D9ME5O4fnmb0jd0J" Name="Present Interval" Kind="InputPin" />
+              <Pin Id="RDuFElWZztfNV3lSaQi0MX" Name="Output" Kind="OutputPin" />
+              <Pin Id="QQJRY2s8JrSMFBOCeFtTHd" Name="Client Bounds" Kind="OutputPin" />
+              <Pin Id="VlIVc7P9xBkM1P4m1183iG" Name="Input Source" Kind="OutputPin" />
+              <Pin Id="OQheV2dhwd1QF7ssTX6JmD" Name="Back Buffer" Kind="OutputPin" IsHidden="true" />
+            </Node>
+            <Node Bounds="357,147,52,19" Id="S48q3Z8Ytg0L72OM39cEtk">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="GetSlice" />
+              </p:NodeReference>
+              <Pin Id="JuiQwAp6EWmLrJfSF4eMPN" Name="Input" Kind="StateInputPin" />
+              <Pin Id="S3CG52SmSW7MByg66p3MxF" Name="Default Value" Kind="InputPin" />
+              <Pin Id="GBcGzvasxJzN834mVVwc5x" Name="Index" Kind="InputPin" />
+              <Pin Id="Hau2OkNeRyNP9CZ9BUgJJM" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="358,191,54,19" Id="AGvZnzdbMBFQFxXfGja59V">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetState (Fixture)" />
+              </p:NodeReference>
+              <Pin Id="PurB2t55KxgNywVjW6ZaXy" Name="Input" Kind="InputPin" />
+              <Pin Id="AqjvDKzE2iqOfmhz9b7Cy4" Name="Output" Kind="OutputPin" />
+              <Pin Id="Fd1PYHUHPSMPlaGVtWhVrY" Name="State" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="409,236,67,19" Id="RfSY4YE2YNsOrA56Ndm7rU">
+              <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Extensions.PropertyBank" LastDependency="Schema.Plugins.Surfaces.Extensions.ResourceMode.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetTexture" />
+              </p:NodeReference>
+              <Pin Id="MhCTMry1N3jOUr6UWYXA5K" Name="Input" Kind="InputPin" />
+              <Pin Id="VS2vXkdtj8RNyNG0fs3uhC" Name="Output" Kind="OutputPin" />
+              <Pin Id="NKW7CC7LtvWLdFE6BOjoGK" Name="Result" Kind="OutputPin" />
+              <Pin Id="UaHIIgTGd5APuw7VWXZeqi" Name="Default" Kind="InputPin" />
+            </Node>
+          </Canvas>
+          <ProcessDefinition Id="GX0eOpIQzyDOhhNIYJrivE" IsHidden="true">
+            <Fragment Id="G9xMqkYUY5yL6olSCz4vrU" Patch="CfRpjf87LsrNoRk1xiB5Np" Enabled="true" />
+            <Fragment Id="UEyaYl5hVEaOrPP1FfsHY7" Patch="N5PLskb2ERWOg8qXdcy3p3" Enabled="true" />
+            <Fragment Id="LQJW7C0c1W5NcBcLYCj4J6" Patch="Q7FZemgSrYePPkSVpjAqp5" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="VO6JJP2vFetMwhrV8ZNfAu" Ids="LbQclO8KUAPLeGWOUIiIZR,O3gLuYB9TwwMZo9bw7DWC5" IsHidden="true" />
+          <Link Id="MUI2kbyxJk2NbWw4KUiNm5" Ids="Gved0wdQbdEQMTwEqfObFN,LPB798t19cgMZaODz6GA9p" IsHidden="true" />
+          <Link Id="PyRWvf5DZGXLTnAmepWzTQ" Ids="MhoZYuxusA3MiqIXNWLlzG,Gved0wdQbdEQMTwEqfObFN" />
+          <Link Id="CLqHEHUFqYWNpsOOSnRdqq" Ids="O3gLuYB9TwwMZo9bw7DWC5,JSDnFKpTtZMPAB7YtuBJUK" />
+          <Patch Id="CfRpjf87LsrNoRk1xiB5Np" Name="Create" ParticipatingElements="Qps2UN7Ht0cPRJckPo3yOz" />
+          <Patch Id="N5PLskb2ERWOg8qXdcy3p3" Name="Update">
+            <Pin Id="LbQclO8KUAPLeGWOUIiIZR" Name="Fixtures" Kind="InputPin" />
+            <Pin Id="DAn103L0B4ANigxn5KsDoi" Name="Configuration" Kind="InputPin" />
+          </Patch>
+          <Patch Id="Q7FZemgSrYePPkSVpjAqp5" Name="ListSupportedModels">
+            <Pin Id="LPB798t19cgMZaODz6GA9p" Name="Output" Kind="OutputPin" />
+          </Patch>
+          <Patch Id="JinOzSPKaDCMNHzIcWk9XF" Name="Dispose" />
+          <Link Id="MvWClUgw66UL9z1xgpv9fr" Ids="O3gLuYB9TwwMZo9bw7DWC5,JuiQwAp6EWmLrJfSF4eMPN" />
+          <Link Id="RrlBgENnrYsQW658UbWLVV" Ids="Hau2OkNeRyNP9CZ9BUgJJM,PurB2t55KxgNywVjW6ZaXy" />
+          <Link Id="MKWurBMIWcJQNwaRrWZwyX" Ids="Fd1PYHUHPSMPlaGVtWhVrY,MhCTMry1N3jOUr6UWYXA5K" />
+          <Link Id="VUAlxF9Q2c8MHzEY8CHYT2" Ids="NKW7CC7LtvWLdFE6BOjoGK,LdPtCUUEWR1L0QaSeM6sZV" />
+        </Patch>
+      </Node>
+      <Canvas Id="ONQcazoiU7bLTqRtz2tYLF" Name="Resources" Position="79,208">
+        <!--
+
+    ************************ GetResourceImage ************************
+
+-->
+        <Node Name="GetResourceImage" Bounds="93,91" Id="E0QMbpylSSIMiCcE9PZ49F">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="MXaZSbacTGtOBkNb1HsmGM">
+            <Canvas Id="Eq5pp6fJAREPdOIiLFPWr0" CanvasType="Group">
+              <Node Bounds="125,99,81,19" Id="EYjl1TXqkRhMsxZhL96BMM">
+                <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="IsNullOrEmpty" />
+                </p:NodeReference>
+                <Pin Id="PnT73CPrgdwNjQvEZyzHbF" Name="Input" Kind="StateInputPin" />
+                <Pin Id="EA3J2NsTGbaLsF1HlsMokX" Name="Result" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="125,126,37,19" Id="OcRKHuXREiZMCw7Ol4DUS4">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="NOT" />
+                </p:NodeReference>
+                <Pin Id="GsVGSc2RvG5M4JMlrzFR2k" Name="Input" Kind="StateInputPin" />
+                <Pin Id="CUIkrF5DstfO70uIQnSP9H" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="56,59,73,19" Id="M4nLmThu4ZfOqqa75ym2t2">
+                <p:NodeReference LastCategoryFullName="Schema.Extensions.Resource" LastDependency="Schema.Extensions.Resource.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetResource (PropertyBank)" />
+                </p:NodeReference>
+                <Pin Id="CGU7bQp6BqbQIpjkExjcsp" Name="Input" Kind="InputPin" />
+                <Pin Id="LB8mpgWdWJQLEx6ngpKDdb" Name="Output" Kind="OutputPin" />
+                <Pin Id="LnGwXpSjpUhN2MKR2IBc8p" Name="Result" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="PgkzsBjrFpLNjWKqJkR0Gj" Bounds="240,524" />
+              <Node Bounds="361,335,59,26" Id="HPCvKWf0dVnMiwuFyg7uB0">
+                <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="FileExists" />
+                </p:NodeReference>
+                <Pin Id="SSYinJbVKauNAQjdkCHczu" Name="Input" Kind="StateInputPin" />
+                <Pin Id="Jw3Ljcf8edBME9VKYFd58T" Name="Exists" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="329,374,37,19" Id="Vb5wZene8aMNfEMVWyEhGu">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="AND" />
+                </p:NodeReference>
+                <Pin Id="RA4tbyFXAwLNQLoE1i3IRQ" Name="Input" Kind="StateInputPin" />
+                <Pin Id="GEsTguYLPhpNLLamfUwe2R" Name="Input 2" Kind="InputPin" />
+                <Pin Id="QMU5OOHhYqUNhSNz605bFu" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <ControlPoint Id="VoL9gGxpCoOObnTLZJIIBY" Bounds="330,528" />
+              <ControlPoint Id="POlAZo1slzrOeCYnEuH81h" Bounds="56,29" />
+              <ControlPoint Id="IpaLzN8MZHwLGxS9nujRPn" Bounds="56,108" />
+              <ControlPoint Id="QziI3ZWeNxrPjn6V5n8tg5" Bounds="247,32" />
+              <Node Bounds="232,168,191,113" Id="QCBOaerxNEuMv6RThDfsWt">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="P7KVlcBHOg8L7QDNsxa5Ea" Name="Force" Kind="InputPin" />
+                <Pin Id="IrfG6luzQQCMrHlHlR3kaz" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="DeW8AuGiburPq3R5yDZtNu" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="Hva02Vi7GxsN8QlyTFNEoh" ManuallySortedPins="true">
+                  <Patch Id="DkBQGrjVvxAPdwAbmhKBsr" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="EhF5tIVVFLjLcqnUrFK2op" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="244,191,97,19" Id="Mf7zDY70kKAPuHodZCI3ul">
+                    <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="GetResourcesPath" />
+                    </p:NodeReference>
+                    <Pin Id="CZZPGGlF8xRLyHtPESbhxG" Name="Project Directory" Kind="InputPin" />
+                    <Pin Id="VCUkOQ1YYHtPiGfSCfr36k" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="244,235,57,26" Id="JJiEy0JW7e5O9ikuTxdTUj">
+                    <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="ClassType" Name="Path" NeedsToBeDirectParent="true">
+                        <p:OuterCategoryReference Kind="Category" Name="IO" NeedsToBeDirectParent="true" />
+                      </CategoryReference>
+                      <Choice Kind="OperationCallFlag" Name="Combine" />
+                    </p:NodeReference>
+                    <Pin Id="PGcE3Wb6nDNNgft4NFj2sa" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="S5LY0EJX4hPMY36PPCuZmJ" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="OvlaZpJf9fWMeKmHKKvaFJ" Name="Output" Kind="StateOutputPin" />
+                  </Node>
+                  <Node Bounds="363,191,48,19" Id="JEaUgQ1Lf9RQDY2zuWKmo9">
+                    <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="ToPath" />
+                    </p:NodeReference>
+                    <Pin Id="NOMq1dcG8RCMlZGtNJnDGe" Name="Input" Kind="InputPin" />
+                    <Pin Id="VpsRv7WF1FsOzFh7x7p91Y" Name="Result" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="OuDBQyApsO5MjMzGz3Sug9" Bounds="364,174" Alignment="Top" />
+                <ControlPoint Id="BbOHhndXLAnQGu83OhYAC5" Bounds="250,174" Alignment="Top" />
+                <ControlPoint Id="MxEexvCvbcTOyWtot0CDt0" Bounds="247,275" Alignment="Bottom" />
+              </Node>
+              <Node Bounds="226,413,107,80" Id="RhQM5ChdSgbPOxSljQe8gc">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="FHgrvibbH7EL02Hpq6MuvW" Name="Condition" Kind="InputPin" />
+                <ControlPoint Id="QDJrHCaI16KNp6cPwUQR0E" Bounds="240,487" Alignment="Bottom" />
+                <ControlPoint Id="AmKJeTDqgujMQbZmuxOmqE" Bounds="240,419" Alignment="Top" />
+                <Patch Id="Ro5xmvGTLdsPj2LSm5XyDm" ManuallySortedPins="true">
+                  <Patch Id="Dic4R0N3SZcPqd9rdlExkH" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="KdbMcnsbZkgMi9sTI9KcEO" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="246,443,75,19" Id="Ap5Cu6VAPnCPgXoeiWe1g4">
+                    <p:NodeReference LastCategoryFullName="Graphics.Skia.IO" LastDependency="VL.Skia.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Skia" />
+                      <Choice Kind="ProcessAppFlag" Name="ImageReader" />
+                    </p:NodeReference>
+                    <Pin Id="UKScMQJqK1LNxG9Dw7E8Ub" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="HtBGcL2OfBAPiIAD71kCwd" Name="Filename" Kind="InputPin" />
+                    <Pin Id="R3S83HPgGBeMo0LR4VOsl9" Name="Load" Kind="InputPin" DefaultValue="False" />
+                    <Pin Id="UmZTEsAXRsWQIp3J8xuWt9" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+              </Node>
+            </Canvas>
+            <ProcessDefinition Id="RbAJaecYv28MLj6L1QHKCH">
+              <Fragment Id="Po6CCOaj6pqOfHIAFELFoJ" Patch="SMRucZSg83NQaa8R9vNuHE" Enabled="true" />
+              <Fragment Id="QCk803QOf6WOl83SZyJ43Y" Patch="Rmir7yvJpxZN3JnYhP7YJA" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="I4zbxo6sqCdN81nJaza9gF" Ids="EA3J2NsTGbaLsF1HlsMokX,GsVGSc2RvG5M4JMlrzFR2k" />
+            <Link Id="Gk7DAjbZ1FyQScPuxw3hVu" Ids="LnGwXpSjpUhN2MKR2IBc8p,PnT73CPrgdwNjQvEZyzHbF" />
+            <Link Id="UMxMquj2ke4LRxgDxI66f4" Ids="PgkzsBjrFpLNjWKqJkR0Gj,Jx82pkzbz7XMNI9kNCRSSl" IsHidden="true" />
+            <Link Id="PCfCBMe7BnFQcEiukGp4DS" Ids="Jw3Ljcf8edBME9VKYFd58T,GEsTguYLPhpNLLamfUwe2R" />
+            <Link Id="GxAEJeO949xQcdRQqipOch" Ids="CUIkrF5DstfO70uIQnSP9H,RA4tbyFXAwLNQLoE1i3IRQ" />
+            <Link Id="Q30PamkmoFiLEIvujHlDEP" Ids="QMU5OOHhYqUNhSNz605bFu,VoL9gGxpCoOObnTLZJIIBY" />
+            <Link Id="OwyjoZyCai1PGgudBknBwQ" Ids="VoL9gGxpCoOObnTLZJIIBY,Fu5NWvxTwtDLuKtbkRBbcx" IsHidden="true" />
+            <Link Id="LPTBAcPMV7VLji48AAIHNI" Ids="C9BACutMPDlM8i082bzUHE,POlAZo1slzrOeCYnEuH81h" IsHidden="true" />
+            <Link Id="MTdHxKgC5tHQRAGYK5H2mb" Ids="POlAZo1slzrOeCYnEuH81h,CGU7bQp6BqbQIpjkExjcsp" />
+            <Link Id="OB6H3bTO0onMF8gEQuBFin" Ids="IpaLzN8MZHwLGxS9nujRPn,PBKn6f7CNy1MruKBSMgs4B" IsHidden="true" />
+            <Link Id="Avlh8mw5pwRO3t3a705Kgp" Ids="LB8mpgWdWJQLEx6ngpKDdb,IpaLzN8MZHwLGxS9nujRPn" />
+            <Patch Id="SMRucZSg83NQaa8R9vNuHE" Name="Create" />
+            <Patch Id="Rmir7yvJpxZN3JnYhP7YJA" Name="Update">
+              <Pin Id="C9BACutMPDlM8i082bzUHE" Name="Input" Kind="InputPin" />
+              <Pin Id="PBKn6f7CNy1MruKBSMgs4B" Name="Output" Kind="OutputPin" />
+              <Pin Id="Jx82pkzbz7XMNI9kNCRSSl" Name="Image" Kind="OutputPin" Bounds="221,421" />
+              <Pin Id="Fu5NWvxTwtDLuKtbkRBbcx" Name="Available" Kind="OutputPin" Bounds="342,440" />
+              <Pin Id="TW9xs5kRHpeMWEGlC3HxL4" Name="Project Directory" Kind="InputPin" Bounds="251,32" />
+            </Patch>
+            <Link Id="L7jS3YbLWHhM1Vp1hMNu7b" Ids="TW9xs5kRHpeMWEGlC3HxL4,QziI3ZWeNxrPjn6V5n8tg5" IsHidden="true" />
+            <Link Id="QrQvUyHNkrLNWTpixVjnQd" Ids="VCUkOQ1YYHtPiGfSCfr36k,PGcE3Wb6nDNNgft4NFj2sa" />
+            <Link Id="KkWMumppYUFPWdPa0gz8qv" Ids="VpsRv7WF1FsOzFh7x7p91Y,S5LY0EJX4hPMY36PPCuZmJ" />
+            <Link Id="Hm6qqJJd4aUPqDVxb28Leo" Ids="LnGwXpSjpUhN2MKR2IBc8p,OuDBQyApsO5MjMzGz3Sug9" />
+            <Link Id="IH3uuZk3Z5uNC74wliYuj2" Ids="OuDBQyApsO5MjMzGz3Sug9,NOMq1dcG8RCMlZGtNJnDGe" />
+            <Link Id="GyRAOlTafCPLedsQdrhihH" Ids="QziI3ZWeNxrPjn6V5n8tg5,BbOHhndXLAnQGu83OhYAC5" />
+            <Link Id="DPvd6MUVKMdQcf4DupNEdb" Ids="BbOHhndXLAnQGu83OhYAC5,CZZPGGlF8xRLyHtPESbhxG" />
+            <Link Id="AzSDT2ASvKoLm36WrQjze4" Ids="OvlaZpJf9fWMeKmHKKvaFJ,MxEexvCvbcTOyWtot0CDt0" />
+            <Link Id="GL0j3iUSNOAMFm8ITCK2q2" Ids="MxEexvCvbcTOyWtot0CDt0,SSYinJbVKauNAQjdkCHczu" />
+            <Link Id="VeWJXEdvFQ6ON6vavmnz51" Ids="QMU5OOHhYqUNhSNz605bFu,FHgrvibbH7EL02Hpq6MuvW" />
+            <Link Id="BAR9mhov13zMNerwSuI7js" Ids="AmKJeTDqgujMQbZmuxOmqE,QDJrHCaI16KNp6cPwUQR0E" IsFeedback="true" />
+            <Link Id="Jiv9lQvf2wcMjlN3eQtPm8" Ids="UmZTEsAXRsWQIp3J8xuWt9,QDJrHCaI16KNp6cPwUQR0E" />
+            <Link Id="UxktqI68dlWPx74fwsDiuP" Ids="QDJrHCaI16KNp6cPwUQR0E,PgkzsBjrFpLNjWKqJkR0Gj" />
+            <Link Id="TwEDkKBDBhQOd6Ym5f7Zbf" Ids="MxEexvCvbcTOyWtot0CDt0,HtBGcL2OfBAPiIAD71kCwd" />
+          </Patch>
+        </Node>
+      </Canvas>
+      <!--
+
+    ************************ GetFixtureFinalPosition (Internal) ************************
+
+-->
+      <Node Name="GetFixtureFinalPosition (Internal)" Bounds="83,303,176,190" Id="U2usszWBxSpMRXiWnLc8Fb">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" />
+        </p:NodeReference>
+        <Patch Id="DQFEMXiPDSWMluqR3qSIce">
+          <Node Bounds="144,438,68,19" Id="E7xZnZqUqvaLyz449x0eRP">
+            <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                  </p:OuterCategoryReference>
+                </p:OuterCategoryReference>
+              </CategoryReference>
+              <Choice Kind="OperationCallFlag" Name="GetPosition" />
+            </p:NodeReference>
+            <Pin Id="IHDE7VtWeKjMdFBIRFTz6t" Name="Input" Kind="InputPin" />
+            <Pin Id="O4fapG4T3Y0NCAsSUu1QH9" Name="Default Value" Kind="InputPin" />
+            <Pin Id="FysyY3LEo91N8DxGVroNg0" Name="Output" Kind="OutputPin" />
+            <Pin Id="ReZTFc8POjKM4kssVKrOmc" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="95,404,54,19" Id="J0iyaIHjDFxOo3ntlVz3cy">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="GetState (Fixture)" />
+            </p:NodeReference>
+            <Pin Id="P6UTbOcRzTrLTm0WotrYmi" Name="Input" Kind="InputPin" />
+            <Pin Id="JmGfNiAqpevNyhRXNWWaxc" Name="Output" Kind="OutputPin" />
+            <Pin Id="U3wjEof3lMVPxPY6fIABNF" Name="State" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="96,345,57,19" Id="Fw8eokCa9COMN0FMtTXmbw">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Fixture" />
+              <Choice Kind="OperationCallFlag" Name="GetSetup (Fixture)" />
+            </p:NodeReference>
+            <Pin Id="GnPT71PXLJUNpPfJuAFprg" Name="Input" Kind="InputPin" />
+            <Pin Id="ExV8pe92Q3aPiHLGTq3ITg" Name="Output" Kind="OutputPin" />
+            <Pin Id="NERN2lcu20iL91J2knAENC" Name="Setup" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="148,375,68,19" Id="LV4YvJ4JepMNhs3tY18iaa">
+            <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true">
+                <p:OuterCategoryReference Kind="Category" Name="Model" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Schema" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                  </p:OuterCategoryReference>
+                </p:OuterCategoryReference>
+              </CategoryReference>
+              <Choice Kind="OperationCallFlag" Name="GetPosition" />
+            </p:NodeReference>
+            <Pin Id="KHHtK0jZiUCNcaNgyoK2ff" Name="Input" Kind="InputPin" />
+            <Pin Id="Too0P86ZHMqMphjFGPreBp" Name="Default Value" Kind="InputPin" />
+            <Pin Id="VQF8pFWQA01OC6YIAtqBdn" Name="Output" Kind="OutputPin" />
+            <Pin Id="D633CLx4KAsNeBG9u22lHN" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Link Id="BWz6dxqj6byNRG5433Hz8S" Ids="U3wjEof3lMVPxPY6fIABNF,IHDE7VtWeKjMdFBIRFTz6t" />
+          <Link Id="N2lx1KW8VYeNgzoJrWqGgC" Ids="NERN2lcu20iL91J2knAENC,KHHtK0jZiUCNcaNgyoK2ff" />
+          <Link Id="EZLBUIJHAi7LOjy2g3xkQb" Ids="D633CLx4KAsNeBG9u22lHN,O4fapG4T3Y0NCAsSUu1QH9" />
+          <Link Id="UU6pokER9XLP79cdCq7I81" Ids="ExV8pe92Q3aPiHLGTq3ITg,P6UTbOcRzTrLTm0WotrYmi" />
+          <ControlPoint Id="AGE40ZeMeSQOnIwRq6NP9l" Bounds="208,476" />
+          <Link Id="CREDWQZxccGPdXhvLqPVfe" Ids="ReZTFc8POjKM4kssVKrOmc,AGE40ZeMeSQOnIwRq6NP9l" />
+          <Pin Id="IDSD09QuguvLVNcVE4iyhq" Name="Result" Kind="OutputPin" />
+          <Link Id="ML4WDPFrybaN1OkmsqX20O" Ids="AGE40ZeMeSQOnIwRq6NP9l,IDSD09QuguvLVNcVE4iyhq" IsHidden="true" />
+          <ControlPoint Id="JuvN4GZzw5JLveCnok9Xgc" Bounds="98,321" />
+          <Link Id="Ovuqo9S1u0lNwAfGgjDeya" Ids="JuvN4GZzw5JLveCnok9Xgc,GnPT71PXLJUNpPfJuAFprg" />
+          <Pin Id="AlJGmIZjqTKQHFvkbpmgl3" Name="Input" Kind="InputPin" />
+          <Link Id="J4pkTJuHDQXMBubRyZujMz" Ids="AlJGmIZjqTKQHFvkbpmgl3,JuvN4GZzw5JLveCnok9Xgc" IsHidden="true" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ SortFixturesByDistance (Internal) ************************
+
+-->
+      <Node Name="SortFixturesByDistance (Internal)" Bounds="87,568,328,274" Id="CNUweUyFIyUONC13oN6LfF">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" />
+        </p:NodeReference>
+        <Patch Id="AjVGvq4dB6ZMXG0ib5kUkc">
+          <Node Bounds="122,616,281,179" Id="Up3fLyPJECOPAh3bsrCjla">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+              <CategoryReference Kind="ClassType" Name="Spread" NeedsToBeDirectParent="true" />
+              <Choice Kind="OperationCallFlag" Name="Sort (Comparer)" />
+            </p:NodeReference>
+            <Pin Id="MCDkgyZPUAfQbr2UDVaIny" Name="Input" Kind="StateInputPin" />
+            <Pin Id="CTATi6NXzjqPqXHSP5HebE" Name="Output" Kind="StateOutputPin" />
+            <Patch Id="Re8wYd4OEHVLwbi6u2Yad3" Name="Comparer" ManuallySortedPins="true">
+              <Pin Id="NOzRMBXVXb0NscLQrOK1H7" Name="Input 1" Kind="InputPin" />
+              <Pin Id="SLVMoTMpsnQLDXUhWvgIb2" Name="Input 2" Kind="InputPin" />
+              <Pin Id="DvXMzSYS9tDMXIGH7nw1iL" Name="Result" Kind="OutputPin" />
+              <ControlPoint Id="FF3J5JrwQdsMWH66dj2pCU" Bounds="136,624" />
+              <ControlPoint Id="QLesLedB1LGNPYeMCErmcW" Bounds="272,624" />
+              <ControlPoint Id="VqNqe5nSSDHLSDV0yBOCtc" Bounds="137,788" />
+              <Node Bounds="270,675,44,26" Id="HvgwMeyxaQsO3FinRS5XkC">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Y" />
+                </p:NodeReference>
+                <Pin Id="KJSplkAbpNOL5job1qjyo1" Name="Input" Kind="StateInputPin" />
+                <Pin Id="HUXZnkOrfjLMZUKTNYkQ7W" Name="Y" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="134,717,25,19" Id="C8Wp0cQ2UG2Mz3SxhbSIuz">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Math" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="&gt;" />
+                </p:NodeReference>
+                <Pin Id="Uqu9CyudwsiO6MSu7uhZzr" Name="Input" Kind="InputPin" />
+                <Pin Id="IjgLb6e83SJN0B3WhxMQv6" Name="Input 2" Kind="InputPin" />
+                <Pin Id="FfU2lDlweIxMeMo9tsI2eS" Name="Result" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="135,746,45,19" Id="AcbZJl0rK17MRyuvrjPo6s">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Switch" />
+                </p:NodeReference>
+                <Pin Id="EBd8BQhAq3FMcskyW8kR92" Name="Index" Kind="InputPin" />
+                <Pin Id="I1FsfWdOVvyNY2wes4TSc5" Name="Input" Kind="InputPin" DefaultValue="-1" />
+                <Pin Id="IlB0RXWCaRRNP6UQVcP2zB" Name="Input 2" Kind="InputPin" DefaultValue="1" />
+                <Pin Id="GS3Um8eeFJYOhrtSNf3Zfi" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="270,647,121,19" Id="AGmip8uOC14Ol3ASGUtT6z">
+                <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.SurfacesOutput" LastDependency="Schema.Plugins.Surfaces.Output - Copy.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetFixtureFinalPosition" />
+                </p:NodeReference>
+                <Pin Id="CRA0ypaViJ2O8vERbgZGTb" Name="Input" Kind="InputPin" />
+                <Pin Id="IRNEXFdYNL6NyIzK1kX6lm" Name="Result" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="134,675,44,26" Id="MbnQSmtvobKLycQTyJNG86">
+                <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Y" />
+                </p:NodeReference>
+                <Pin Id="SxASNu5XM0hLuXxMXgnjy2" Name="Input" Kind="StateInputPin" />
+                <Pin Id="UsDTIQdgb8DMVqWr5DpMhv" Name="Y" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="134,647,121,19" Id="BfGWgi9vrKdPYxYq5BKPrj">
+                <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.SurfacesOutput" LastDependency="Schema.Plugins.Surfaces.Output - Copy.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="GetFixtureFinalPosition" />
+                </p:NodeReference>
+                <Pin Id="GBdhiPVmIpAL5FzMTgSm5E" Name="Input" Kind="InputPin" />
+                <Pin Id="S7K3Y08kzP0LEiJCuXiime" Name="Result" Kind="OutputPin" />
+              </Node>
+            </Patch>
+          </Node>
+          <Link Id="KsoX9O7fHGCLY3RQUAkOpL" Ids="NOzRMBXVXb0NscLQrOK1H7,FF3J5JrwQdsMWH66dj2pCU" IsHidden="true" />
+          <Link Id="EWC4VryGvHHNKvpAk52wx9" Ids="SLVMoTMpsnQLDXUhWvgIb2,QLesLedB1LGNPYeMCErmcW" IsHidden="true" />
+          <Link Id="Q2zMmB9L4niMHYceYgUUqL" Ids="VqNqe5nSSDHLSDV0yBOCtc,DvXMzSYS9tDMXIGH7nw1iL" IsHidden="true" />
+          <Link Id="K41WMDwljmNMhiGaFZg9Sa" Ids="FfU2lDlweIxMeMo9tsI2eS,EBd8BQhAq3FMcskyW8kR92" />
+          <Link Id="JfewUAWHQL7OeARSxuFSGF" Ids="GS3Um8eeFJYOhrtSNf3Zfi,VqNqe5nSSDHLSDV0yBOCtc" />
+          <Link Id="LmsWVFAi6gRPPGYfFSS1Lp" Ids="HUXZnkOrfjLMZUKTNYkQ7W,IjgLb6e83SJN0B3WhxMQv6" />
+          <Link Id="EqQaIbjXYHXMAS2qPF9YRs" Ids="QLesLedB1LGNPYeMCErmcW,CRA0ypaViJ2O8vERbgZGTb" />
+          <Link Id="UcV9thH4WPENloGAHHvnEX" Ids="IRNEXFdYNL6NyIzK1kX6lm,KJSplkAbpNOL5job1qjyo1" />
+          <Link Id="MBUHrmmbd0zOBZKVAuVJfG" Ids="S7K3Y08kzP0LEiJCuXiime,SxASNu5XM0hLuXxMXgnjy2" />
+          <Link Id="RJE3rBYm65fOgzDo9ElrC1" Ids="UsDTIQdgb8DMVqWr5DpMhv,Uqu9CyudwsiO6MSu7uhZzr" />
+          <Link Id="QfJOyx95OCnNj6OiO7mV89" Ids="FF3J5JrwQdsMWH66dj2pCU,GBdhiPVmIpAL5FzMTgSm5E" />
+          <Pin Id="LVRqP9GVNNbNbHiYDSbIjb" Name="Input" Kind="InputPin" />
+          <ControlPoint Id="VuyYhTXdx2FMIymsiKLk9W" Bounds="122,586" />
+          <Link Id="BsWgAWFPiwLLXh3Y2Q3Qyc" Ids="LVRqP9GVNNbNbHiYDSbIjb,VuyYhTXdx2FMIymsiKLk9W" IsHidden="true" />
+          <Link Id="Ti2CsUx28B5NNQnIyVHdwm" Ids="VuyYhTXdx2FMIymsiKLk9W,MCDkgyZPUAfQbr2UDVaIny" />
+          <Pin Id="IylegwE9W8VMG3Jcks2Fb7" Name="Output" Kind="OutputPin" />
+          <ControlPoint Id="DTcWNxebaLUO6oQ03DAV9L" Bounds="122,825" />
+          <Link Id="KnaIHnejjt1MVhdpZrcB3b" Ids="DTcWNxebaLUO6oQ03DAV9L,IylegwE9W8VMG3Jcks2Fb7" IsHidden="true" />
+          <Link Id="IKAi7UsTJHRLEX4xocoKKL" Ids="CTATi6NXzjqPqXHSP5HebE,DTcWNxebaLUO6oQ03DAV9L" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="PqNzLFEOjmWObBlMqmJt5X">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="UuEXD29YG8bMXRUP0hkVoF">
+        <Canvas Id="IYeWQ5L7Lm3NGdpIIeRW1v" CanvasType="Group" />
+        <Patch Id="Q6I1OqV0Ov8NbIU3p3psCp" Name="Create" />
+        <Patch Id="CY5MNOvc09cQNQEOBPS8Mc" Name="Update" />
+        <ProcessDefinition Id="UmW5PCPHsoyNvfTTvi7rBK">
+          <Fragment Id="HZj8NwjbOB5MaN1w6B2FSt" Patch="Q6I1OqV0Ov8NbIU3p3psCp" Enabled="true" />
+          <Fragment Id="Ecljg3hozAHNZpP8tEN9Kl" Patch="CY5MNOvc09cQNQEOBPS8Mc" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="Dh18pTWyGOUMOJHES4lxuv" Location="VL.Skia" Version="2025.7.0-0002-g93330f7cea" />
+  <DocumentDependency Id="GtoNSr5Jck5MoLUBgvyH2B" Location="../../../VVVV.Schema.Core.vl" />
+  <DocumentDependency Id="PXXQC734twkPzvFz6zbV6M" Location="../../../UI/Schema.UI.Camera.vl" />
+  <NugetDependency Id="IeRfMfEoiluO7iujOcuIIn" Location="VL.WinFormsUtils" Version="1.0.9" />
+  <DocumentDependency Id="MLaZ39lusIgL1STTLSrfaF" Location="../../../Schema.PropertyExtensions.vl" />
+  <DocumentDependency Id="PxWeqnqhgfJMsuK66ZIGT2" Location="../../../Extensions/Resource/Schema.Extensions.Resource.vl" />
+  <DocumentDependency Id="SNEP883xu4TOghojjD9lDL" Location="../Extensions/Schema.Plugins.Surfaces.Extensions.ResourceMode.vl" />
+  <NugetDependency Id="PfRjHWJcPgXOgqoqiz9hSX" Location="VL.Stride" Version="2025.7.0-0002-g93330f7cea" />
+</Document>

--- a/Main/vl/Plugins/Surfaces/Schema.Plugins.Surfaces.vl
+++ b/Main/vl/Plugins/Surfaces/Schema.Plugins.Surfaces.vl
@@ -1,0 +1,291 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="Qs5m35w5PVhMYwithHCZjD" LanguageVersion="2025.7.0-0002-g93330f7cea" Version="0.128">
+  <NugetDependency Id="IayehzgJYuuPzRaVq5PsRr" Location="VL.CoreLib" Version="2025.7.0-0002-g93330f7cea" />
+  <Patch Id="FYTcOwkjvUHLVXFz2wjaXQ">
+    <Canvas Id="BTDVuqzOhBKNrU0CoSxSZY" DefaultCategory="Schema.Plugins.Surfaces" CanvasType="FullCategory">
+      <!--
+
+    ************************ SurfacesPlugin ************************
+
+-->
+      <Node Name="SurfacesPlugin" Bounds="114,108" Id="AbE3gh8NVZyLdhp8W6bvEi">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
+          <Choice Kind="ContainerDefinition" Name="Process" />
+        </p:NodeReference>
+        <Patch Id="SeTyTvdfuorLA7zQO7pMtO">
+          <Canvas Id="OmGVA9C6q7mOpvvyatnvvc" CanvasType="Group">
+            <Node Bounds="631,406,105,26" Id="AeLbfX9TmAcPkySS7cEpOX">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="IsReloadingOutputs" />
+              </p:NodeReference>
+              <Pin Id="GdzBsuIzURsPdIP5zCSC1J" Name="Input" Kind="StateInputPin" />
+              <Pin Id="SfKP42Cn2PeO0virAar26K" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="TCtJGaQTn76LUuUFWhRIT5" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="619,521,181,116" Id="OqhHUPHktfcM1ylvCgrwsk">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+              </p:NodeReference>
+              <Pin Id="RtHzgiIwWHDPEQ2Cdl5MeH" Name="Condition" Kind="InputPin" />
+              <ControlPoint Id="LM7ZpfcVKhuMcyTqA7RupD" Bounds="633,527" Alignment="Top" />
+              <ControlPoint Id="TA8AB6pefhzOYDfSCwWmtD" Bounds="633,631" Alignment="Bottom" />
+              <Patch Id="CxWx7MB4GyFPP9fRz8jqjM" ManuallySortedPins="true">
+                <Patch Id="K0ELvRP8t7fQFxrk7ZLJQ8" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="S6cUQvK3L6BPhPyzb56dcU" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="638,584,85,26" Id="UE48Ke5UlAKP397AesFdV1">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RegisterOutput" />
+                  </p:NodeReference>
+                  <Pin Id="TsPsJ6SdkGFL0HivZom8cR" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="LnfeqEriXiWQOo2wRvqoPP" Name="Key" Kind="InputPin" DefaultValue="Surfaces">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="String" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="KBite3w29HxLMOn4QaaeIg" Name="Value" Kind="InputPin" />
+                  <Pin Id="UQxO3JPCfiXPW8VE3owKgU" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="717,544,71,26" Id="P7WQ8wM4Sg9OZeeRtStG4C">
+                  <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Output.SurfacesOutput" LastDependency="Schema.Plugins.Surfaces.Output.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                    <CategoryReference Kind="ClassType" Name="SurfacesOutput" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="J5aFS2Cq3zBN3wXwrhRd3J" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="DPQEK2ggG3lO0dqVbH1S1A" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Patch>
+            </Node>
+            <ControlPoint Id="MujehUUJ0bzM89yyiiKTIn" Bounds="659,1468" />
+            <ControlPoint Id="Q6NNKCnHNVMLdAB4f50QRC" Bounds="631,364" />
+            <Node Bounds="631,470,104,26" Id="DgCKQB54IzdQBdmEUwtq9T">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetProjectDirectory" />
+              </p:NodeReference>
+              <Pin Id="GwRF3t0FCrcPx8u4oIblIW" Name="Input" Kind="StateInputPin" />
+              <Pin Id="MiBleFtS3odMFRbEnEsNn9" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="JjhuvQ662cbOrx0qJZsMVj" Name="Project Directory" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="642,661,99,26" Id="JLAX9zWPCc3MCWr9QhB65M">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="IsReloadingEnums" />
+              </p:NodeReference>
+              <Pin Id="J5JiBYAmln1P0XehEW6Zyg" Name="Input" Kind="StateInputPin" />
+              <Pin Id="DSvqSCGKarfMude1kxywY1" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="VX42hWvKZbyMx85HlcBUfB" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="654,950,98,26" Id="C6jAlgpmyksP3DWwpX8gXj">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="IsReloadingBlocks" />
+              </p:NodeReference>
+              <Pin Id="LNQaYu0VlYOOePlIIU6aVK" Name="Input" Kind="StateInputPin" />
+              <Pin Id="LXDRpVzHeXiOQY8bskrU8Z" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="BNPPMI2uXSiLijmKijmYjQ" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="622,718,383,183" Id="FgfORuR39eyNUHOcDQuMUn">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+              </p:NodeReference>
+              <Pin Id="JUI8QoJxufNNqkt51PtGwf" Name="Condition" Kind="InputPin" />
+              <ControlPoint Id="Olhwu6fhEEUM724AvflIGd" Bounds="660,724" Alignment="Top" />
+              <ControlPoint Id="JPPrr0F7TDQNqOI5PPeXcs" Bounds="660,895" Alignment="Bottom" />
+              <Patch Id="CP7s87jLxlXMI6PQXGgeLQ" ManuallySortedPins="true">
+                <Patch Id="AjjQQxwS9pSP3PUmerarF4" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="U6wLeak9ZLmNiJJKzrEmHk" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="660,741,125,26" Id="NE0RTvpLPrHPABBIssY9uy">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="State" />
+                    <Choice Kind="OperationCallFlag" Name="Split" />
+                  </p:NodeReference>
+                  <Pin Id="M3yfL1HZsqjOnx9LQK6hM7" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="MCow3MIXjwNPfsIslEidJT" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="FXkWZkZFn78LTc99d9xUJ7" Name="Fixtures" Kind="OutputPin" />
+                  <Pin Id="Fr7HVyGH8sAMc1zcZRaWPb" Name="Global Properties" Kind="OutputPin" />
+                  <Pin Id="LDvb3B1ItJ3M0sYNyhLFrU" Name="Director" Kind="OutputPin" />
+                  <Pin Id="NNSLf0SAABvM4UmGARY2I8" Name="Enum Registry" Kind="OutputPin" />
+                  <Pin Id="NzuSuk4DqJJNpNSkrZ8z6F" Name="Tree Registry" Kind="OutputPin" />
+                  <Pin Id="Ize1pJxznbHOYbogFyYXq3" Name="Bee Registry" Kind="OutputPin" />
+                </Node>
+              </Patch>
+            </Node>
+            <Node Bounds="579,992,480,396" Id="CrWzxJn3pVyO2jpCYdkBIf">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+              </p:NodeReference>
+              <Pin Id="NNG52Q2qSDxNkTj9uPISXQ" Name="Condition" Kind="InputPin" />
+              <ControlPoint Id="A6tOEZn85xULRr6Nrx7n8A" Bounds="656,998" Alignment="Top" />
+              <ControlPoint Id="FGNPBFKohRiNx6NzFzmJD7" Bounds="658,1382" Alignment="Bottom" />
+              <Patch Id="GjkYFFEMl6vLJ9rToyao8d" ManuallySortedPins="true">
+                <Patch Id="QgT14c1LRhKNpZpYeHfyur" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="LR1QKIcwqP8OoYhvtHRENY" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="656,1040,148,80" Id="Cghe1wKPGLiOVxFk3zatK3">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
+                  </p:NodeReference>
+                  <Pin Id="AYdd0WrWG7eLQWRFcqjyYV" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="UWbQnPCkGyuNpBp8CVKQmL" Name="Key" Kind="InputPin" />
+                  <Pin Id="Rn7yO1XAUjyOrsn5yNUC0a" Name="Output" Kind="StateOutputPin" />
+                  <Patch Id="FWlVrzF0GfaMahVVK79QWY" Name="Constructor" ManuallySortedPins="true">
+                    <Pin Id="SF5Lx8IGjRRLOh1iz74l4L" Name="Result" Kind="OutputPin" />
+                    <ControlPoint Id="TFesmbMp94rLBaqLDcNBzd" Bounds="670,1113" />
+                    <Node Bounds="668,1063,124,26" Id="FYUZ0qV2oTyMhPV7Bz8Wjo">
+                      <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Blocks.Source.Texture.ColorTextureSource" LastDependency="Schema.Plugins.Surfaces.Blocks.Source.Texture.Color.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="ColorTextureSource" />
+                        <Choice Kind="OperationCallFlag" Name="Create" />
+                      </p:NodeReference>
+                      <Pin Id="DWXdC61EyrfNrmPHLHyV3P" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="PgaaYolJtz3M5snuAYtb1z" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                  </Patch>
+                </Node>
+                <Pad Id="A5CaxzQPkaALsnbV7M1qRT" Comment="Key" Bounds="801,1020,205,15" ShowValueBox="true" isIOBox="true" Value="Create.Texture.Color">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="656,1159,148,80" Id="D4r48cOCrRoNfo9ULTnu1y">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
+                  </p:NodeReference>
+                  <Pin Id="NZOxDu3iyKuNBKLt2GOVC8" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="DCq5gMeeOyCP5stWP2S5Z5" Name="Key" Kind="InputPin" />
+                  <Pin Id="MCjXaQrF6HpM9b7wLxkVUo" Name="Output" Kind="StateOutputPin" />
+                  <Patch Id="SPW7Kpon0y7LuYnhtnFmPb" Name="Constructor" ManuallySortedPins="true">
+                    <Pin Id="Q3dZSSzKAXWP0NIb3uIR77" Name="Result" Kind="OutputPin" />
+                    <ControlPoint Id="GOXDFdp8XloLy3V7qubNlD" Bounds="670,1232" />
+                    <Node Bounds="668,1182,124,26" Id="BG8GpYgMYU3LKUe5HX1rRB">
+                      <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Blocks.Source.Texture.NoiseTextureSource" LastDependency="Schema.Plugins.Surfaces.Blocks.Source.Texture.Noise.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="NoiseTextureSource" />
+                        <Choice Kind="OperationCallFlag" Name="Create" />
+                      </p:NodeReference>
+                      <Pin Id="In7B6emVhX4MuSMdEXVdEG" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="U2jZJEygYOnLo9cSbOtRBE" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                  </Patch>
+                </Node>
+                <Pad Id="LQ7FQqsZ42dNd0md9xLqHX" Comment="Key" Bounds="801,1137,205,15" ShowValueBox="true" isIOBox="true" Value="Create.Texture.Noise">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="658,1284,148,80" Id="KQxfNboQu2iQPEDyc3PaQU">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="RegisterBlock" />
+                  </p:NodeReference>
+                  <Pin Id="J9Lawv2zEZ8LmL8bRufB3P" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="LgqUF0pATj1PyQWRCGCXBI" Name="Key" Kind="InputPin" />
+                  <Pin Id="Hol5sV30fAVPMPjr766e47" Name="Output" Kind="StateOutputPin" />
+                  <Patch Id="PeQlfDkEUtKNBWP6WUhxAp" Name="Constructor" ManuallySortedPins="true">
+                    <Pin Id="BgbDC4lfU0IMkMxJAZHxkT" Name="Result" Kind="OutputPin" />
+                    <ControlPoint Id="LJqi7dbxizYPk1hgqeCM7r" Bounds="672,1357" />
+                    <Node Bounds="670,1307,124,26" Id="R66ky1XHDI2MFOxrbPu9zd">
+                      <p:NodeReference LastCategoryFullName="Schema.Plugins.Surfaces.Blocks.Combine.Texture.MultiplyTextureCombine" LastDependency="Schema.Plugins.Surfaces.Blocks.Combine.Multiply.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="MultiplyTextureCombine" />
+                        <Choice Kind="OperationCallFlag" Name="Create" />
+                      </p:NodeReference>
+                      <Pin Id="DX5ZFRXILqjND34qbk9PTR" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="Tkloz205vQvQU0yCPntHqt" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                  </Patch>
+                </Node>
+                <Pad Id="SSdzDg2qg3oO3VUtk2nmMC" Comment="Key" Bounds="803,1262,205,15" ShowValueBox="true" isIOBox="true" Value="Combine.Texture.Multiply">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+              </Patch>
+            </Node>
+          </Canvas>
+          <Patch Id="KusRl61P0yAL1spU5HyuN2" Name="Create" />
+          <Patch Id="MOpVW131ElWQUxLhn7SPnp" Name="Update">
+            <Pin Id="AysY6gw35GvLVEf6vpg6ns" Name="Output" Kind="OutputPin" Bounds="619,618" />
+            <Pin Id="EU1oAZpeMTDOMmGsV5zPRs" Name="Input" Kind="InputPin" />
+          </Patch>
+          <ProcessDefinition Id="IEO8KlWjVwvO8lumrutg7G">
+            <Fragment Id="UjXkDqtz1TkPG5Bizkb6Dl" Patch="KusRl61P0yAL1spU5HyuN2" Enabled="true" />
+            <Fragment Id="UI9smEBWQfkQJiqwcJHtnS" Patch="MOpVW131ElWQUxLhn7SPnp" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="Emel1XF4MjrOQWLCrO41PW" Ids="TCtJGaQTn76LUuUFWhRIT5,RtHzgiIwWHDPEQ2Cdl5MeH" />
+          <Link Id="TvHMRdGrZuSMJ1rZqvrwSW" Ids="LM7ZpfcVKhuMcyTqA7RupD,TA8AB6pefhzOYDfSCwWmtD" IsFeedback="true" />
+          <Link Id="O8qmhbMyW5QPAhK3XrFMOZ" Ids="LM7ZpfcVKhuMcyTqA7RupD,TsPsJ6SdkGFL0HivZom8cR" />
+          <Link Id="HeVXon5WELUQdleEIS4hPd" Ids="UQxO3JPCfiXPW8VE3owKgU,TA8AB6pefhzOYDfSCwWmtD" />
+          <Link Id="Rme8KBniKBbO1dQcGikpOu" Ids="MujehUUJ0bzM89yyiiKTIn,AysY6gw35GvLVEf6vpg6ns" IsHidden="true" />
+          <Link Id="BkUFiWiZSisMvOPF6vWrXS" Ids="EU1oAZpeMTDOMmGsV5zPRs,Q6NNKCnHNVMLdAB4f50QRC" IsHidden="true" />
+          <Link Id="H49JXq50K2fPCb0jOurJHx" Ids="Q6NNKCnHNVMLdAB4f50QRC,GdzBsuIzURsPdIP5zCSC1J" />
+          <Link Id="B3eOQQNFxosM5Obo50gLgS" Ids="DPQEK2ggG3lO0dqVbH1S1A,KBite3w29HxLMOn4QaaeIg" />
+          <Link Id="Q1IKUuKqU3QLBNCS8wDlbl" Ids="SfKP42Cn2PeO0virAar26K,GwRF3t0FCrcPx8u4oIblIW" />
+          <Link Id="EGXzkx8Smp1P7LVttoaKdY" Ids="MiBleFtS3odMFRbEnEsNn9,LM7ZpfcVKhuMcyTqA7RupD" />
+          <Link Id="HsJpIgeqrWxNo8c9dabQvx" Ids="TA8AB6pefhzOYDfSCwWmtD,J5JiBYAmln1P0XehEW6Zyg" />
+          <Link Id="BhEw5MINdQbMiSuCd5BiN8" Ids="VX42hWvKZbyMx85HlcBUfB,JUI8QoJxufNNqkt51PtGwf" />
+          <Link Id="HooS10O2rn8QFR8YZFSO23" Ids="Olhwu6fhEEUM724AvflIGd,JPPrr0F7TDQNqOI5PPeXcs" IsFeedback="true" />
+          <Link Id="QIhzw5IMK8ZNaNb185EYrE" Ids="DSvqSCGKarfMude1kxywY1,Olhwu6fhEEUM724AvflIGd" />
+          <Link Id="KSRVnNGqUaCOw8ooBYe1S0" Ids="Olhwu6fhEEUM724AvflIGd,M3yfL1HZsqjOnx9LQK6hM7" />
+          <Link Id="BU4rXWwzQElQVQXUKSswmh" Ids="MCow3MIXjwNPfsIslEidJT,JPPrr0F7TDQNqOI5PPeXcs" />
+          <Link Id="V4LyJ6NQgShNmwPI2yTUuv" Ids="JPPrr0F7TDQNqOI5PPeXcs,LNQaYu0VlYOOePlIIU6aVK" />
+          <Link Id="AvOEtJcJL31O8MH5eFInwY" Ids="TFesmbMp94rLBaqLDcNBzd,SF5Lx8IGjRRLOh1iz74l4L" IsHidden="true" />
+          <Link Id="REqTEwXIZE9La9n5knLkjI" Ids="A6tOEZn85xULRr6Nrx7n8A,FGNPBFKohRiNx6NzFzmJD7" IsFeedback="true" />
+          <Link Id="VTFIDGz31g0NRzLk92uqWk" Ids="A6tOEZn85xULRr6Nrx7n8A,AYdd0WrWG7eLQWRFcqjyYV" />
+          <Link Id="S1RMklgmkbEMOrkSMEWkka" Ids="LXDRpVzHeXiOQY8bskrU8Z,A6tOEZn85xULRr6Nrx7n8A" />
+          <Link Id="IZktGmzR0fUNn3jjsPGyFn" Ids="PgaaYolJtz3M5snuAYtb1z,TFesmbMp94rLBaqLDcNBzd" />
+          <Link Id="RSczxIlApCWNLGK2n6RZEG" Ids="A5CaxzQPkaALsnbV7M1qRT,UWbQnPCkGyuNpBp8CVKQmL" />
+          <Link Id="FIyxuC4U3gLOYlNHTuEx62" Ids="FGNPBFKohRiNx6NzFzmJD7,MujehUUJ0bzM89yyiiKTIn" />
+          <Link Id="GSa1NV3WsTeMw6uyhGBAwE" Ids="BNPPMI2uXSiLijmKijmYjQ,NNG52Q2qSDxNkTj9uPISXQ" />
+          <Link Id="S7fYALIgvm8Mp8J22AhAtw" Ids="GOXDFdp8XloLy3V7qubNlD,Q3dZSSzKAXWP0NIb3uIR77" IsHidden="true" />
+          <Link Id="OeRdAr76nXbNOzQKpqcMfX" Ids="U2jZJEygYOnLo9cSbOtRBE,GOXDFdp8XloLy3V7qubNlD" />
+          <Link Id="Mko3KemAF8MONmhtchDHwV" Ids="Rn7yO1XAUjyOrsn5yNUC0a,NZOxDu3iyKuNBKLt2GOVC8" />
+          <Link Id="QAWIzUz1eteMNgzo2ecKOl" Ids="LQ7FQqsZ42dNd0md9xLqHX,DCq5gMeeOyCP5stWP2S5Z5" />
+          <Link Id="Gdvff86wlHoQWUzujbFB0R" Ids="LJqi7dbxizYPk1hgqeCM7r,BgbDC4lfU0IMkMxJAZHxkT" IsHidden="true" />
+          <Link Id="Sb0CewtNYYqNxCYrp4qX1u" Ids="Tkloz205vQvQU0yCPntHqt,LJqi7dbxizYPk1hgqeCM7r" />
+          <Link Id="BtmJfSdgWZVPUZpbiPWabl" Ids="SSdzDg2qg3oO3VUtk2nmMC,LgqUF0pATj1PyQWRCGCXBI" />
+          <Link Id="Pu8k6LVCUXCNxv40AuTe9B" Ids="MCjXaQrF6HpM9b7wLxkVUo,J9Lawv2zEZ8LmL8bRufB3P" />
+          <Link Id="KNXRP21kB8SLUAJIMdkyZu" Ids="Hol5sV30fAVPMPjr766e47,FGNPBFKohRiNx6NzFzmJD7" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="C3I62KkqlrTL56Y76YBRwP">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="G2aPHVktRncL4EstAhfRdW">
+        <Canvas Id="Ja9FYruC9OGOGXLUdXOCiv" CanvasType="Group" />
+        <Patch Id="QHOuGwgXO68QdEoo9x4wDq" Name="Create" />
+        <Patch Id="TuzMxi3QZQYPwsdtMX82VZ" Name="Update" />
+        <ProcessDefinition Id="VuK3HP0CeqUOe4L0Ofw843">
+          <Fragment Id="B9Czm0DKzQ4M2H66WM5XeW" Patch="QHOuGwgXO68QdEoo9x4wDq" Enabled="true" />
+          <Fragment Id="Lfgsk5trWKxOPjnaa39f5U" Patch="TuzMxi3QZQYPwsdtMX82VZ" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="VQamwCeXtG7Npz2fiLcHor" Location="VL.Skia" Version="2025.7.0-0002-g93330f7cea" />
+  <DocumentDependency Id="NY4ubYimEa9QEC55xJmgbi" Location="./Output/Schema.Plugins.Surfaces.Output.vl" />
+  <DocumentDependency Id="IrjbTwT1swuMGtN3wsCQFY" Location="../../VVVV.Schema.Core.vl" />
+  <DocumentDependency Id="HHXnb3dpWxuMLDDIOppqEY" Location="./Blocks/Schema.Plugins.Surfaces.Blocks.Source.Texture.Color.vl" />
+  <DocumentDependency Id="TwJhMzmS4e7LLhTfJOIbVW" Location="./Extensions/Schema.Plugins.Surfaces.Extensions.Texture.vl" />
+  <DocumentDependency Id="FGcVUwlb4WgMSJFnj9oq7H" Location="./Blocks/Schema.Plugins.Surfaces.Blocks.Combine.Multiply.vl" />
+  <DocumentDependency Id="TVIQQgI7cdxLO5tkzSnLkW" Location="./Blocks/Schema.Plugins.Surfaces.Blocks.Source.Texture.Noise.vl" />
+</Document>

--- a/Main/vl/Plugins/XBoxController/Schema.Plugins.XBoxController.vl
+++ b/Main/vl/Plugins/XBoxController/Schema.Plugins.XBoxController.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Ek8QQnm3YhpLHHjoyrvom5" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="Ek8QQnm3YhpLHHjoyrvom5" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="DTd774zLcseLGBRmr2yH0M" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Eny9LQLNx9uLh7Foc0vhnV">
     <Canvas Id="RzIPJGd57R3QRCbNzjSDjn" DefaultCategory="Schema.Plugins.XBoxController" CanvasType="FullCategory">
       <!--
@@ -520,8 +520,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="VedtIDoRe4uNPx3COdWpHC" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="VedtIDoRe4uNPx3COdWpHC" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="SMtEvYqQ0XBNcOrpsTh0oI" Location="../../VVVV.Schema.Core.vl" />
-  <NugetDependency Id="ULkdtBZTTq5PNxOQrRYqVY" Location="ncalc" Version="1.3.8" />
   <NugetDependency Id="RU48RZgP5C6N901SYwU1h1" Location="VL.IO.Xbox360Controller" Version="1.0.4" />
 </Document>

--- a/Main/vl/Schema.App.vl
+++ b/Main/vl/Schema.App.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="ChVmkF4mHOWMFyheJQAIh5" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="ChVmkF4mHOWMFyheJQAIh5" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="UE30RSOrMKfNsdpEs0ZFYR" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="Ep2iriBhATjLXxcs4iOjXi">
     <Canvas Id="LgcqCAAEeisOEqqW9H5Ak2" DefaultCategory="Schema.App" CanvasType="FullCategory">
       <!--

--- a/Main/vl/Schema.Projects.vl
+++ b/Main/vl/Schema.Projects.vl
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="S8UvIzJI4xaMpRHM4LsW1a" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="Ev2bqZ1Eo0DMuKrCv46omb" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="S8UvIzJI4xaMpRHM4LsW1a" LanguageVersion="2025.7.0" Version="0.128">
   <Patch Id="U22k9dk7LhZL8HTA3tN2sI">
     <Canvas Id="LC8mvV1rs74OGbJrOqm45s" DefaultCategory="Schema.Projects" CanvasType="FullCategory">
       <!--
@@ -14,7 +13,7 @@
         </p:NodeReference>
         <Patch Id="BmrIIJPQ7xpL5c4eNVKg3U">
           <Canvas Id="OICIxji2AhBOQKYF1xrP5W" CanvasType="Group">
-            <Node Bounds="434,344,134,26" Id="RvgbEfExqudPNJL4zphvWM">
+            <Node Bounds="442,310,134,26" Id="RvgbEfExqudPNJL4zphvWM">
               <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Path" />
@@ -23,9 +22,8 @@
               <Pin Id="KPfEzTZZtenLsE7LcyWYco" Name="Input" Kind="StateInputPin" />
               <Pin Id="QRhyiQxRJx2MdHCV3fBKFO" Name="Input 2" Kind="InputPin" />
               <Pin Id="SM8v9Y3fYjwLoIXy6cbL7E" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="Jf1BxdOCpC9MHQHGu0xs18" Name="Input 3" Kind="InputPin" />
             </Node>
-            <Node Bounds="389,403,84,26" Id="J7F3Au71PyiLjrbRjg1EKF">
+            <Node Bounds="389,489,84,26" Id="J7F3Au71PyiLjrbRjg1EKF">
               <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="DirectoryExists" />
@@ -33,21 +31,21 @@
               <Pin Id="LdZeUYBK8CcLxZ6bDibFeY" Name="Input" Kind="StateInputPin" />
               <Pin Id="JsNvvQJvoJfLJ75MS49npV" Name="Exists" Kind="OutputPin" />
             </Node>
-            <Node Bounds="320,476,186,366" Id="IIv4jietnoGPsfwxsgYoFi">
+            <Node Bounds="264,562,242,366" Id="IIv4jietnoGPsfwxsgYoFi">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
               <Pin Id="PlKi9VSsfWRN2mPkjnGZsi" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="AEuJvhUYmdKQTsMYOeObld" Bounds="404,808" Alignment="Bottom" />
-              <ControlPoint Id="SERtmfhWH8gOFM8U7GKikx" Bounds="408,489" Alignment="Top" />
-              <ControlPoint Id="QtqBb3b6G9uO3Mk4vu033G" Bounds="430,836" Alignment="Bottom" />
-              <ControlPoint Id="UZm0uOa7ZaJOEpfcFxEQpk" Bounds="430,482" Alignment="Top" />
+              <ControlPoint Id="AEuJvhUYmdKQTsMYOeObld" Bounds="404,922" Alignment="Bottom" />
+              <ControlPoint Id="SERtmfhWH8gOFM8U7GKikx" Bounds="408,568" Alignment="Top" />
+              <ControlPoint Id="QtqBb3b6G9uO3Mk4vu033G" Bounds="430,922" Alignment="Bottom" />
+              <ControlPoint Id="UZm0uOa7ZaJOEpfcFxEQpk" Bounds="430,568" Alignment="Top" />
               <Patch Id="BagjhyG6HQ2LaFTbvZglqu" ManuallySortedPins="true">
                 <Patch Id="Nnv1rKvT5xwPF98gAQWIQH" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="ApgeydCZNHlLYzRb8pYUQV" Name="Then" ParticipatingElements="Ty382YGFIm5LEoD3EKM2Kl,CtKhwJu0XmTMNmfymKjwF4" ManuallySortedPins="true" />
-                <Node Bounds="362,499,87,19" Id="MA7w2JiVd1nMzYt8GpPxS0">
+                <Node Bounds="362,585,87,19" Id="MA7w2JiVd1nMzYt8GpPxS0">
                   <p:NodeReference LastCategoryFullName="System.Application" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ApplicationPath" />
@@ -55,7 +53,7 @@
                   <Pin Id="VU4WX5Xgc40M4Rvq2mrv34" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="DaQsIHrf18bMetMZht8AVR" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="362,566,57,26" Id="Ty382YGFIm5LEoD3EKM2Kl">
+                <Node Bounds="362,652,57,26" Id="Ty382YGFIm5LEoD3EKM2Kl">
                   <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Path" />
@@ -65,7 +63,7 @@
                   <Pin Id="DIg1SLzyk7tOvA1Yehc06j" Name="Input 2" Kind="InputPin" />
                   <Pin Id="NleJwKmNr7ZQZ6dwTxGf4A" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="362,533,57,19" Id="CtKhwJu0XmTMNmfymKjwF4">
+                <Node Bounds="362,619,57,19" Id="CtKhwJu0XmTMNmfymKjwF4">
                   <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
@@ -75,14 +73,14 @@
                   <Pin Id="UutL6UVhyPQPKaVUe413s5" Name="Extension" Kind="InputPin" />
                   <Pin Id="RiPBRrAHvSOOs39dSoUUYa" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="351,651,69,91" Id="J5AmSkkCGUjPaKJx7YYOCk">
+                <Node Bounds="369,796,71,91" Id="J5AmSkkCGUjPaKJx7YYOCk">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
                   </p:NodeReference>
                   <Patch Id="LDhGH2j9cOlOvQzX4s63pg" ManuallySortedPins="true">
-                    <ControlPoint Id="M1BiwkOloepQVyGq0APyFG" Bounds="367,735" />
-                    <Node Bounds="363,674,45,26" Id="OO0gX7ekBREM9AilgJky7s">
+                    <ControlPoint Id="M1BiwkOloepQVyGq0APyFG" Bounds="385,880" />
+                    <Node Bounds="381,819,45,26" Id="OO0gX7ekBREM9AilgJky7s">
                       <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Copy" />
@@ -103,14 +101,13 @@
                       <Pin Id="P4TTwk3nE5qLVMrJpFLqch" Name="Output" Kind="OutputPin" />
                     </Patch>
                   </Patch>
-                  <Pin Id="MlPOlMjo09FN4BjHuk7SJ3" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="O6yDtVQ4A9cQDTma9uUgzu" Name="Default Output" Kind="InputPin" />
                   <Pin Id="CK0IYIA1rd5NzXQmA7K8bu" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RDdeBXoIYFSLEFdwgZeUu8" Name="Result" Kind="OutputPin" />
                   <Pin Id="Njwb3GsUwglPRAwa5miaH0" Name="Success" Kind="OutputPin" />
                   <Pin Id="F5ol1ook82mP8KOE2YuEjq" Name="Error Message" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="437,533,57,19" Id="LdbjhXzSCPfOh9TBkNMQm5">
+                <Node Bounds="437,619,57,19" Id="LdbjhXzSCPfOh9TBkNMQm5">
                   <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
@@ -124,9 +121,28 @@
                   <Pin Id="U85WpNkvqmAOMjVWeejM5R" Name="Extension" Kind="InputPin" />
                   <Pin Id="CfZS2kPBcIFM4cfCRbSlsJ" Name="Result" Kind="OutputPin" />
                 </Node>
+                <Node Bounds="276,717,48,19" Id="EIWJBqUE8fwOQ8Gov6ycXj">
+                  <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Format" />
+                  </p:NodeReference>
+                  <Pin Id="BFYkff8YDmuLPM91aw9XD7" Name="Format" Kind="InputPin" DefaultValue="Initializing Project Root: {0} -&gt; {1}" />
+                  <Pin Id="OUkFZ0jDwZnPiuNp8Rk17J" Name="Input" Kind="InputPin" />
+                  <Pin Id="SRhkqErsb8JPejrLAEdPw2" Name="Output" Kind="OutputPin" />
+                  <Pin Id="MDzFRFaeglHQDdfNnpRtwR" Name="Input 2" Kind="InputPin" />
+                </Node>
+                <Node Bounds="276,760,51,19" Id="AfvmpxmqUsYMWUp5D62IvU">
+                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+                  </p:NodeReference>
+                  <Pin Id="CGn4xTIg6MTODsO50rnP7w" Name="Message" Kind="InputPin" />
+                  <Pin Id="IeQ1MbdjsPWMrOhP4kTsvz" Name="Apply" Kind="InputPin" />
+                </Node>
               </Patch>
             </Node>
-            <Node Bounds="388,437,37,19" Id="RCi1t7We6fRLYtjyRZkIQu">
+            <Node Bounds="388,523,37,19" Id="RCi1t7We6fRLYtjyRZkIQu">
               <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -134,7 +150,7 @@
               <Pin Id="CZXWkUgou3APCes6Ka1Um2" Name="Input" Kind="StateInputPin" />
               <Pin Id="UAjXg1UakOCPuijjJZwkJD" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="564,309,57,19" Id="KqbuBJirmLdO4IICASGg78">
+            <Node Bounds="571,270,57,19" Id="KqbuBJirmLdO4IICASGg78">
               <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
@@ -148,15 +164,15 @@
               <Pin Id="M9oe7r2vYXTL7KgeCPgfY1" Name="Extension" Kind="InputPin" />
               <Pin Id="DD2y5CFjl7rMK0I9KBO5Zm" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="Klndr0ZKcomQKGhHvcbkCH" Bounds="419,1131" />
-            <Node Bounds="201,888,154,162" Id="LwH4pCLrtmNNGIaQ0xWpQD">
+            <ControlPoint Id="Klndr0ZKcomQKGhHvcbkCH" Bounds="419,1217" />
+            <Node Bounds="201,974,154,162" Id="LwH4pCLrtmNNGIaQ0xWpQD">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
-              <ControlPoint Id="BqswTiYzBP7OxshGGsSKcC" Bounds="215,894" Alignment="Top" />
-              <ControlPoint Id="DgF5T2e14wONpO6Ge3389c" Bounds="215,1044" Alignment="Bottom" />
+              <ControlPoint Id="BqswTiYzBP7OxshGGsSKcC" Bounds="215,980" Alignment="Top" />
+              <ControlPoint Id="DgF5T2e14wONpO6Ge3389c" Bounds="215,1130" Alignment="Bottom" />
               <Pin Id="GgCmHOtFOrBPfsIYd0hvti" Name="Condition" Kind="InputPin" DefaultValue="True">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
@@ -165,7 +181,7 @@
               <Patch Id="CxBMUj1ijoyLY6fRvQQoAc" ManuallySortedPins="true">
                 <Patch Id="HceLHtbNPEnLUX3feiZcMi" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="UB1gb1Ze9W6LXciRW3BVW0" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="261,965,72,19" Id="VCuN98C8WadPNbW5hRkDbY">
+                <Node Bounds="261,1051,72,19" Id="VCuN98C8WadPNbW5hRkDbY">
                   <p:NodeReference LastCategoryFullName="Control.Parallel" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ThreadSleep" />
@@ -178,7 +194,7 @@
                 </Node>
               </Patch>
             </Node>
-            <ControlPoint Id="NjxQG0oHZbROh5807QGSRp" Bounds="565,261" />
+            <ControlPoint Id="NjxQG0oHZbROh5807QGSRp" Bounds="573,240" />
             <Node Bounds="442,229,118,19" Id="J0scOKzSOVeP4R68Q917nd">
               <p:NodeReference LastCategoryFullName="Schema.Projects" LastDependency="Schema.Projects.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -186,9 +202,54 @@
               </p:NodeReference>
               <Pin Id="VgXymAIzlZ6OCFwClrgejJ" Name="Output" Kind="OutputPin" />
             </Node>
+            <Node Bounds="362,270,48,19" Id="RFAg5mMy4LINiqCXPqCokp">
+              <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="Format" />
+              </p:NodeReference>
+              <Pin Id="S9W36rmc3ysMN5dZdaSZ5N" Name="Format" Kind="InputPin" DefaultValue="Project Root Folder: {0}" />
+              <Pin Id="MH4uw5sEhJUO1YJzvu81Da" Name="Input" Kind="InputPin" />
+              <Pin Id="ObWTJ2HsSxOLEvlodMiTC8" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="470,1100,48,19" Id="IjyMmOEymiLLvehJvwi6U7">
+              <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                <Choice Kind="OperationCallFlag" Name="Format" />
+              </p:NodeReference>
+              <Pin Id="LEVSq5nARAyOFmokCgoEWg" Name="Format" Kind="InputPin" DefaultValue="Project Folder: {0}" />
+              <Pin Id="C3lJ2OyEtR0OlZeSlm4U9H" Name="Input" Kind="InputPin" />
+              <Pin Id="G6TVHzVmiPZOp574wSIzYG" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="362,310,51,19" Id="AnYuaNyWwNWO1urXsYSkRa">
+              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+              </p:NodeReference>
+              <Pin Id="HgOOUr2gTYuLcIHZ1szLdx" Name="Message" Kind="InputPin" />
+              <Pin Id="Up7sSodfgWhLDzufwA0jla" Name="Apply" Kind="InputPin" />
+            </Node>
+            <Node Bounds="219,220,54,19" Id="JqmzFYFOZudLgVcysh9Zce">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="OnOpen" />
+              </p:NodeReference>
+              <Pin Id="VabPmilNBvzNT30iUEEmdK" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="GbFbvuyJmN0Lvj0zc9z9ZO" Name="Simulate" Kind="InputPin" />
+              <Pin Id="B9LPPLjKbllOnhQI8t9LGV" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="470,1140,51,19" Id="Cm09PvjF3lVN6nWCQRk1Vh">
+              <p:NodeReference LastCategoryFullName="Schema.Utilities.Logging" LastDependency="Schema.Utilities.Logging.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+              </p:NodeReference>
+              <Pin Id="D7kSG10IjDgMtyXLhTXWA9" Name="Message" Kind="InputPin" />
+              <Pin Id="HHbbiaimuHrOiWawIIh9ul" Name="Apply" Kind="InputPin" />
+            </Node>
           </Canvas>
           <Patch Id="T9IZWAHlxyYNAVULohflV9" Name="Create" />
-          <Patch Id="Qq1x84RkVCPPrRNe5NuZ7H" Name="Update" ParticipatingElements="RvgbEfExqudPNJL4zphvWM,J7F3Au71PyiLjrbRjg1EKF,RCi1t7We6fRLYtjyRZkIQu,KqbuBJirmLdO4IICASGg78,J0scOKzSOVeP4R68Q917nd,Ffz84LzxmJyOyRsDDYOKKB,HHbzNXYERHLQIeDtGnCW23,SWFt5uYiUriQP0zujJPJ4o,Rzrts0VYQnLMJK0jaFPdD9,K2igvdUVTFUPOa2Dwl7pge,Uhvv2R5OOQ1P1kLFlnwLm9,EgJ6TsIv3AmNmtmKy299tr,LSRILCEq6tFNSQJ6HBcPdC,DRaooEbUIjZP4KtsT6lzOq,CA20QeQz1HeOb6BVWycaAV,SyFoCHhjPWhLn268Boz7HM,QvQrtLa5rFzNNTVQH6NZQF,D9fY2sUrPdfLcHPHniQaYb,Uem1vHHnH4FLAnyaQjGUzk,GD2A26NzDLgMtJMcGubBV5,ExUdsvssPpcLiKpigd4Mw6,PlJ0a7jy4K1P457tl2yar0,G1w88f4eSRvOA09wBhYlAw,InOWCE2G5qKONv5FWo4WHQ,ILwjpFeReqnNCWHz9SEqXZ,UOoSz1dH5K7MkY3L04Icj7">
+          <Patch Id="Qq1x84RkVCPPrRNe5NuZ7H" Name="Update" ParticipatingElements="RvgbEfExqudPNJL4zphvWM,J7F3Au71PyiLjrbRjg1EKF,RCi1t7We6fRLYtjyRZkIQu,KqbuBJirmLdO4IICASGg78,J0scOKzSOVeP4R68Q917nd,Ffz84LzxmJyOyRsDDYOKKB,HHbzNXYERHLQIeDtGnCW23,SWFt5uYiUriQP0zujJPJ4o,Rzrts0VYQnLMJK0jaFPdD9,K2igvdUVTFUPOa2Dwl7pge,Uhvv2R5OOQ1P1kLFlnwLm9,EgJ6TsIv3AmNmtmKy299tr,LSRILCEq6tFNSQJ6HBcPdC,DRaooEbUIjZP4KtsT6lzOq,SyFoCHhjPWhLn268Boz7HM,QvQrtLa5rFzNNTVQH6NZQF,D9fY2sUrPdfLcHPHniQaYb,Uem1vHHnH4FLAnyaQjGUzk,ExUdsvssPpcLiKpigd4Mw6,PlJ0a7jy4K1P457tl2yar0,InOWCE2G5qKONv5FWo4WHQ,ILwjpFeReqnNCWHz9SEqXZ,UOoSz1dH5K7MkY3L04Icj7,AnYuaNyWwNWO1urXsYSkRa">
             <Pin Id="QvjJGvIFwIdPnDEeyZRfzz" Name="Output" Kind="OutputPin" />
             <Pin Id="RqBW42DaZRgPZKkTlovMCp" Name="Project Name" Kind="InputPin" />
           </Patch>
@@ -205,21 +266,31 @@
           <Link Id="EgJ6TsIv3AmNmtmKy299tr" Ids="RiPBRrAHvSOOs39dSoUUYa,Uig1VxSDygSMMnAzA6XtSV" />
           <Link Id="LSRILCEq6tFNSQJ6HBcPdC" Ids="NleJwKmNr7ZQZ6dwTxGf4A,JiGyHox7BV6Pr4nbQCzl48" />
           <Link Id="DRaooEbUIjZP4KtsT6lzOq" Ids="SERtmfhWH8gOFM8U7GKikx,QBnvGhzBtrlPyO2i5pxVxk" />
-          <Link Id="CA20QeQz1HeOb6BVWycaAV" Ids="DD2y5CFjl7rMK0I9KBO5Zm,Jf1BxdOCpC9MHQHGu0xs18" />
           <Link Id="ESbS8EnpXRoLBrmN9mh6oi" Ids="Klndr0ZKcomQKGhHvcbkCH,QvjJGvIFwIdPnDEeyZRfzz" IsHidden="true" />
           <Link Id="SyFoCHhjPWhLn268Boz7HM" Ids="BqswTiYzBP7OxshGGsSKcC,DgF5T2e14wONpO6Ge3389c" IsFeedback="true" />
           <Link Id="QvQrtLa5rFzNNTVQH6NZQF" Ids="AEuJvhUYmdKQTsMYOeObld,BqswTiYzBP7OxshGGsSKcC" />
           <Link Id="D9fY2sUrPdfLcHPHniQaYb" Ids="BqswTiYzBP7OxshGGsSKcC,DgF5T2e14wONpO6Ge3389c" />
           <Link Id="D4JessvWogqNDuAmXvHpGb" Ids="M1BiwkOloepQVyGq0APyFG,P4TTwk3nE5qLVMrJpFLqch" IsHidden="true" />
           <Link Id="Uem1vHHnH4FLAnyaQjGUzk" Ids="SOns9F7ryjMMArg2UgTTyP,M1BiwkOloepQVyGq0APyFG" />
-          <Link Id="GD2A26NzDLgMtJMcGubBV5" Ids="RDdeBXoIYFSLEFdwgZeUu8,AEuJvhUYmdKQTsMYOeObld" />
           <Link Id="ExUdsvssPpcLiKpigd4Mw6" Ids="UZm0uOa7ZaJOEpfcFxEQpk,QtqBb3b6G9uO3Mk4vu033G" IsFeedback="true" />
           <Link Id="PlJ0a7jy4K1P457tl2yar0" Ids="Njwb3GsUwglPRAwa5miaH0,QtqBb3b6G9uO3Mk4vu033G" />
-          <Link Id="G1w88f4eSRvOA09wBhYlAw" Ids="SM8v9Y3fYjwLoIXy6cbL7E,Klndr0ZKcomQKGhHvcbkCH" />
           <Link Id="InOWCE2G5qKONv5FWo4WHQ" Ids="NjxQG0oHZbROh5807QGSRp,DfOONl6oKVOMs2iKwAvWJO" />
           <Link Id="HPPiNiI28KUQRhAvLKGwqq" Ids="RqBW42DaZRgPZKkTlovMCp,NjxQG0oHZbROh5807QGSRp" IsHidden="true" />
           <Link Id="ILwjpFeReqnNCWHz9SEqXZ" Ids="VgXymAIzlZ6OCFwClrgejJ,KPfEzTZZtenLsE7LcyWYco" />
           <Link Id="UOoSz1dH5K7MkY3L04Icj7" Ids="CfZS2kPBcIFM4cfCRbSlsJ,DIg1SLzyk7tOvA1Yehc06j" />
+          <Link Id="FtiLI0zOCraOoXfjO4Hvsq" Ids="VgXymAIzlZ6OCFwClrgejJ,MH4uw5sEhJUO1YJzvu81Da" />
+          <Link Id="GNFz1S1XP9qN9KNFc9aQfJ" Ids="NleJwKmNr7ZQZ6dwTxGf4A,OUkFZ0jDwZnPiuNp8Rk17J" />
+          <Link Id="Hi1Wx3LlLZqPCzsNox4k15" Ids="SM8v9Y3fYjwLoIXy6cbL7E,MDzFRFaeglHQDdfNnpRtwR" />
+          <Link Id="Hp7gjzLMgEgLtz6N3ypdUj" Ids="SM8v9Y3fYjwLoIXy6cbL7E,C3lJ2OyEtR0OlZeSlm4U9H" />
+          <Link Id="AFaVv7TVqJJQTzo9LzFvTH" Ids="ObWTJ2HsSxOLEvlodMiTC8,HgOOUr2gTYuLcIHZ1szLdx" />
+          <Link Id="DioY1bYlXLHMOZs27MCIO1" Ids="SRhkqErsb8JPejrLAEdPw2,CGn4xTIg6MTODsO50rnP7w" />
+          <Link Id="BRYoiyOsxbzMmlVyL6AyfW" Ids="B9LPPLjKbllOnhQI8t9LGV,IeQ1MbdjsPWMrOhP4kTsvz" />
+          <Link Id="EXpa42OyuQlPAFdaar2WBH" Ids="B9LPPLjKbllOnhQI8t9LGV,Up7sSodfgWhLDzufwA0jla" />
+          <Link Id="EgKWtRoifqLP8DXYfkIbiv" Ids="G6TVHzVmiPZOp574wSIzYG,D7kSG10IjDgMtyXLhTXWA9" />
+          <Link Id="OnsMNeGHEW1PUU8AeweHB9" Ids="B9LPPLjKbllOnhQI8t9LGV,HHbbiaimuHrOiWawIIh9ul" />
+          <Link Id="NWmkromgRo7MIvu7aU8wQP" Ids="DD2y5CFjl7rMK0I9KBO5Zm,QRhyiQxRJx2MdHCV3fBKFO" />
+          <Link Id="TORskaVR4DjMogSfMUikNJ" Ids="DgF5T2e14wONpO6Ge3389c,Klndr0ZKcomQKGhHvcbkCH" />
+          <Link Id="EFhNzzYODiXNPGG4S3BPFy" Ids="SERtmfhWH8gOFM8U7GKikx,AEuJvhUYmdKQTsMYOeObld" />
         </Patch>
       </Node>
       <!--
@@ -370,7 +441,7 @@
         </p:NodeReference>
         <Patch Id="UVSAKbe6awTOR4KJ2aAY6Q">
           <Canvas Id="DOLCqUwEuj1N9lnuHovU5V" CanvasType="Group">
-            <Node Bounds="683,487" Id="OyAVh2FcjFON3Xa9dgTJze">
+            <Node Bounds="683,487,114,19" Id="OyAVh2FcjFON3Xa9dgTJze">
               <p:NodeReference LastCategoryFullName="Schema.Projects" LastDependency="Schema.Projects.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetProjectSettingPath" />
@@ -384,7 +455,6 @@
                 <Choice Kind="ProcessAppFlag" Name="TryCatch" />
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               </p:NodeReference>
-              <Pin Id="K0VTwmVNBbZM8iAeXx37o6" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="H6o8iac6FlKL9AuYS5J7X9" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
               <Pin Id="Gh0rHT6Rlb3M5WYSWsYZI6" Name="Result" Kind="OutputPin" />
               <Patch Id="Ol9OrBlm3PCMwCvVtwHYpN" ManuallySortedPins="true">
@@ -510,24 +580,12 @@
     ************************ GetSchemaProjectRoot ************************
 
 -->
-        <Node Name="GetSchemaProjectRoot" Bounds="597,454,179,131" Id="KBLOOkJ0sbZM81Uj6IvjiC">
+        <Node Name="GetSchemaProjectRoot" Bounds="557,106,212,158" Id="KBLOOkJ0sbZM81Uj6IvjiC">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="T9esjuB5gjAM5IM0F8IaoJ">
-            <Node Bounds="609,477,77,19" Id="Ar064zyks5qOCS2YsxDPkQ">
-              <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="SystemFolder" />
-              </p:NodeReference>
-              <Pin Id="TQyic0Ovis2NWyvSehGZKG" Name="Special Folder" Kind="InputPin" DefaultValue="Personal">
-                <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="SpecialFolder" />
-                </p:TypeAnnotation>
-              </Pin>
-              <Pin Id="LFWcH8haJn2NPbkgYvCmjo" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="630,512,134,26" Id="CZppuj8sHVSPccWAVIwVZy">
+            <Node Bounds="571,191,134,26" Id="CZppuj8sHVSPccWAVIwVZy">
               <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Path" />
@@ -537,7 +595,7 @@
               <Pin Id="G44i3Q3dn7VNfBjPQqDkt4" Name="Input 2" Kind="InputPin" />
               <Pin Id="Qnzvt19IVmONXQBRP0XRV8" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="693,477,57,19" Id="Eoyry1JME0RNsgwBX4t2lT">
+            <Node Bounds="700,129,57,19" Id="Eoyry1JME0RNsgwBX4t2lT">
               <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
@@ -551,12 +609,19 @@
               <Pin Id="OObUo3E5oY5LjdFzBwhhjF" Name="Extension" Kind="InputPin" />
               <Pin Id="AlRxuQBVGgHPGWqYWqjPwK" Name="Result" Kind="OutputPin" />
             </Node>
-            <Link Id="JpmGNuQGKPrPIA7bqRuXbP" Ids="LFWcH8haJn2NPbkgYvCmjo,JVxs2qkbkdQMkdFAinrqjP" />
             <Link Id="Q1aLLhZdlksMn0cZGO3jGt" Ids="AlRxuQBVGgHPGWqYWqjPwK,G44i3Q3dn7VNfBjPQqDkt4" />
             <Pin Id="OXmcaapkk1yP2t1UUZPgfI" Name="Output" Kind="OutputPin" />
-            <ControlPoint Id="PAbFrfY8xKXOSogDfJv9Ba" Bounds="630,568" />
+            <ControlPoint Id="PAbFrfY8xKXOSogDfJv9Ba" Bounds="571,247" />
             <Link Id="QhD6SEPQJG9OGF1KjkqZXA" Ids="PAbFrfY8xKXOSogDfJv9Ba,OXmcaapkk1yP2t1UUZPgfI" IsHidden="true" />
             <Link Id="Hr1tqvdFwLWLliE1LD5Ud7" Ids="Qnzvt19IVmONXQBRP0XRV8,PAbFrfY8xKXOSogDfJv9Ba" />
+            <Node Bounds="571,130,99,19" Id="G02Ll9lwUAML5qcnGeU3Ra">
+              <p:NodeReference LastCategoryFullName="Schema.Projects" LastDependency="Schema.Projects.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GetPersonalFolder" />
+              </p:NodeReference>
+              <Pin Id="ChfRjAzPtCjO3R6Lw2pDS9" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Link Id="E8nvzWztqmjLJ3j30ERUiL" Ids="ChfRjAzPtCjO3R6Lw2pDS9,JVxs2qkbkdQMkdFAinrqjP" />
           </Patch>
         </Node>
         <!--
@@ -564,19 +629,19 @@
     ************************ GetProjectSettingPath ************************
 
 -->
-        <Node Name="GetProjectSettingPath" Bounds="594,679,142,158" Id="BH0z519RDgQNDqYxPa6Aqh">
+        <Node Name="GetProjectSettingPath" Bounds="812,238,142,158" Id="BH0z519RDgQNDqYxPa6Aqh">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="T4Fjq1onWeDOlcIUdfYcUV">
-            <Node Bounds="606,702,118,19" Id="Qs6CPFEUlMSNfFJG7OTbKu">
+            <Node Bounds="824,261,118,19" Id="Qs6CPFEUlMSNfFJG7OTbKu">
               <p:NodeReference LastCategoryFullName="Schema.Projects" LastDependency="Schema.Projects.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetSchemaProjectRoot" />
               </p:NodeReference>
               <Pin Id="MgCJdfctK1PQT1GNZcUfep" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="626,779,57,19" Id="U3wt0xGchHqO9f8gSgjZ7J">
+            <Node Bounds="824,338,57,19" Id="U3wt0xGchHqO9f8gSgjZ7J">
               <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
@@ -590,10 +655,10 @@
               <Pin Id="J3Njxjukn78N5ugeNLrqUx" Name="Extension" Kind="InputPin" />
               <Pin Id="GK4IvhpnL2WMjWQ4ao89oH" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="EuVxAkkkrOTORRVBBKuGJJ" Bounds="629,820" />
+            <ControlPoint Id="EuVxAkkkrOTORRVBBKuGJJ" Bounds="826,379" />
             <Pin Id="LZ3KYSuOvqoOeXk9CcEsTv" Name="Output" Kind="OutputPin" Bounds="616,865" />
             <Link Id="EVFc1pahpD0PDZG3AAG5XD" Ids="EuVxAkkkrOTORRVBBKuGJJ,LZ3KYSuOvqoOeXk9CcEsTv" IsHidden="true" />
-            <Node Bounds="627,741,57,19" Id="ADoOw5MVI6oLfmf8sybEcl">
+            <Node Bounds="824,300,57,19" Id="ADoOw5MVI6oLfmf8sybEcl">
               <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Filename (Split)" />
@@ -613,20 +678,147 @@
     ************************ DefaultProjectName ************************
 
 -->
-        <Node Name="DefaultProjectName" Bounds="816,595,136,80" Id="NV8yCVbJCk5NL5CvJx7oru">
+        <Node Name="DefaultProjectName" Bounds="812,110,105,70" Id="NV8yCVbJCk5NL5CvJx7oru">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="N8uF7htvgFbMqIYCQXAZRo">
-            <Pad Id="ULWmAA704zFL6UN4i89nkH" Bounds="863,633,58,15" ShowValueBox="true" isIOBox="true" Value="default">
+            <Pad Id="ULWmAA704zFL6UN4i89nkH" Bounds="828,138,58,15" ShowValueBox="true" isIOBox="true" Value="default">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
-            <ControlPoint Id="VMkH7X6xzlRNuYax1GQock" Bounds="864,658" />
+            <ControlPoint Id="VMkH7X6xzlRNuYax1GQock" Bounds="828,163" />
             <Link Id="TI4wy3W85RhPY53pSG5VTU" Ids="ULWmAA704zFL6UN4i89nkH,VMkH7X6xzlRNuYax1GQock" />
             <Pin Id="NR7fMjrk7bnNYAZyX8ik81" Name="Output" Kind="OutputPin" Bounds="864,658" />
             <Link Id="A3CRDloVMjiL5IvKb6qU4m" Ids="VMkH7X6xzlRNuYax1GQock,NR7fMjrk7bnNYAZyX8ik81" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ GetPersonalFolder ************************
+
+-->
+        <Node Name="GetPersonalFolder" Bounds="66,90,448,416" Id="KL43EvEPaB6PC1H9xhRw5f">
+          <p:NodeReference>
+            <Choice Kind="OperationDefinition" />
+          </p:NodeReference>
+          <Patch Id="LS3IYY3CFgXQDPogYu7lFi">
+            <Pin Id="Q3L3O9aViSLLnCcpLgCktk" Name="Output" Kind="OutputPin" />
+            <ControlPoint Id="NpVS7ps9RnhM1SkGkFb7D1" Bounds="105,489" />
+            <Node Bounds="89,148,74,19" Id="TdFftzIbQtYNnA3qSZ7moD">
+              <p:NodeReference LastCategoryFullName="System.Runtime.InteropServices.RuntimeInformation" LastDependency="System.Runtime.InteropServices.RuntimeInformation.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="IsOSPlatform" />
+              </p:NodeReference>
+              <Pin Id="BoTkHDX1hjkOOZcgDhn8B9" Name="Os Platform" Kind="InputPin" />
+              <Pin Id="EjYF0ALnSIQNblisdenLaz" Name="Result" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="89,127,57,19" Id="BS6qpNSsO4ZNPo61JGogYc">
+              <p:NodeReference LastCategoryFullName="System.Runtime.InteropServices.OSPlatform" LastDependency="System.Runtime.InteropServices.RuntimeInformation.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="OSPlatform" />
+                <Choice Kind="OperationCallFlag" Name="Windows" />
+              </p:NodeReference>
+              <Pin Id="S0aByXek6fDPdupIynFTU9" Name="Windows" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="89,182,263,94" Id="Ecb50ueqeOZP8fswulxHU4">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+              </p:NodeReference>
+              <Pin Id="DIbeEJ4ge3cO2CyHdJhNxs" Name="Condition" Kind="InputPin" />
+              <Patch Id="BjYeYL84JObPWnwDpV6WaX" ManuallySortedPins="true">
+                <Patch Id="SyawrAsUPdhNP9mqAcSZjz" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="CmJwAiaWjlYOrBxmJJxxVs" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="103,228,77,19" Id="QLlHWm0MuOQQFtBzaEuTeG">
+                  <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SystemFolder" />
+                  </p:NodeReference>
+                  <Pin Id="JIxPOBOGGTKP6gFGLXgdPU" Name="Special Folder" Kind="InputPin" />
+                  <Pin Id="Ri9PHWfrTkzQWnaCnWLDLr" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="Lf4UR6bWesmLBg59xSIcKT" Comment="Special Folder" Bounds="105,210,150,15" ShowValueBox="true" isIOBox="true" Value="Personal">
+                  <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="SpecialFolder" />
+                  </p:TypeAnnotation>
+                </Pad>
+              </Patch>
+              <ControlPoint Id="BgKV08bJWCOOU748jjdFjF" Bounds="105,270" Alignment="Bottom" />
+              <ControlPoint Id="JOL0nw4MGBXQC8tXF4t3wP" Bounds="105,188" Alignment="Top" />
+            </Node>
+            <Node Bounds="89,322,152,137" Id="SXIEQKQ2HpmNRMNy2LMYll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+              </p:NodeReference>
+              <Pin Id="T506xmZzGC0M9vLITcBaSd" Name="Condition" Kind="InputPin" />
+              <Patch Id="AYPK5to7nSFPSaVdmqaGJ4" ManuallySortedPins="true">
+                <Patch Id="NYFofocG5U5QN2AQ3xluW9" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="B7Cjo3bZ2tAMlky2I1X1Dm" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="103,410,57,19" Id="Fqub8yZv4VAPz04Lx7lMbT">
+                  <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
+                  </p:NodeReference>
+                  <Pin Id="EnFEVmAsVgYNwouOONm9ls" Name="Directory" Kind="InputPin" />
+                  <Pin Id="QO0wJl9Vi5iQRkAGhy85qL" Name="Filename" Kind="InputPin" />
+                  <Pin Id="JxQ5xCCnYGLLWgkYqRSOqa" Name="Extension" Kind="InputPin" />
+                  <Pin Id="ISZi87dphbLLeBY5OUKjip" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="103,380,126,19" Id="AwvobkZeO2VObOFyLbuT4G">
+                  <p:NodeReference LastCategoryFullName="System.Environment" LastDependency="System.Runtime.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="System" />
+                    <AssemblyReference ID="System.Runtime.dll" />
+                    <Choice Kind="OperationCallFlag" Name="GetEnvironmentVariable" />
+                  </p:NodeReference>
+                  <Pin Id="HQZc8l7tdp8PDYBa7RnX7o" Name="Variable" Kind="InputPin" />
+                  <Pin Id="Qxjcr1f9v7hQEq3PC11Zog" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="LFQ1SCruvnYOvRvFMLN90g" Comment="Variable" Bounds="105,360,62,15" ShowValueBox="true" isIOBox="true" Value="HOME">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                  </p:TypeAnnotation>
+                </Pad>
+              </Patch>
+              <ControlPoint Id="JGBQ2zI7tcDNkzm8QGI7YJ" Bounds="105,453" Alignment="Bottom" />
+              <ControlPoint Id="Bc8wXJerI5yNkMIgzYHHhc" Bounds="105,328" Alignment="Top" />
+            </Node>
+            <Node Bounds="89,288,37,19" Id="Kf0jLCGyn1KO2HpbRnmtRZ">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="NOT" />
+              </p:NodeReference>
+              <Pin Id="KX2Gu3hEDbfOuirpu3hTm8" Name="Input" Kind="StateInputPin" />
+              <Pin Id="D4bYz9WP1zPLiYQ1pbbOrZ" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Link Id="PkzCEt8kuCZOQxVwBfIUgA" Ids="NpVS7ps9RnhM1SkGkFb7D1,Q3L3O9aViSLLnCcpLgCktk" IsHidden="true" />
+            <Link Id="PeTpSIzkBuRLHFoMk76Bck" Ids="S0aByXek6fDPdupIynFTU9,BoTkHDX1hjkOOZcgDhn8B9" />
+            <Link Id="LULrl17tEwsOIdwnExUin2" Ids="EjYF0ALnSIQNblisdenLaz,DIbeEJ4ge3cO2CyHdJhNxs" />
+            <Link Id="BpeKneT8Z4BLP3y9g2urNx" Ids="EjYF0ALnSIQNblisdenLaz,KX2Gu3hEDbfOuirpu3hTm8" />
+            <Link Id="MFW5ZiiJIofLCJ1n1RGspt" Ids="D4bYz9WP1zPLiYQ1pbbOrZ,T506xmZzGC0M9vLITcBaSd" />
+            <Link Id="HGBpwHXuRSDOvUNgHq1DMH" Ids="Bc8wXJerI5yNkMIgzYHHhc,JGBQ2zI7tcDNkzm8QGI7YJ" IsFeedback="true" />
+            <Link Id="NIKdEYZQyUeNi4S83ghhtQ" Ids="ISZi87dphbLLeBY5OUKjip,JGBQ2zI7tcDNkzm8QGI7YJ" />
+            <Link Id="R3ddVYUA8miMTTl3YSbi7g" Ids="JGBQ2zI7tcDNkzm8QGI7YJ,NpVS7ps9RnhM1SkGkFb7D1" />
+            <Link Id="EPnRq2hn1imPRMC9cKt4D7" Ids="JOL0nw4MGBXQC8tXF4t3wP,BgKV08bJWCOOU748jjdFjF" IsFeedback="true" />
+            <Link Id="UU9C5rgD2wGPGQzp2fwvNO" Ids="Ri9PHWfrTkzQWnaCnWLDLr,BgKV08bJWCOOU748jjdFjF" />
+            <Link Id="ETM29y639WWMCUyHuVjMG2" Ids="BgKV08bJWCOOU748jjdFjF,Bc8wXJerI5yNkMIgzYHHhc" />
+            <Link Id="Rufjo0OwhBhMmjPjnsX58H" Ids="Lf4UR6bWesmLBg59xSIcKT,JIxPOBOGGTKP6gFGLXgdPU" />
+            <Pad Id="GeZiHqsetRhQQ1whQM6Gf0" Bounds="170,118,326,60" ShowValueBox="true" isIOBox="true" Value="Multi-OS safe hotfix for https://forum.vvvv.org/t/systemfolder-personal-not-working-outside-of-windows/24795">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="String" />
+              </p:TypeAnnotation>
+              <p:ValueBoxSettings>
+                <p:fontsize p:Type="Int32">9</p:fontsize>
+                <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+              </p:ValueBoxSettings>
+            </Pad>
+            <Link Id="EUkiojPMc8cM3Bw35gokE5" Ids="LFQ1SCruvnYOvRvFMLN90g,HQZc8l7tdp8PDYBa7RnX7o" />
+            <Link Id="UL0GgTmcLMSNVupbc0zTHD" Ids="Qxjcr1f9v7hQEq3PC11Zog,EnFEVmAsVgYNwouOONm9ls" />
           </Patch>
         </Node>
       </Canvas>
@@ -652,4 +844,8 @@
       </Patch>
     </Node>
   </Patch>
+  <NugetDependency Id="GHnq2OjkE3WNZw9UdZ6IS6" Location="VL.CoreLib" Version="2025.7.0" />
+  <NugetDependency Id="CkGbxEo1WcLLPmxHmBj3cg" Location="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  <DocumentDependency Id="RfEVGTQJmmmLaJx9rEUsUq" Location="./Utilities/Schema.Utilities.Logging.vl" />
+  <PlatformDependency Id="UJTLRJ5eefGQKcv6f3pUCe" Location="System.Runtime" />
 </Document>

--- a/Main/vl/UI/Schema.UI.ExtrasMenu.vl
+++ b/Main/vl/UI/Schema.UI.ExtrasMenu.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="VVGiGbed0mwP6opbhDTj7R" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="M7K2WXBtkagOWXUBLAGceb" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="VVGiGbed0mwP6opbhDTj7R" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="M7K2WXBtkagOWXUBLAGceb" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="O3f5l5YKXIsOs6e5a9gnlp">
     <Canvas Id="IV8B18BGkO4NCphLiTB0uC" DefaultCategory="Main" CanvasType="FullCategory">
       <!--
@@ -317,7 +317,7 @@
                 <Item>Report a Bug</Item>
               </p:Value>
             </Pad>
-            <Node Bounds="829,809,46,19" Id="KOE8bEgHLQ1LffYf4kXbwZ">
+            <Node Bounds="809,780,46,19" Id="KOE8bEgHLQ1LffYf4kXbwZ">
               <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
@@ -336,7 +336,7 @@
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="830,751,25,19" Id="MO2HEraSgW8LYcNMCwSxGH">
+            <Node Bounds="809,722,25,19" Id="MO2HEraSgW8LYcNMCwSxGH">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="* (Scale)" />
@@ -349,7 +349,7 @@
               </Pin>
               <Pin Id="AplAFlxy0u4OkYQfOmWnvX" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="830,785,22,19" Id="G4fHkKcs5TjMNManJyF1Du">
+            <Node Bounds="809,751,22,19" Id="G4fHkKcs5TjMNManJyF1Du">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="- (Negate)" />
@@ -674,7 +674,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="FvyCBWxKuJoOOhidQqSfUI" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="FvyCBWxKuJoOOhidQqSfUI" Location="VL.Skia" Version="2024.6.7" />
   <DocumentDependency Id="R3jPBYcQYUTMpNoTSZXzb9" Location="./Icons/Schema.UI.Icons.vl" />
   <DocumentDependency Id="G3IS1aeKUFuLMuz7aAMANi" Location="./Schema.UI.Actions.vl" />
   <DocumentDependency Id="FUImoqebp09Oqt0yWXh3Gu" Location="./Schema.UI.PluginSelector.vl" />

--- a/Main/vl/UI/Schema.UI.PluginSelector.vl
+++ b/Main/vl/UI/Schema.UI.PluginSelector.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="EkxkWrjfgzROJohpRG4mlT" LanguageVersion="2024.6.7" Version="0.128">
-  <NugetDependency Id="U1I0OhyHUHFMyqmgwJOgv1" Location="VL.CoreLib" Version="2024.6.7" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="EkxkWrjfgzROJohpRG4mlT" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="U1I0OhyHUHFMyqmgwJOgv1" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="G00lriESh6ML7hC1qy2p9n">
     <Canvas Id="VhTdbIzRNAwNuSAhimGm4u" DefaultCategory="Schema.UI.PluginSelector" CanvasType="FullCategory">
       <!--
@@ -154,8 +154,8 @@
               <Pin Id="Pzk0xMkhHZqNUX49vn9K3G" Name="Output" Kind="StateOutputPin" />
               <Pin Id="ISdzryFd7MEQJz837zRPPd" Name="Project Directory" Kind="OutputPin" />
             </Node>
-            <Pad Id="FBwl8E8m01UNorAsfRqyfA" Comment="" Bounds="755,1041,113,127" ShowValueBox="true" isIOBox="true" />
-            <Node Bounds="630,1670,61,19" Id="EaHlYZV9OmTMsCE41WXXDN">
+            <Pad Id="FBwl8E8m01UNorAsfRqyfA" Comment="" Bounds="408,1401,217,116" ShowValueBox="true" isIOBox="true" />
+            <Node Bounds="731,1710,61,19" Id="EaHlYZV9OmTMsCE41WXXDN">
               <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Rectangle (Join)" />
@@ -173,7 +173,7 @@
               </Pin>
               <Pin Id="FhcvPGU4xKYM0gTnvDCvPk" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="945,799,83,26" Id="K4LWok35dn6O3TYjLiL5WD">
+            <Node Bounds="533,1322,83,26" Id="K4LWok35dn6O3TYjLiL5WD">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromSequence" />
@@ -182,7 +182,7 @@
               <Pin Id="RMxV7ffS28pOpetSflXuZr" Name="Input" Kind="StateInputPin" />
               <Pin Id="TXHU854I6Z1LUBe6eZYqyd" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="855,980,48,19" Id="C0TQxFkP6g9LC88Vm1Qyxw">
+            <Node Bounds="406,1360,132,19" Id="C0TQxFkP6g9LC88Vm1Qyxw">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Concat" />
@@ -192,7 +192,7 @@
               <Pin Id="GvjmT7BTRE3QWsdQCtZ4Iu" Name="Output" Kind="StateOutputPin" />
               <Pin Id="FOf3BHFLRAxN0yQbBwZ51J" Name="Input 2" Kind="InputPin" />
             </Node>
-            <Node Bounds="926,846,60,26" Id="Mcyc7qKZQfuNAw5HQhg5h0">
+            <Node Bounds="483,1242,60,26" Id="Mcyc7qKZQfuNAw5HQhg5h0">
               <p:NodeReference LastCategoryFullName="Schema.UI.View.Widgets.LabelWidget" LastDependency="Schema.UI.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="LabelWidget" />
@@ -206,7 +206,7 @@
               </Pin>
               <Pin Id="BP1B2FLIgIFOHIgV0q6HXE" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="822,933,65,19" Id="AJxveVDLZblOjC6M5cBGSf">
+            <Node Bounds="406,1325,65,19" Id="AJxveVDLZblOjC6M5cBGSf">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromValue" />
@@ -215,7 +215,7 @@
               <Pin Id="UCyqVvEWFuePZypNwliM88" Name="Input" Kind="StateInputPin" />
               <Pin Id="SkiwZZLdbg6Myk4Egq7iCW" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="822,890,62,26" Id="RnZSDe44SiKNjspHdTtQyj">
+            <Node Bounds="406,1283,62,26" Id="RnZSDe44SiKNjspHdTtQyj">
               <p:NodeReference LastCategoryFullName="Collections.Common.KeyValuePair" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="KeyValuePair" />
@@ -225,7 +225,7 @@
               <Pin Id="VcdTOQeGS3DOmbHkJBEr5W" Name="Value" Kind="InputPin" />
               <Pin Id="RXeUCiN2jSHNNxr4GJIS14" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Pad Id="U44ZPGQ6mhAQTXRWtMwgRg" Comment="Key" Bounds="823,870,35,15" ShowValueBox="true" isIOBox="true" Value="title">
+            <Pad Id="U44ZPGQ6mhAQTXRWtMwgRg" Comment="Key" Bounds="408,1252,35,15" ShowValueBox="true" isIOBox="true" Value="title">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
@@ -263,7 +263,7 @@
             </Pad>
             <Pad Id="Pkh5elJbI2DLy3UBTyNHp1" SlotId="SSUN6cX30VlLL7xYBTnFAg" Bounds="658,1152" />
             <Pad Id="A9XX4lE5FovN10C9suyBed" SlotId="SSUN6cX30VlLL7xYBTnFAg" Bounds="233,1468" />
-            <Node Bounds="700,1607,85,19" Id="E3hgUkk0pOdO6uze9htZdg">
+            <Node Bounds="697,1540,85,19" Id="E3hgUkk0pOdO6uze9htZdg">
               <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Oscillator (Generic)" />
@@ -287,12 +287,12 @@
               <Pin Id="AkRt2oBqcdRL2RjmbYCUgO" Name="Function" Kind="OutputPin" IsHidden="true" />
               <Pin Id="HTQZd5TVRknPM0ikQLk7z1" Name="Has Changed" Kind="OutputPin" />
             </Node>
-            <Pad Id="PRIOMRko3OtN0gUTMfA6MY" Comment="Size" Bounds="683,1509,35,28" ShowValueBox="true" isIOBox="true" Value="1.25, 0.12">
+            <Pad Id="PRIOMRko3OtN0gUTMfA6MY" Comment="Size" Bounds="781,1650,35,28" ShowValueBox="true" isIOBox="true" Value="1.25, 0.12">
               <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector2" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="KaS3nNuQ5rANPttpd7ylR3" Comment="Size" Bounds="599,1507,35,28" ShowValueBox="true" isIOBox="true" Value="1, 0">
+            <Pad Id="KaS3nNuQ5rANPttpd7ylR3" Comment="Size" Bounds="761,1620,35,28" ShowValueBox="true" isIOBox="true" Value="1, 0">
               <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector2" />
               </p:TypeAnnotation>
@@ -421,6 +421,7 @@
                   <Pin Id="L2grPCpESOnNtIwf3RyvP5" Name="Radius" Kind="InputPin" />
                   <Pin Id="OAewhm4w39kOUXvOQsyuPg" Name="Paint" Kind="InputPin" />
                   <Pin Id="L4gkNQieX71LIKi4ft6vaq" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="OYwRWH7UWsRQGPL9kes27H" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="PGG2L5ILctuNAAIMXjTCYn" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="671,2252,85,19" Id="VyoSrJOpChNN2Gk3tDcrrp">
@@ -436,7 +437,7 @@
                   <Pin Id="Lnxca6zc5wwNDcpGAgHB61" Name="Enabled" Kind="InputPin" />
                   <Pin Id="TaeZ5uA8iKuNc2nIyuN7Wi" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="819,2043,83,19" Id="C0k7twuyNEPP3uhq3UMVWF">
+                <Node Bounds="824,2040,83,19" Id="C0k7twuyNEPP3uhq3UMVWF">
                   <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Layout.Common" LastDependency="Schema.UI.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TabTitleButton" />
@@ -481,36 +482,6 @@
                   </Pin>
                   <Pin Id="QWEcMw2EIUKQM3xnDOYXzu" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="875,2080,46,19" Id="QoUCLAK5DfcPRzeswFUwva">
-                  <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="Center" />
-                    <CategoryReference Kind="RecordType" Name="Rectangle" NeedsToBeDirectParent="true" />
-                  </p:NodeReference>
-                  <Pin Id="ILBkwnBaPjuPdZfILsK0mU" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="V6GhQPvncvbPcWIhMIMMSd" Name="Center" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="876,2111,22,19" Id="Exf6O2vRDAPL7drHBWRJQz">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="- (Negate)" />
-                  </p:NodeReference>
-                  <Pin Id="DbAYiF2P3TONJmPlOrrlT6" Name="Input" Kind="InputPin" />
-                  <Pin Id="AXdlgq7T6hFPkI0efxfxU2" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="879,2141,25,19" Id="QUnX47YXMhxMvxQHT750ZH">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="/ (Scale)" />
-                  </p:NodeReference>
-                  <Pin Id="E7psJMmn234LmwbldVfFyO" Name="Input" Kind="InputPin" />
-                  <Pin Id="QcTDXuVcpLGOAZ7MlzzRjG" Name="Scalar" Kind="InputPin" DefaultValue="2">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Float32" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="NAcV0iaKdyjL5bBPJvIyqk" Name="Output" Kind="OutputPin" />
-                </Node>
                 <Node Bounds="996,2120,284,95" Id="Qh17s5bMbdsNOkPX79PU1p">
                   <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ProcessAppFlag" Name="ForEach" />
@@ -520,6 +491,7 @@
                   <Pin Id="TK7JS1HDjEHQOrUpv8G1Nx" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="EM7LUS8FFeaMuw4oKa1a4v" Name="Messages" Kind="InputPin" />
                   <Pin Id="O65qVZeIqs0LNRwSrJ01NS" Name="Reset" Kind="InputPin" />
+                  <Pin Id="Gxyx1DizQM6LmYsb5lOBz3" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="T5QKWaOrl5hOtdLYMvpPjz" Name="Result" Kind="OutputPin" />
                   <Patch Id="ExSbWDehuMoPem2KFdU1Yo" ManuallySortedPins="true">
                     <Patch Id="HWT7RzAiQwUP7GcIwTYVqk" Name="Create" ManuallySortedPins="true" />
@@ -547,7 +519,7 @@
                 </Node>
               </Patch>
             </Node>
-            <Node Bounds="660,1640,45,19" Id="Mzzkqdv2Dt9Otei6RQP4nq">
+            <Node Bounds="759,1680,45,19" Id="Mzzkqdv2Dt9Otei6RQP4nq">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Lerp" />
@@ -557,7 +529,7 @@
               <Pin Id="Kvu4Dl7tNK7OYckqJckXc4" Name="Scalar" Kind="InputPin" />
               <Pin Id="VsStA53F5gBPjbr3OhgVUp" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="800,1534,62,19" Id="Bd7Up1ZNTE3PqbhMSExfBV">
+            <Node Bounds="697,1493,62,19" Id="Bd7Up1ZNTE3PqbhMSExfBV">
               <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="ToFloat32" />
@@ -565,7 +537,7 @@
               <Pin Id="D5KzBVr5sXBOflz0H6i3sA" Name="Input" Kind="InputPin" />
               <Pin Id="ScDI7V5ZkgONnl4v1bDZnV" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="658,1713,25,19" Id="HNGz7zGcYSzPFfh9UgsyOE">
+            <Node Bounds="657,1710,25,19" Id="HNGz7zGcYSzPFfh9UgsyOE">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -578,8 +550,7 @@
               </Pin>
               <Pin Id="Lh4aE87O0b1N2NGyB6XBSi" Name="Result" Kind="OutputPin" />
             </Node>
-            <Pad Id="BSy5Aj8VLUELacTbTNZoKr" Comment="Velocity" Bounds="766,1648,35,15" ShowValueBox="true" isIOBox="true" />
-            <Node Bounds="875,1611,65,19" Id="G5luU13MSvnLou5MbdCUyf">
+            <Node Bounds="803,1540,65,19" Id="G5luU13MSvnLou5MbdCUyf">
               <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Damper" />
@@ -717,6 +688,7 @@
               <Pin Id="OSkFth7uck5PhiW63nE10X" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="UFeIODpaZABM3BsJabS8jv" Name="Message" Kind="InputPin" />
               <Pin Id="Qb0O1czWafZPV1nBL2aViX" Name="Send" Kind="InputPin" />
+              <Pin Id="ST4xXAIJJbhMvct4ySNKn9" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="JWicZwQTYd6OfHr6Mtc2eb" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="235,1809,335,604" Id="Bfzu4RDAWw5MHgbDVVQe7l">
@@ -728,6 +700,7 @@
               <Pin Id="P7l5n1wsMHgOAXB4CXtSBq" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="Qdm0LJCqjqcPR1jBL6aCe8" Name="Messages" Kind="InputPin" />
               <Pin Id="UcnyLHwiMqWNrvfxeNS0s7" Name="Reset" Kind="InputPin" />
+              <Pin Id="Fk6EUZKnVoAPUvVjUVsrnG" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="A4rhSNeAPgGMBANztkSbl4" Name="Result" Kind="OutputPin" />
               <Patch Id="EUOImXOkS8ZOHsUcoL45Wu" ManuallySortedPins="true">
                 <Patch Id="KDKgfXuCR7IOmpXX8dOugQ" Name="Create" ManuallySortedPins="true" />
@@ -908,7 +881,6 @@
           <Link Id="JSAcYZPjfQtNPfUvoaGOBn" Ids="VJ6hSeI5HE2OkbZq2Vi430,HhuwT71OirUQX9ihdqckaC" />
           <Link Id="L456TeR70ycL2aK8ppZELq" Ids="MFnTJWvPGbvNt3diNQNSfa,SDy8hT3eYjTPRtAQdzM2cN" IsFeedback="true" />
           <Link Id="KDoImRqczBcPM57aESjpq4" Ids="K5UBfOGJ0ggPFBv9Ee9QUU,SDy8hT3eYjTPRtAQdzM2cN" />
-          <Link Id="D3lDS4dhBa2NHI0KuGzx99" Ids="UB95Ldp3QvxOdMgDsXzzOc,BSy5Aj8VLUELacTbTNZoKr" />
           <Link Id="NzrhP2s1gyXL0jDKokiqrm" Ids="ScDI7V5ZkgONnl4v1bDZnV,AKrA6Lp2RY1LIBE2WoSZtd" />
           <Link Id="EBKtySyHQ7cPkOJCLLGOeo" Ids="UyFfHQfbxEvPWYvsMpbJd2,SO78yXk4pfFLzMkU2yfEL6" />
           <Link Id="N2gTJoGRTu5NG8f1yaIblD" Ids="AoHpL939N9lONQYrmdvigo,OkT8jv0F6F2MymkfZTyS0f" />
@@ -958,9 +930,6 @@
           <Link Id="Uc4Rh5FI8PNPMgn3P0TMcq" Ids="AqxdpPcHwhbLOgLZMNIgVY,R1L30OL90k4OtB5KsLhIjn" />
           <Link Id="Of1SVerXwQxNpGQbYUXUre" Ids="BvFyPkdVDw2NLL5kpaDVtU,TyzVcCCb09kPSDNWBWFBWo" />
           <Link Id="HsFYaOdj8UIQLoF8ehFU5i" Ids="QWEcMw2EIUKQM3xnDOYXzu,Ari37gBuhUNPJF0LGV5EiQ" />
-          <Link Id="HAVf7xUdrM3QFdG9LSoP3P" Ids="V6GhQPvncvbPcWIhMIMMSd,DbAYiF2P3TONJmPlOrrlT6" />
-          <Link Id="AxXEspmDcXdNqmnDW6ytOp" Ids="T9NF5L7eFx2QZU43IBDCsh,ILBkwnBaPjuPdZfILsK0mU" />
-          <Link Id="NKUzAx5lEOJNUWrEhvDB2u" Ids="AXdlgq7T6hFPkI0efxfxU2,E7psJMmn234LmwbldVfFyO" />
           <Link Id="GRXP7seXa9tLw3oqiOqcga" Ids="PM315kxc9DiMCP9p5ZlcCn,QVbpNjk7D7nPmADAQHJrW4" IsHidden="true" />
           <Link Id="MpJnT4bUSPOOuCHqFC7aQT" Ids="CQSazOLQ16yNd4n3M6rwP3,JpLANEmwyYQPboqk6WRfn8" IsHidden="true" />
           <Link Id="Rb4aRZ9rXmiPaNLhkkJt6d" Ids="C2a41JFTYU1PGTPZX27IbV,EM7LUS8FFeaMuw4oKa1a4v" />
@@ -1000,7 +969,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="M6sBw0DJ4CLPlGdwUtrl0P" Location="VL.Skia" Version="2024.6.7" />
+  <NugetDependency Id="M6sBw0DJ4CLPlGdwUtrl0P" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="D84xX0eAnU0Ou83bf7W1dd" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="GvzI1nVmKS9MGSUjvL865H" Location="./Schema.UI.vl" />
   <DocumentDependency Id="D5ab7v8nWdAPt4KNu7n2zS" Location="../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />

--- a/Main/vl/UI/Schema.UI.PluginSelector.vl
+++ b/Main/vl/UI/Schema.UI.PluginSelector.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="EkxkWrjfgzROJohpRG4mlT" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="U1I0OhyHUHFMyqmgwJOgv1" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="EkxkWrjfgzROJohpRG4mlT" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="U1I0OhyHUHFMyqmgwJOgv1" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="G00lriESh6ML7hC1qy2p9n">
     <Canvas Id="VhTdbIzRNAwNuSAhimGm4u" DefaultCategory="Schema.UI.PluginSelector" CanvasType="FullCategory">
       <!--
@@ -14,7 +14,7 @@
         </p:NodeReference>
         <Patch Id="O6D2pQgSklOMLdMfCxqT8Y">
           <Canvas Id="BFNSkKVk3SkLruvqeCe4mY" CanvasType="Group">
-            <Pad Id="RoTQbnr1EmZQS5CAo7PWUd" Comment="Available Plugins" Bounds="1400,253,100,249" ShowValueBox="true" isIOBox="true">
+            <Pad Id="RoTQbnr1EmZQS5CAo7PWUd" Comment="Available Plugins" Bounds="753,107,100,249" ShowValueBox="true" isIOBox="true">
               <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
@@ -43,7 +43,7 @@
                 <Item>YAMLStacks</Item>
               </p:Value>
             </Pad>
-            <Node Bounds="1030,681,150,19" Id="PseXkhY6NtaNCLzrS3UXlu">
+            <Node Bounds="194,757,150,19" Id="PseXkhY6NtaNCLzrS3UXlu">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetDirectoryInRegistryPath" />
@@ -56,7 +56,7 @@
               </Pin>
               <Pin Id="DuCvnrrSkLUPSrqzsEUvJr" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1030,713,93,19" Id="NvjIluh8vw5P6ZhkjDPLuE">
+            <Node Bounds="194,789,93,19" Id="NvjIluh8vw5P6ZhkjDPLuE">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="DirectoryFilePath" />
@@ -74,7 +74,7 @@
               </Pin>
               <Pin Id="RdkwG4hS0SXOp5Zksda0BY" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1365,1121,63,26" Id="KhT7XcIXHXPPwL1koVd3jF">
+            <Node Bounds="657,925,63,26" Id="KhT7XcIXHXPPwL1koVd3jF">
               <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="PropertyBank" />
@@ -84,23 +84,23 @@
               <Pin Id="DpgTZ4vVdHTMUXHJYeThUM" Name="Properties" Kind="InputPin" />
               <Pin Id="Gnj7OBHW3HTMoRSSHlRqUv" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="1300,550,405,358" Id="TZg6IzlzrRjNtLbEE1B1TF">
+            <Node Bounds="653,404,405,358" Id="TZg6IzlzrRjNtLbEE1B1TF">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
               <Pin Id="VQMEaEVF3BMQXsdXoh6BlN" Name="Break" Kind="OutputPin" />
-              <ControlPoint Id="QqTTs4KKjo4MPLwVKUUgnV" Bounds="1392,556" Name="Key" Alignment="Top" />
-              <ControlPoint Id="NOleAQlKdDbOOAYt2wD58R" Bounds="1314,556" Name="Properties" Alignment="Top" />
-              <ControlPoint Id="EA1eoUn927eOXaH8FT7xk8" Bounds="1378,902" Name="Properties" Alignment="Bottom" />
-              <ControlPoint Id="OShDPoD6mMsMWGKO6qRJtz" Bounds="1506,556" Name="Widgets" Alignment="Top" />
-              <ControlPoint Id="PnTomwVFMvTMEK78L5VmPJ" Bounds="1522,902" Name="Widgets" Alignment="Bottom" />
+              <ControlPoint Id="QqTTs4KKjo4MPLwVKUUgnV" Bounds="745,410" Name="Key" Alignment="Top" />
+              <ControlPoint Id="NOleAQlKdDbOOAYt2wD58R" Bounds="667,410" Name="Properties" Alignment="Top" />
+              <ControlPoint Id="EA1eoUn927eOXaH8FT7xk8" Bounds="731,756" Name="Properties" Alignment="Bottom" />
+              <ControlPoint Id="OShDPoD6mMsMWGKO6qRJtz" Bounds="859,410" Name="Widgets" Alignment="Top" />
+              <ControlPoint Id="PnTomwVFMvTMEK78L5VmPJ" Bounds="875,756" Name="Widgets" Alignment="Bottom" />
               <Patch Id="FpHis5VIIZjQMY3viUOWlf" ManuallySortedPins="true">
                 <Patch Id="FmjM1UiszxYNXd1R49rqt0" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="EmaQy75zpCUPXwcqCDD8gg" Name="Update" ManuallySortedPins="true" />
                 <Patch Id="CEsEnsVxA6yOJ1klkOxBM8" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="1375,855,53,26" Id="OUUfo7EEhjCQbjdhjxP0U3">
+                <Node Bounds="728,709,53,26" Id="OUUfo7EEhjCQbjdhjxP0U3">
                   <p:NodeReference LastCategoryFullName="Collections.Dictionary" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetItem" />
@@ -111,7 +111,7 @@
                   <Pin Id="GfviOvdDFgZLqwKl1llu53" Name="Value" Kind="InputPin" />
                   <Pin Id="OfJBfm86Qz9LjO78m0YgRM" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1568,790,65,26" Id="JWNDloIzpQcOEgKSQkfJRU">
+                <Node Bounds="921,644,65,26" Id="JWNDloIzpQcOEgKSQkfJRU">
                   <p:NodeReference LastCategoryFullName="Schema.UI.View.Widgets.ToggleWidget" LastDependency="Schema.UI.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="ToggleWidget" />
@@ -121,7 +121,7 @@
                   <Pin Id="UOEQEwGLQ5tQFOKqVfsvui" Name="Initial Value" Kind="InputPin" />
                   <Pin Id="He3wjVDPathQEaJZK5yxLN" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1520,861,76,26" Id="BmXVNdFBoJRNItXzCt5exN">
+                <Node Bounds="873,715,76,26" Id="BmXVNdFBoJRNItXzCt5exN">
                   <p:NodeReference LastCategoryFullName="Collections.SortedDictionary" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetItem" />
@@ -132,20 +132,20 @@
                   <Pin Id="G7mq1vYw1dVLtHIJ2LD4ll" Name="Value" Kind="InputPin" />
                   <Pin Id="Gn7yM5Ku2u7Mn0turEqDFN" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="LvvUSZKbMIBNTw9I4Vumem" Comment="" Bounds="1570,840,104,15" ShowValueBox="true" isIOBox="true">
+                <Pad Id="LvvUSZKbMIBNTw9I4Vumem" Comment="" Bounds="923,694,104,15" ShowValueBox="true" isIOBox="true">
                   <p:TypeAnnotation LastCategoryFullName="Schema.UI.View.Widgets" LastDependency="Schema.UI.vl">
                     <Choice Kind="TypeFlag" Name="IPropertyWidget" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="HmDDLghAvNVMe90lyV7AeU" Bounds="1446,802,35,35" ShowValueBox="true" isIOBox="true" Value="False">
+                <Pad Id="HmDDLghAvNVMe90lyV7AeU" Bounds="799,656,35,35" ShowValueBox="true" isIOBox="true" Value="False">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
               </Patch>
             </Node>
-            <ControlPoint Id="UPvwoB9n4QSLvH7ll7sYmw" Bounds="946,349" />
-            <Node Bounds="932,633,104,26" Id="F7h56yBrkmJMRYmwzt2lIU">
+            <ControlPoint Id="UPvwoB9n4QSLvH7ll7sYmw" Bounds="110,425" />
+            <Node Bounds="96,709,104,26" Id="F7h56yBrkmJMRYmwzt2lIU">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetProjectDirectory" />
@@ -154,8 +154,8 @@
               <Pin Id="Pzk0xMkhHZqNUX49vn9K3G" Name="Output" Kind="StateOutputPin" />
               <Pin Id="ISdzryFd7MEQJz837zRPPd" Name="Project Directory" Kind="OutputPin" />
             </Node>
-            <Pad Id="FBwl8E8m01UNorAsfRqyfA" Comment="" Bounds="1505,1176,35,15" ShowValueBox="true" isIOBox="true" />
-            <Node Bounds="1466,1594,61,19" Id="EaHlYZV9OmTMsCE41WXXDN">
+            <Pad Id="FBwl8E8m01UNorAsfRqyfA" Comment="" Bounds="755,1041,113,127" ShowValueBox="true" isIOBox="true" />
+            <Node Bounds="630,1670,61,19" Id="EaHlYZV9OmTMsCE41WXXDN">
               <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Rectangle (Join)" />
@@ -173,7 +173,7 @@
               </Pin>
               <Pin Id="FhcvPGU4xKYM0gTnvDCvPk" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="1592,945,83,26" Id="K4LWok35dn6O3TYjLiL5WD">
+            <Node Bounds="945,799,83,26" Id="K4LWok35dn6O3TYjLiL5WD">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromSequence" />
@@ -182,7 +182,7 @@
               <Pin Id="RMxV7ffS28pOpetSflXuZr" Name="Input" Kind="StateInputPin" />
               <Pin Id="TXHU854I6Z1LUBe6eZYqyd" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1500,1141,48,19" Id="C0TQxFkP6g9LC88Vm1Qyxw">
+            <Node Bounds="855,980,48,19" Id="C0TQxFkP6g9LC88Vm1Qyxw">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Concat" />
@@ -192,7 +192,7 @@
               <Pin Id="GvjmT7BTRE3QWsdQCtZ4Iu" Name="Output" Kind="StateOutputPin" />
               <Pin Id="FOf3BHFLRAxN0yQbBwZ51J" Name="Input 2" Kind="InputPin" />
             </Node>
-            <Node Bounds="1573,992,60,26" Id="Mcyc7qKZQfuNAw5HQhg5h0">
+            <Node Bounds="926,846,60,26" Id="Mcyc7qKZQfuNAw5HQhg5h0">
               <p:NodeReference LastCategoryFullName="Schema.UI.View.Widgets.LabelWidget" LastDependency="Schema.UI.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="ClassType" Name="LabelWidget" />
@@ -206,7 +206,7 @@
               </Pin>
               <Pin Id="BP1B2FLIgIFOHIgV0q6HXE" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="1469,1079,65,19" Id="AJxveVDLZblOjC6M5cBGSf">
+            <Node Bounds="822,933,65,19" Id="AJxveVDLZblOjC6M5cBGSf">
               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromValue" />
@@ -215,7 +215,7 @@
               <Pin Id="UCyqVvEWFuePZypNwliM88" Name="Input" Kind="StateInputPin" />
               <Pin Id="SkiwZZLdbg6Myk4Egq7iCW" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1469,1036,62,26" Id="RnZSDe44SiKNjspHdTtQyj">
+            <Node Bounds="822,890,62,26" Id="RnZSDe44SiKNjspHdTtQyj">
               <p:NodeReference LastCategoryFullName="Collections.Common.KeyValuePair" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="KeyValuePair" />
@@ -225,12 +225,12 @@
               <Pin Id="VcdTOQeGS3DOmbHkJBEr5W" Name="Value" Kind="InputPin" />
               <Pin Id="RXeUCiN2jSHNNxr4GJIS14" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <Pad Id="U44ZPGQ6mhAQTXRWtMwgRg" Comment="Key" Bounds="1470,1016,35,15" ShowValueBox="true" isIOBox="true" Value="title">
+            <Pad Id="U44ZPGQ6mhAQTXRWtMwgRg" Comment="Key" Bounds="823,870,35,15" ShowValueBox="true" isIOBox="true" Value="title">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="1069,1458,78,26" Id="Fsgs993wo18M31XhH5fCa5">
+            <Node Bounds="233,1534,78,26" Id="Fsgs993wo18M31XhH5fCa5">
               <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetProperties" />
@@ -240,7 +240,7 @@
               <Pin Id="FMsztfGpUIMPsyF7xd7h9b" Name="Output" Kind="StateOutputPin" />
               <Pin Id="D79niKyEykEMJaYG9QQMTU" Name="Properties" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1142,1499,57,19" Id="JUVQAYNKHLHL75jvXkn69R">
+            <Node Bounds="306,1575,57,19" Id="JUVQAYNKHLHL75jvXkn69R">
               <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Changed" />
@@ -251,8 +251,8 @@
               <Pin Id="Pu8pnLiRsloMaTQpjMmDUN" Name="Result" Kind="OutputPin" />
               <Pin Id="RkoQ8vY1BmTQPeVWz3Dx7B" Name="Unchanged" Kind="OutputPin" />
             </Node>
-            <Pad Id="OaFIoEB1MRMO0MpdgjQslu" Comment="" Bounds="1144,1585,35,35" ShowValueBox="true" isIOBox="true" />
-            <Pad Id="QtiVYLqrB5VL7dzFD3AYpn" Bounds="857,1544,257,19" ShowValueBox="true" isIOBox="true" Value="TODO reactivity for widgets/propertybank">
+            <Pad Id="OaFIoEB1MRMO0MpdgjQslu" Comment="" Bounds="308,1661,35,35" ShowValueBox="true" isIOBox="true" />
+            <Pad Id="QtiVYLqrB5VL7dzFD3AYpn" Bounds="21,1620,257,19" ShowValueBox="true" isIOBox="true" Value="TODO reactivity for widgets/propertybank">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
@@ -261,9 +261,9 @@
                 <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
               </p:ValueBoxSettings>
             </Pad>
-            <Pad Id="Pkh5elJbI2DLy3UBTyNHp1" SlotId="SSUN6cX30VlLL7xYBTnFAg" Bounds="1308,1215" />
-            <Pad Id="A9XX4lE5FovN10C9suyBed" SlotId="SSUN6cX30VlLL7xYBTnFAg" Bounds="1146,1398" />
-            <Node Bounds="1536,1531,85,19" Id="E3hgUkk0pOdO6uze9htZdg">
+            <Pad Id="Pkh5elJbI2DLy3UBTyNHp1" SlotId="SSUN6cX30VlLL7xYBTnFAg" Bounds="658,1152" />
+            <Pad Id="A9XX4lE5FovN10C9suyBed" SlotId="SSUN6cX30VlLL7xYBTnFAg" Bounds="233,1468" />
+            <Node Bounds="700,1607,85,19" Id="E3hgUkk0pOdO6uze9htZdg">
               <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Oscillator (Generic)" />
@@ -287,34 +287,34 @@
               <Pin Id="AkRt2oBqcdRL2RjmbYCUgO" Name="Function" Kind="OutputPin" IsHidden="true" />
               <Pin Id="HTQZd5TVRknPM0ikQLk7z1" Name="Has Changed" Kind="OutputPin" />
             </Node>
-            <Pad Id="PRIOMRko3OtN0gUTMfA6MY" Comment="Size" Bounds="1519,1433,35,28" ShowValueBox="true" isIOBox="true" Value="1.25, 0.12">
+            <Pad Id="PRIOMRko3OtN0gUTMfA6MY" Comment="Size" Bounds="683,1509,35,28" ShowValueBox="true" isIOBox="true" Value="1.25, 0.12">
               <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector2" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="KaS3nNuQ5rANPttpd7ylR3" Comment="Size" Bounds="1435,1431,35,28" ShowValueBox="true" isIOBox="true" Value="1, 0">
+            <Pad Id="KaS3nNuQ5rANPttpd7ylR3" Comment="Size" Bounds="599,1507,35,28" ShowValueBox="true" isIOBox="true" Value="1, 0">
               <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Vector2" />
               </p:TypeAnnotation>
             </Pad>
-            <Pad Id="GnrjaQwQTeyLKeMyrvT8ru" Bounds="1792,1112,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <Pad Id="GnrjaQwQTeyLKeMyrvT8ru" Bounds="956,1233,35,35" ShowValueBox="true" isIOBox="true" Value="True">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pad>
-            <Node Bounds="1493,1672,570,580" Id="MtMYuxKd23HQQKbzZvT1BV">
+            <Node Bounds="657,1748,635,580" Id="MtMYuxKd23HQQKbzZvT1BV">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
               <Pin Id="CZ23O1DEFDEPykllmpVKfC" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="SDy8hT3eYjTPRtAQdzM2cN" Bounds="1508,2246" Alignment="Bottom" />
-              <ControlPoint Id="MFnTJWvPGbvNt3diNQNSfa" Bounds="1533,1678" Alignment="Top" />
+              <ControlPoint Id="SDy8hT3eYjTPRtAQdzM2cN" Bounds="672,2322" Alignment="Bottom" />
+              <ControlPoint Id="MFnTJWvPGbvNt3diNQNSfa" Bounds="697,1754" Alignment="Top" />
               <Patch Id="SMnQ74rDXv5LWHPZPVRjY3" ManuallySortedPins="true">
                 <Patch Id="VieLCQUnk8qLiooLI4jN26" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="UzP0rVCdvVZPo1j84zOLxL" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="1507,1780,105,19" Id="DZ52eHLM93RQUnbYI1uHPM">
+                <Node Bounds="671,1856,105,19" Id="DZ52eHLM93RQUnbYI1uHPM">
                   <p:NodeReference LastCategoryFullName="Schema.UI.View.Widgets.Layout" LastDependency="Schema.UI.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="WidgetList" />
@@ -329,7 +329,7 @@
                   <Pin Id="KJplCUsOFFvMOrY4wmYEAc" Name="Output" Kind="OutputPin" />
                   <Pin Id="CtvVxBUq6YDMBKALW3B4E6" Name="Bounds" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1505,2213,80,19" Id="NRPU30DaJvkQWPsPvt3m7T">
+                <Node Bounds="669,2289,80,19" Id="NRPU30DaJvkQWPsPvt3m7T">
                   <p:NodeReference LastCategoryFullName="Graphics.Skia.Transform" LastDependency="VL.Skia.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TransformSRT" />
@@ -348,7 +348,7 @@
                   <Pin Id="HhuwT71OirUQX9ihdqckaC" Name="Translation" Kind="InputPin" />
                   <Pin Id="K5UBfOGJ0ggPFBv9Ee9QUU" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1581,1815,46,19" Id="LzVuaYlbTMXQWbPls1WGBO">
+                <Node Bounds="745,1891,46,19" Id="LzVuaYlbTMXQWbPls1WGBO">
                   <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Center" />
@@ -357,7 +357,7 @@
                   <Pin Id="S8r96niWOvfNfu4cYPyf0Y" Name="Input" Kind="StateInputPin" />
                   <Pin Id="AiOXySPFD0dOrcLS3Nmwh5" Name="Center" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1581,1845,22,19" Id="Gbbel8JgEL6MGXpJU9MtXw">
+                <Node Bounds="745,1921,22,19" Id="Gbbel8JgEL6MGXpJU9MtXw">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="- (Negate)" />
@@ -365,7 +365,7 @@
                   <Pin Id="JlyDojLz3VhNB0leTv60L6" Name="Input" Kind="InputPin" />
                   <Pin Id="VJ6hSeI5HE2OkbZq2Vi430" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1588,1695,56,19" Id="VBtUMtnsHbqNIAU6qeoyqc">
+                <Node Bounds="752,1771,56,19" Id="VBtUMtnsHbqNIAU6qeoyqc">
                   <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetAlpha" />
@@ -375,7 +375,7 @@
                   <Pin Id="OkT8jv0F6F2MymkfZTyS0f" Name="Alpha" Kind="InputPin" />
                   <Pin Id="UyFfHQfbxEvPWYvsMpbJd2" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1607,1737,56,19" Id="TwXFKpE7kF4PIwPLZo4LKT">
+                <Node Bounds="771,1813,56,19" Id="TwXFKpE7kF4PIwPLZo4LKT">
                   <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetAlpha" />
@@ -389,7 +389,7 @@
                   <Pin Id="UuIt5VSDvFoOHydqlwis5q" Name="Alpha" Kind="InputPin" />
                   <Pin Id="QtzgPzoPpqSLSmSrkY4sXN" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1644,1851,25,19" Id="UhxbLSDIr8jN9sOalB6Jf6">
+                <Node Bounds="808,1927,56,19" Id="UhxbLSDIr8jN9sOalB6Jf6">
                   <p:NodeReference LastCategoryFullName="Schema.UI" LastDependency="Schema.UI.Style.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="SkiaStyle" />
@@ -398,7 +398,7 @@
                   <Pin Id="IMdx4DdD7e4PYAKtkz8RhD" Name="Radius" Kind="OutputPin" />
                   <Pin Id="DnEyIAzOadWPhydOHbp9CA" Name="Highlight" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1657,1802,51,26" Id="BsLCBA7Wd8LPNIHyOzcDGy">
+                <Node Bounds="821,1878,51,26" Id="BsLCBA7Wd8LPNIHyOzcDGy">
                   <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Inflate (Uniform)" />
@@ -411,7 +411,7 @@
                   </Pin>
                   <Pin Id="B6eI4RzWPwJNcMiwRFXdaP" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1639,1896,65,19" Id="JV2jSOJWz3ENfAY1szNeMw">
+                <Node Bounds="803,1972,90,19" Id="JV2jSOJWz3ENfAY1szNeMw">
                   <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers" LastDependency="VL.Skia.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="RoundRectangle (Bounds)" />
@@ -423,7 +423,7 @@
                   <Pin Id="L4gkNQieX71LIKi4ft6vaq" Name="Enabled" Kind="InputPin" />
                   <Pin Id="PGG2L5ILctuNAAIMXjTCYn" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1507,2176,85,19" Id="VyoSrJOpChNN2Gk3tDcrrp">
+                <Node Bounds="671,2252,85,19" Id="VyoSrJOpChNN2Gk3tDcrrp">
                   <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Group" />
@@ -436,7 +436,7 @@
                   <Pin Id="Lnxca6zc5wwNDcpGAgHB61" Name="Enabled" Kind="InputPin" />
                   <Pin Id="TaeZ5uA8iKuNc2nIyuN7Wi" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1655,1967,45,19" Id="C0k7twuyNEPP3uhq3UMVWF">
+                <Node Bounds="819,2043,83,19" Id="C0k7twuyNEPP3uhq3UMVWF">
                   <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Layout.Common" LastDependency="Schema.UI.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TabTitleButton" />
@@ -452,7 +452,7 @@
                   <Pin Id="T9NF5L7eFx2QZU43IBDCsh" Name="Bounds" Kind="OutputPin" />
                   <Pin Id="C2a41JFTYU1PGTPZX27IbV" Name="On Click" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1660,2113,105,19" Id="IfNzDEqujX4L4FSAGjLjX1">
+                <Node Bounds="824,2189,105,19" Id="IfNzDEqujX4L4FSAGjLjX1">
                   <p:NodeReference LastCategoryFullName="Graphics.Skia.Transform" LastDependency="VL.Skia.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TransformSRT (Center)" />
@@ -481,7 +481,7 @@
                   </Pin>
                   <Pin Id="QWEcMw2EIUKQM3xnDOYXzu" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1711,2004,46,19" Id="QoUCLAK5DfcPRzeswFUwva">
+                <Node Bounds="875,2080,46,19" Id="QoUCLAK5DfcPRzeswFUwva">
                   <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Center" />
@@ -490,7 +490,7 @@
                   <Pin Id="ILBkwnBaPjuPdZfILsK0mU" Name="Input" Kind="StateInputPin" />
                   <Pin Id="V6GhQPvncvbPcWIhMIMMSd" Name="Center" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1712,2035,22,19" Id="Exf6O2vRDAPL7drHBWRJQz">
+                <Node Bounds="876,2111,22,19" Id="Exf6O2vRDAPL7drHBWRJQz">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="- (Negate)" />
@@ -498,7 +498,7 @@
                   <Pin Id="DbAYiF2P3TONJmPlOrrlT6" Name="Input" Kind="InputPin" />
                   <Pin Id="AXdlgq7T6hFPkI0efxfxU2" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1715,2065,25,19" Id="QUnX47YXMhxMvxQHT750ZH">
+                <Node Bounds="879,2141,25,19" Id="QUnX47YXMhxMvxQHT750ZH">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="/ (Scale)" />
@@ -511,7 +511,7 @@
                   </Pin>
                   <Pin Id="NAcV0iaKdyjL5bBPJvIyqk" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1832,2044,219,95" Id="Qh17s5bMbdsNOkPX79PU1p">
+                <Node Bounds="996,2120,284,95" Id="Qh17s5bMbdsNOkPX79PU1p">
                   <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ProcessAppFlag" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -527,9 +527,9 @@
                       <Pin Id="PM315kxc9DiMCP9p5ZlcCn" Name="Input 1" Kind="InputPin" />
                       <Pin Id="JpLANEmwyYQPboqk6WRfn8" Name="Output" Kind="OutputPin" />
                     </Patch>
-                    <ControlPoint Id="QVbpNjk7D7nPmADAQHJrW4" Bounds="1844,2052" />
-                    <ControlPoint Id="CQSazOLQ16yNd4n3M6rwP3" Bounds="1844,2132" />
-                    <Node Bounds="1954,2087,85,19" Id="J3zNrSqrtRoLyxVIqy8CTC">
+                    <ControlPoint Id="QVbpNjk7D7nPmADAQHJrW4" Bounds="1008,2128" />
+                    <ControlPoint Id="CQSazOLQ16yNd4n3M6rwP3" Bounds="1008,2208" />
+                    <Node Bounds="1118,2163,150,19" Id="J3zNrSqrtRoLyxVIqy8CTC">
                       <p:NodeReference LastCategoryFullName="Schema.UI.Actions" LastDependency="Schema.UI.Actions.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="LaunchCurrentProjectSettings" />
@@ -537,7 +537,7 @@
                       <Pin Id="JaSAYzBLth2QaOQWWO2Kcq" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="NLUGb5HkhwwNOzC4B870Hb" Name="Update" Kind="InputPin" />
                     </Node>
-                    <Pad Id="S3NTxwp3klnPlMfJguCYra" Comment="Output" Bounds="1848,2082,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+                    <Pad Id="S3NTxwp3klnPlMfJguCYra" Comment="Output" Bounds="1012,2158,35,35" ShowValueBox="true" isIOBox="true" Value="True">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                         <FullNameCategoryReference ID="Primitive" />
@@ -547,7 +547,7 @@
                 </Node>
               </Patch>
             </Node>
-            <Node Bounds="1496,1564,45,19" Id="Mzzkqdv2Dt9Otei6RQP4nq">
+            <Node Bounds="660,1640,45,19" Id="Mzzkqdv2Dt9Otei6RQP4nq">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Lerp" />
@@ -557,7 +557,7 @@
               <Pin Id="Kvu4Dl7tNK7OYckqJckXc4" Name="Scalar" Kind="InputPin" />
               <Pin Id="VsStA53F5gBPjbr3OhgVUp" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1532,1502,62,19" Id="Bd7Up1ZNTE3PqbhMSExfBV">
+            <Node Bounds="800,1534,62,19" Id="Bd7Up1ZNTE3PqbhMSExfBV">
               <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="ToFloat32" />
@@ -565,7 +565,7 @@
               <Pin Id="D5KzBVr5sXBOflz0H6i3sA" Name="Input" Kind="InputPin" />
               <Pin Id="ScDI7V5ZkgONnl4v1bDZnV" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1494,1637,25,19" Id="HNGz7zGcYSzPFfh9UgsyOE">
+            <Node Bounds="658,1713,25,19" Id="HNGz7zGcYSzPFfh9UgsyOE">
               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -578,8 +578,8 @@
               </Pin>
               <Pin Id="Lh4aE87O0b1N2NGyB6XBSi" Name="Result" Kind="OutputPin" />
             </Node>
-            <Pad Id="BSy5Aj8VLUELacTbTNZoKr" Comment="Velocity" Bounds="1602,1572,35,15" ShowValueBox="true" isIOBox="true" />
-            <Node Bounds="1711,1535,65,19" Id="G5luU13MSvnLou5MbdCUyf">
+            <Pad Id="BSy5Aj8VLUELacTbTNZoKr" Comment="Velocity" Bounds="766,1648,35,15" ShowValueBox="true" isIOBox="true" />
+            <Node Bounds="875,1611,65,19" Id="G5luU13MSvnLou5MbdCUyf">
               <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Damper" />
@@ -602,7 +602,7 @@
               <Pin Id="LQnRHcjipLdQQzGHSXQb98" Name="Function" Kind="OutputPin" IsHidden="true" />
               <Pin Id="HFnHGXmADPhPmJyR3Cnqqx" Name="Has Changed" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1789,1249,228,266" Id="LI7je1LvdA1N9GmJ8nacaU">
+            <Node Bounds="953,1325,228,266" Id="LI7je1LvdA1N9GmJ8nacaU">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -612,19 +612,19 @@
               <Patch Id="Tonoc0SID9YPkm1wifrdBX" ManuallySortedPins="true">
                 <Patch Id="LbvKM8hbTd3M4PuuCl1UZe" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="KY8bIsnGzubMLaazRDwmKS" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="1874,1270,131,212" Id="DIm6TI1pSJON7cb40LbDcZ">
+                <Node Bounds="1038,1346,131,212" Id="DIm6TI1pSJON7cb40LbDcZ">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:NodeReference>
                   <Pin Id="FmoyHdJsWn1MiRsoshOCXS" Name="Break" Kind="OutputPin" />
-                  <ControlPoint Id="D4SciJIL69TNNkkuwhEjCA" Bounds="1888,1276" Alignment="Top" />
+                  <ControlPoint Id="D4SciJIL69TNNkkuwhEjCA" Bounds="1052,1352" Alignment="Top" />
                   <Patch Id="B8PSFg0X8fNLEdyl1s7Hmy" ManuallySortedPins="true">
                     <Patch Id="E8jCjXxUO4uLHXUKdGv5Cv" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="E5beng4dTjuPdiVCYXTEok" Name="Update" ManuallySortedPins="true" />
                     <Patch Id="IGD6YitqLLtQKuUXijlzy8" Name="Dispose" ManuallySortedPins="true" />
-                    <Node Bounds="1889,1436,63,26" Id="UouhyYPLJviMaqL7UNhyXx">
+                    <Node Bounds="1053,1512,63,26" Id="UouhyYPLJviMaqL7UNhyXx">
                       <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Set" />
@@ -634,7 +634,7 @@
                       <Pin Id="BjiwLL1U4JxLD5gdPH67Uo" Name="Value" Kind="InputPin" />
                       <Pin Id="Q5YLWaX5eJ7MQGkbfKJt82" Name="Output" Kind="StateOutputPin" />
                     </Node>
-                    <Node Bounds="1906,1358,87,26" Id="UXaMKhiJKkqN1oVTOMQyGk">
+                    <Node Bounds="1070,1434,87,26" Id="UXaMKhiJKkqN1oVTOMQyGk">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.State" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="GetConfigValue" />
@@ -651,7 +651,7 @@
                       <Pin Id="HKby1UvQziROryAQuNf0R4" Name="Value" Kind="OutputPin" />
                       <Pin Id="Ubfjt5ZkOUhNqa9jvLyMJf" Name="Found" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="1947,1317,25,19" Id="Gh6FY40TpSbLR0oQjcFXz7">
+                    <Node Bounds="1111,1393,25,19" Id="Gh6FY40TpSbLR0oQjcFXz7">
                       <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="+" />
@@ -664,7 +664,7 @@
                       <Pin Id="SUje2wDZT6CLxJNjogHjrX" Name="Input 2" Kind="InputPin" />
                       <Pin Id="NMcSMOBb6URPtHV1oasNJ3" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="1947,1403,25,19" Id="BHOgw8U4NptNI7xbBEnRtP">
+                    <Node Bounds="1111,1479,25,19" Id="BHOgw8U4NptNI7xbBEnRtP">
                       <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="=" />
@@ -681,7 +681,7 @@
                 </Node>
               </Patch>
             </Node>
-            <Node Bounds="1789,1196,56,19" Id="QnQoLcw8xRCP3V88lI5mZt">
+            <Node Bounds="953,1272,56,19" Id="QnQoLcw8xRCP3V88lI5mZt">
               <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="TogEdge" />
@@ -691,9 +691,9 @@
               <Pin Id="M0PaaVlgBxuNDCIbpwiVp5" Name="Up Edge" Kind="OutputPin" />
               <Pin Id="DOGiA7I1n6pNSYy7xWOyHx" Name="Down Edge" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="KNaLDQHABCWOw4kXkDkLLY" Bounds="1500,2354" />
-            <ControlPoint Id="NWSY9Y8kVEUOop2laggKWh" Bounds="919,845" />
-            <Node Bounds="1798,1840,45,19" Id="MombtEI2ve7LgoAFjRZrtK">
+            <ControlPoint Id="KNaLDQHABCWOw4kXkDkLLY" Bounds="664,2430" />
+            <ControlPoint Id="NWSY9Y8kVEUOop2laggKWh" Bounds="100,872" />
+            <Node Bounds="962,1916,45,19" Id="MombtEI2ve7LgoAFjRZrtK">
               <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Fill" />
@@ -708,7 +708,7 @@
               <Pin Id="MPa7WsYt5LoLswucWGsSfj" Name="Shader" Kind="InputPin" />
               <Pin Id="Tk0gLBXqklJQIYztKPUaiG" Name="Output" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1178,1645,25,19" Id="VZc7uXUruSmLvpw5Y2SET4">
+            <Node Bounds="306,1721,79,19" Id="VZc7uXUruSmLvpw5Y2SET4">
               <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ToObservable" />
@@ -719,7 +719,7 @@
               <Pin Id="Qb0O1czWafZPV1nBL2aViX" Name="Send" Kind="InputPin" />
               <Pin Id="JWicZwQTYd6OfHr6Mtc2eb" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="1202,1733,215,604" Id="Bfzu4RDAWw5MHgbDVVQe7l">
+            <Node Bounds="235,1809,335,604" Id="Bfzu4RDAWw5MHgbDVVQe7l">
               <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ProcessAppFlag" Name="ForEach" />
                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
@@ -735,9 +735,9 @@
                   <Pin Id="GN0Ry6DiUItPdgWwriJcVN" Name="Input 1" Kind="InputPin" />
                   <Pin Id="KmVLxDk4JumOYzy6eGfvYx" Name="Output" Kind="OutputPin" />
                 </Patch>
-                <ControlPoint Id="NDg8XXCJgMsLQsS8Iiyhvh" Bounds="1212,1741" />
-                <ControlPoint Id="CWKgzoCr4L9L10kYXtHQ9F" Bounds="1212,2205" />
-                <Node Bounds="1220,2095,50,26" Id="OAVJvstwZgWLL8dLMisDm7">
+                <ControlPoint Id="NDg8XXCJgMsLQsS8Iiyhvh" Bounds="376,1817" />
+                <ControlPoint Id="CWKgzoCr4L9L10kYXtHQ9F" Bounds="376,2281" />
+                <Node Bounds="384,2171,50,26" Id="OAVJvstwZgWLL8dLMisDm7">
                   <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToJSON" />
@@ -751,7 +751,7 @@
                   <Pin Id="TrM6SmaOc5SMMYBKsu9S1T" Name="Omit Root Object" Kind="InputPin" />
                   <Pin Id="BfmywDZSt1eLxeipVtBkjS" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1214,2056,65,19" Id="L1CBVFIuDUyLYebcEsuqYL">
+                <Node Bounds="378,2132,65,19" Id="L1CBVFIuDUyLYebcEsuqYL">
                   <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="XElement (Join)" />
@@ -766,20 +766,20 @@
                   <Pin Id="K7f7WI2GwFhPXqL0n4G89p" Name="Children" Kind="InputPin" />
                   <Pin Id="AqxdpPcHwhbLOgLZMNIgVY" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1256,1790,138,252" Id="KYosxtKwLqoPgrFECF1XXa">
+                <Node Bounds="420,1866,138,252" Id="KYosxtKwLqoPgrFECF1XXa">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                     <FullNameCategoryReference ID="Primitive" />
                   </p:NodeReference>
                   <Pin Id="LlE6scRWRApNi281eAYgDM" Name="Break" Kind="OutputPin" />
-                  <ControlPoint Id="IRrKpe5QqMlNcTkZWN6B94" Bounds="1280,2036" Alignment="Bottom" />
-                  <ControlPoint Id="MjP7Ybv6U0jPrqZjhzG5HL" Bounds="1335,1796" Alignment="Top" />
+                  <ControlPoint Id="IRrKpe5QqMlNcTkZWN6B94" Bounds="444,2112" Alignment="Bottom" />
+                  <ControlPoint Id="MjP7Ybv6U0jPrqZjhzG5HL" Bounds="499,1872" Alignment="Top" />
                   <Patch Id="EtPtXkYhRoVPM1ZiKLpVNm" ManuallySortedPins="true">
                     <Patch Id="UbX9qTpO3CsQQBKhJ8iL4K" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="Lp2eTFnolFxM529hUaIYVc" Name="Update" ManuallySortedPins="true" />
                     <Patch Id="JvtpmomLRUpLgIEY1S6VXQ" Name="Dispose" ManuallySortedPins="true" />
-                    <Node Bounds="1279,1997,65,19" Id="Unj9r4MtAj7MMQL9X5q8uy">
+                    <Node Bounds="443,2073,65,19" Id="Unj9r4MtAj7MMQL9X5q8uy">
                       <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="XElement (Join)" />
@@ -790,7 +790,7 @@
                       <Pin Id="V00OTrsbH5TO5wyiViQkuW" Name="Children" Kind="InputPin" />
                       <Pin Id="Ab3xkUMHlAtL6cr3N75TJ6" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="1299,1927,55,19" Id="J8huvVtoBCbPBDZckfEXDM">
+                    <Node Bounds="463,2003,55,19" Id="J8huvVtoBCbPBDZckfEXDM">
                       <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -798,13 +798,13 @@
                       <Pin Id="AZBaMQzE0J1MgeEzZnM458" Name="Input" Kind="InputPin" />
                       <Pin Id="O8qcy9UhJMpMA1lofEu390" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Pad Id="AiBG86RZpjdP1QavuCrvDP" Comment="Input" Bounds="1301,1890,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+                    <Pad Id="AiBG86RZpjdP1QavuCrvDP" Comment="Input" Bounds="465,1966,35,35" ShowValueBox="true" isIOBox="true" Value="True">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Boolean" />
                         <FullNameCategoryReference ID="Primitive" />
                       </p:TypeAnnotation>
                     </Pad>
-                    <Node Bounds="1299,1956,55,26" Id="TuJ2L73GDjnNc0mF7fJPNi">
+                    <Node Bounds="463,2032,55,26" Id="TuJ2L73GDjnNc0mF7fJPNi">
                       <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ToLower" />
@@ -813,7 +813,7 @@
                       <Pin Id="Vt2DjDacd2gLlNppeMObL9" Name="Input" Kind="StateInputPin" />
                       <Pin Id="Btu3JtQjGl3MWTwQKJymYj" Name="Output" Kind="StateOutputPin" />
                     </Node>
-                    <Node Bounds="1268,1813,63,26" Id="FAkYWQhL8VJNMs8SASxfHa">
+                    <Node Bounds="432,1889,63,26" Id="FAkYWQhL8VJNMs8SASxfHa">
                       <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Get" />
@@ -827,8 +827,8 @@
                     </Node>
                   </Patch>
                 </Node>
-                <Pad Id="BG83Q59bPj0MI7YqQgQYTw" Comment="" Bounds="1222,2152,125,172" ShowValueBox="true" isIOBox="true" />
-                <Node Bounds="1300,2153,105,19" Id="DStKzoazQufL0B6E1yCluu">
+                <Pad Id="BG83Q59bPj0MI7YqQgQYTw" Comment="" Bounds="386,2228,125,172" ShowValueBox="true" isIOBox="true" />
+                <Node Bounds="247,2273,105,19" Id="DStKzoazQufL0B6E1yCluu">
                   <p:NodeReference LastCategoryFullName="System.XML" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessNode" Name="JSONWriter (XDocument)" />
@@ -847,8 +847,8 @@
                 </Node>
               </Patch>
             </Node>
-            <ControlPoint Id="MGmAJwYEUFeN9xh2LudJEL" Bounds="1792,1032" />
-            <Node Bounds="1148,1550,25,19" Id="OlW3Bt7KK4JLVVkVknr3YS">
+            <ControlPoint Id="MGmAJwYEUFeN9xh2LudJEL" Bounds="956,1211" />
+            <Node Bounds="306,1616,37,19" Id="OlW3Bt7KK4JLVVkVknr3YS">
               <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
@@ -857,6 +857,7 @@
               <Pin Id="NZHesq8M27GPzXqqZsIGaN" Name="Input 2" Kind="InputPin" />
               <Pin Id="KsUsibThzh1Mr3abRXT2Px" Name="Output" Kind="StateOutputPin" />
             </Node>
+            <Overlay Id="Rg4oAr1lONoLPfuSgd63yj" Name="Plugin List Init" Bounds="521,35,682,1136" />
           </Canvas>
           <ProcessDefinition Id="TkJjBhfLn7jPlUAk9zkCj5">
             <Fragment Id="QGV154Uv1D5NbWEO2SiDh5" Patch="CyT0eLsdkwjMElhIAQ6tJ3" Enabled="true" />
@@ -999,7 +1000,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="M6sBw0DJ4CLPlGdwUtrl0P" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="M6sBw0DJ4CLPlGdwUtrl0P" Location="VL.Skia" Version="2024.6.7" />
   <DocumentDependency Id="D84xX0eAnU0Ou83bf7W1dd" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="GvzI1nVmKS9MGSUjvL865H" Location="./Schema.UI.vl" />
   <DocumentDependency Id="D5ab7v8nWdAPt4KNu7n2zS" Location="../PropertyDefinition/Schema.PropertyDefinition.Helpers.vl" />

--- a/Main/vl/UI/Schema.UI.vl
+++ b/Main/vl/UI/Schema.UI.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="HY4bvk8C4UaOvYdOJXseM9" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="NkBh4OWx9oGOPU9o04edoW" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="HY4bvk8C4UaOvYdOJXseM9" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="NkBh4OWx9oGOPU9o04edoW" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="O2XeIgrncFrPtJVEvrUA3W">
     <Canvas Id="Ci7VwEE3fBNLj4DZqA1kki" DefaultCategory="Schema.UI" CanvasType="FullCategory">
       <!--
@@ -1226,6 +1226,7 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="Polygon" />
                           </p:NodeReference>
+                          <Pin Id="M4Vb6f1eMbMP71AiNt49X6" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="OXhNjIhxdMrNqHkWnor8tH" Name="Points" Kind="InputPin" />
                           <Pin Id="IVa9q7tujbsNOo6wuk6nuS" Name="Closed" Kind="InputPin" />
                           <Pin Id="Or60kQVu83fLxMv5ASjdcp" Name="Paint" Kind="InputPin" />
@@ -1238,6 +1239,7 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="CircleSpread" />
                           </p:NodeReference>
+                          <Pin Id="Iu9BOzA28zNN29radnN1Ix" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="SAaDohor1tKL3TDLTcq2j9" Name="Center" Kind="InputPin" />
                           <Pin Id="KbeIVaQwjmCQdQAtYzc8Uj" Name="Width" Kind="InputPin" />
                           <Pin Id="KNjESlba9W4MQ40zy7uNmj" Name="Factor" Kind="InputPin" />
@@ -1435,6 +1437,7 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="TriangleLayer" />
                           </p:NodeReference>
+                          <Pin Id="F9B4AccQqQHLrPvdS8CcZR" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="DLzDJR6KmTfLXurqh6Tp8W" Name="Bounds" Kind="InputPin" />
                           <Pin Id="QTDnvmqyEXVMagwP95ZGyU" Name="Phase" Kind="InputPin" />
                           <Pin Id="Iqc4qrfS5o7OBeZM5EXpVl" Name="Paint" Kind="InputPin" />
@@ -1695,6 +1698,7 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="LeftClickButtonBehavior" />
                           </p:NodeReference>
+                          <Pin Id="NaylpvwnPN6LsQRYZVnkhz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="U2xZVoidHmENKm4heQSzPP" Name="Bounds" Kind="InputPin" />
                           <Pin Id="RDk6Qs60ll7Pk4wLKzJJd6" Name="Output" Kind="StateOutputPin" />
                           <Pin Id="B2Sr3A5d3WrPyeAxgV4yUD" Name="Is Hovered" Kind="OutputPin" />
@@ -1706,6 +1710,7 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="TriangleButtonRendering" />
                           </p:NodeReference>
+                          <Pin Id="SmLopDyLxDbLdEotxnOA9F" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="PWEG6fIbUjyOlLTPnA4aLa" Name="Bounds" Kind="InputPin" />
                           <Pin Id="GK1UTPM2pTgLpQG4e2SFqc" Name="Phase" Kind="InputPin" />
                           <Pin Id="ETbAxBzx8fTMSPJKOeAfh6" Name="Paint" Kind="InputPin" />
@@ -1720,6 +1725,7 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="SetBehavior" />
                           </p:NodeReference>
+                          <Pin Id="QS75pTGUnStMSJI6bzWaLu" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="H1a75TO851yPKsU36RgHEM" Name="Input" Kind="InputPin" />
                           <Pin Id="DHlOy8jlgXuO26pA2nAdlI" Name="Behavior" Kind="InputPin" />
                           <Pin Id="VcyzoJU0Z5TMNudGDyPvsj" Name="Output" Kind="OutputPin" />
@@ -29084,7 +29090,7 @@
                         <Pin Id="CAfkC7DgDgkO8EN9HImd0p" Name="View Projection" Kind="OutputPin" />
                         <Pin Id="M5gHJkHqbGIP6rb62exxv2" Name="Is Perspective" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2004,852,85,19" Id="IOCLSLNy2GYNt2NQERL7uX">
+                      <Node Bounds="1975,1007,85,19" Id="IOCLSLNy2GYNt2NQERL7uX">
                         <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="Group" />
@@ -29097,7 +29103,7 @@
                         <Pin Id="AsQpRwyqaqjNmhGKBStni6" Name="Enabled" Kind="InputPin" />
                         <Pin Id="NTwSaqn7A7pLb4vVbjlZMn" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2065,493,85,19" Id="RR2L7YQagqvLjMygMQ9LZg">
+                      <Node Bounds="2059,503,85,19" Id="RR2L7YQagqvLjMygMQ9LZg">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="StateLayer" />
@@ -29142,7 +29148,7 @@
                         </Pin>
                         <Pin Id="RWT2EeKXScNN8oFNrQlWuf" Name="Pressed" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2065,529,94,19" Id="QsZRcmEktC3MVSOg8bR49t">
+                      <Node Bounds="2059,537,94,19" Id="QsZRcmEktC3MVSOg8bR49t">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FloorplanLayer" />
@@ -29153,7 +29159,7 @@
                         <Pin Id="MSDQYZd6t4eOyahnsklNwy" Name="Condition" Kind="InputPin" />
                         <Pin Id="FHbKClJwTEXPQWnhHAdaSG" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2065,556,81,19" Id="TBqnrXJVVCsQWwyEL9aAjF">
+                      <Node Bounds="2059,571,81,19" Id="TBqnrXJVVCsQWwyEL9aAjF">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="PixelsLayer" />
@@ -29216,7 +29222,7 @@
                         <Pin Id="B352UUoqnxiLfoDLMY8pbo" Name="Enabled" Kind="InputPin" />
                         <Pin Id="CbtJuhJlyFGL13mKXAucnC" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2065,614,125,19" Id="LQNVav8AbxcLvaUBlkBWpJ">
+                      <Node Bounds="2059,639,125,19" Id="LQNVav8AbxcLvaUBlkBWpJ">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessNode" Name="AddFixtureLayer" />
@@ -29254,7 +29260,7 @@
                         <Pin Id="Lpz5t35d3L3M32C5pN6g9a" Name="Is Perspective" Kind="InputPin" />
                         <Pin Id="TbwQvYvQOL3NmkaNvumyTa" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="2065,650,88,19" Id="TQnYGlQU86ENteKCrP1MFn">
+                      <Node Bounds="2059,673,88,19" Id="TQnYGlQU86ENteKCrP1MFn">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="SetFloorLayer" />
@@ -29265,7 +29271,7 @@
                         <Pin Id="RoN8Aktt3rWMy5aVWLJDRv" Name="Condition" Kind="InputPin" />
                         <Pin Id="Fr9RVg09Gt0NXz3Uz47Zei" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="1998,474,70,19" Id="Pl7XxNLo1HsLDXgQ6Atm1s">
+                      <Node Bounds="1988,470,70,19" Id="Pl7XxNLo1HsLDXgQ6Atm1s">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="GridLayer" />
@@ -29276,7 +29282,7 @@
                         <Pin Id="HNOI0W8PRzaNOUFq6LuzeF" Name="Condition" Kind="InputPin" />
                         <Pin Id="CxqaRYbcK6HOTL4OcKhSsI" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2065,686,131,19" Id="MHOcyIwC3EIPOyXSZvcB5i">
+                      <Node Bounds="2059,707,131,19" Id="MHOcyIwC3EIPOyXSZvcB5i">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FixtureDuplicatorLayer" />
@@ -29311,7 +29317,7 @@
                         <Pin Id="TY9nc31DVdRLCbxgDm5lHD" Name="Inspector Enabled" Kind="InputPin" />
                         <Pin Id="SREJw93uh9jON3Oox4s3BC" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="2108,898,131,19" Id="Qkz2PHqwjsTO1UWLF4qvvd">
+                      <Node Bounds="2059,877,131,19" Id="Qkz2PHqwjsTO1UWLF4qvvd">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FixtureTransformLayer" />
@@ -29322,7 +29328,7 @@
                         <Pin Id="USpm26eqq5EPVIFndn5WhI" Name="Condition" Kind="InputPin" />
                         <Pin Id="RnD6cFEGleGOfOEHpdOGPs" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2081,759,131,19" Id="FUDZs9HIKQxMPCs5PqZaX3">
+                      <Node Bounds="2059,775,131,19" Id="FUDZs9HIKQxMPCs5PqZaX3">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FixturesInspectorLayer" />
@@ -29333,7 +29339,7 @@
                         <Pin Id="JRWMrkx5V3gOmTmeNrlJ3n" Name="Condition" Kind="InputPin" />
                         <Pin Id="BNjy3enhwx9PZgA3944XQJ" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2239,763,37,19" Id="OkVL8DGL3JXNzQeANZtWfi">
+                      <Node Bounds="2185,742,37,19" Id="OkVL8DGL3JXNzQeANZtWfi">
                         <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -29433,7 +29439,7 @@
                         <Pin Id="F5xfkWhFReWMHWgqfpW2Ht" Name="Input 2" Kind="InputPin" />
                         <Pin Id="OY02Hl8q1otO4msDjxEyAb" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="2065,794,137,19" Id="GMA7N1uIwTsObRBIgMcpbH">
+                      <Node Bounds="2059,809,137,19" Id="GMA7N1uIwTsObRBIgMcpbH">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="RectangleSelectionLayer" />
@@ -29444,7 +29450,7 @@
                         <Pin Id="FVSIoTITbV5M6GsVpgl5b8" Name="Condition" Kind="InputPin" />
                         <Pin Id="KDHqTUwpQhVNo1nrQYlXjG" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2105,857,88,19" Id="HalsAFGc4zqLUZZyMJTXXg">
+                      <Node Bounds="2059,843,88,19" Id="HalsAFGc4zqLUZZyMJTXXg">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FixturesLayer" />
@@ -29549,7 +29555,7 @@
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
-                      <Node Bounds="2065,585,69,19" Id="HgqtyR0O6fwLUnPUdqNAzb">
+                      <Node Bounds="2059,605,69,19" Id="HgqtyR0O6fwLUnPUdqNAzb">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="PlanesLayer" />
@@ -29574,7 +29580,7 @@
                         </Pin>
                         <Pin Id="Ir5twQ02VouN5hjDSGvMPG" Name="Value" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="2059,726,112,19" Id="IHcnDFNYDrdQGn55ayWcHS">
+                      <Node Bounds="2059,741,112,19" Id="IHcnDFNYDrdQGn55ayWcHS">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="FixtureRemoverLayer" />
@@ -29593,7 +29599,7 @@
                         <Pin Id="STR4XJJb9MYNNFH6jJJVS4" Name="Input" Kind="StateInputPin" />
                         <Pin Id="RNq8KGRhTl2NY1MkEg5ZGN" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="2102,953,71,19" Id="UBP1xhdskGuQHzQL3FP2EX">
+                      <Node Bounds="2059,911,71,19" Id="UBP1xhdskGuQHzQL3FP2EX">
                         <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="ProcessAppFlag" Name="NamesLayer" />
@@ -29702,14 +29708,14 @@
                           <Pin Id="Ip3UAVbm8GJORVfIxRrrTi" Name="Dispose Cached Outputs" Kind="InputPin" />
                           <Pin Id="Qk7kZPpMbiUQJxVScKxBUi" Name="Has Changed" Kind="OutputPin" />
                           <ControlPoint Id="QKYEnbl7K2wMaeFzsvcO8i" Bounds="539,731" Alignment="Bottom" />
-                          <ControlPoint Id="CGYIUPogqY3OIdoQuSv7Cr" Bounds="609,271" Alignment="Top" />
-                          <ControlPoint Id="ANeqW40sNoAMLoiyirs6nn" Bounds="544,271" Alignment="Top" />
-                          <ControlPoint Id="RPwWzSpYMwsPGn4SouSqBa" Bounds="686,271" Alignment="Top" />
+                          <ControlPoint Id="CGYIUPogqY3OIdoQuSv7Cr" Bounds="609,265" Alignment="Top" />
+                          <ControlPoint Id="ANeqW40sNoAMLoiyirs6nn" Bounds="544,265" Alignment="Top" />
+                          <ControlPoint Id="RPwWzSpYMwsPGn4SouSqBa" Bounds="686,265" Alignment="Top" />
                           <ControlPoint Id="FXv6wD53mRfMwoomdKGGJX" Bounds="663,265" Alignment="Top" />
                           <Patch Id="JWWaqozsKcPNz35FdRUk3d" ManuallySortedPins="true">
                             <Patch Id="NwAWKhBoXoKLA5FV3Dol8G" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="FjI8UE5YHYJM037rGVM9zs" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="535,688,54,13" Id="Jdfg0Y16YisMNnBycw9wL9">
+                            <Node Bounds="535,688,54,19" Id="Jdfg0Y16YisMNnBycw9wL9">
                               <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="Group (Spectral)" />
@@ -29720,7 +29726,7 @@
                               <Pin Id="FY7wXN8NJC0Ld1hoUEDaPf" Name="Enabled" Kind="InputPin" />
                               <Pin Id="IGZuKnie2jkNZkqMZOsafs" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="523,379,204,281" Id="VzUQCKGlVvdLmIGhwFOXGU">
+                            <Node Bounds="523,379,204,287" Id="VzUQCKGlVvdLmIGhwFOXGU">
                               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -29728,12 +29734,12 @@
                               </p:NodeReference>
                               <Pin Id="AXpwQCz4dCsMFMkH1xjsIc" Name="Break" Kind="OutputPin" />
                               <ControlPoint Id="CTYKEJRaEM3OHTJHKZrfOd" Bounds="665,385" Alignment="Top" />
-                              <ControlPoint Id="OSTSxQE3GSMNgYMqEyhFtw" Bounds="538,532" Alignment="Bottom" />
+                              <ControlPoint Id="OSTSxQE3GSMNgYMqEyhFtw" Bounds="538,660" Alignment="Bottom" />
                               <Patch Id="KJsBfwDscDTOD3i7rdpoiN" ManuallySortedPins="true">
                                 <Patch Id="EvFO3G3TqsdLIJyeezxNjB" Name="Create" ManuallySortedPins="true" />
                                 <Patch Id="J4hzrDso9pHOxtCg7CZbUn" Name="Update" ManuallySortedPins="true" />
                                 <Patch Id="FBuvElEKtcBPYo3kqx8nBe" Name="Dispose" ManuallySortedPins="true" />
-                                <Node Bounds="535,627,91,13" Id="TL36f0id0EOL3cRRdgo2sm">
+                                <Node Bounds="535,627,91,19" Id="TL36f0id0EOL3cRRdgo2sm">
                                   <p:NodeReference LastCategoryFullName="Graphics.Skia.Transform" LastDependency="VL.Skia.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="ProcessAppFlag" Name="TransformSRT" />
@@ -29748,7 +29754,7 @@
                                   <Pin Id="DW3ZPB1BEcIOc0M0P3Nci8" Name="Translation" Kind="InputPin" />
                                   <Pin Id="UB6xpzfVeAuNy9OmQ7Ewet" Name="Output" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="621,594,94,13" Id="M359okjGbT9NwNOF77crx3">
+                                <Node Bounds="621,594,94,19" Id="M359okjGbT9NwNOF77crx3">
                                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="ProjectPosition" />
@@ -29763,7 +29769,7 @@
                                   <Pin Id="TOnELfhM5HpOKgtdqQI7tw" Name="Output" Kind="OutputPin" />
                                   <Pin Id="RFA3psgcHgQOTmlyoXZZpN" Name="Z" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="562,594,45,13" Id="M3OhgDuz4thMnSC2kGHmNM">
+                                <Node Bounds="562,594,45,19" Id="M3OhgDuz4thMnSC2kGHmNM">
                                   <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationNode" Name="Switch (Boolean)" />
@@ -29782,7 +29788,7 @@
                                   </Pin>
                                   <Pin Id="GTUYzicfZbNQWeSWWCIokY" Name="Output" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="562,565,25,13" Id="FfLYEAWxfYqQIcuUJXnwPo">
+                                <Node Bounds="562,565,25,19" Id="FfLYEAWxfYqQIcuUJXnwPo">
                                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="=" />
@@ -29791,7 +29797,7 @@
                                   <Pin Id="KN8hAYWJp6ALcWVS6XoOD1" Name="Input 2" Kind="InputPin" />
                                   <Pin Id="DIBQahzAYBULh603uXcj7a" Name="Result" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="595,431,72,22" Id="Tq9Wdy2PkT9NRVRNh5jdEa">
+                                <Node Bounds="595,431,79,26" Id="Tq9Wdy2PkT9NRVRNh5jdEa">
                                   <p:NodeReference LastCategoryFullName="Primitive.Delegates.Delegate (1 -&gt; 1)" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="Invoke" />
@@ -29801,7 +29807,7 @@
                                   <Pin Id="I9ElKmlnNoMNcadU13tKcY" Name="Arg" Kind="InputPin" />
                                   <Pin Id="DM2OgQsBDGMN4mjbRrWe7C" Name="Result" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="608,516" Id="GlUHJVNMwpNOmMYghF88Uc">
+                                <Node Bounds="608,516,25,19" Id="GlUHJVNMwpNOmMYghF88Uc">
                                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -29810,7 +29816,7 @@
                                   <Pin Id="EZROQ4mYz9QMX10DdOn2uF" Name="Input 2" Kind="InputPin" />
                                   <Pin Id="D0216ksZ9xALRXvbRtPZRT" Name="Output" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="655,466,34,13" Id="SB5okUhZMNuPE3dO6ixk1z">
+                                <Node Bounds="655,466,34,19" Id="SB5okUhZMNuPE3dO6ixk1z">
                                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="UnitY" />
@@ -29818,7 +29824,7 @@
                                   </p:NodeReference>
                                   <Pin Id="ACUaz7v8tIyNevNLJd61Wn" Name="Unit Y" Kind="OutputPin" />
                                 </Node>
-                                <Node Bounds="655,498" Id="RZ47nfz3u0bO90B3GlWJ2A">
+                                <Node Bounds="655,498,25,19" Id="RZ47nfz3u0bO90B3GlWJ2A">
                                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="* (Scale)" />
@@ -29829,7 +29835,7 @@
                                 </Node>
                               </Patch>
                             </Node>
-                            <Node Bounds="598,315,46,22" Id="KLA8iZSndW8NQK5DUvOOhx">
+                            <Node Bounds="598,315,46,19" Id="KLA8iZSndW8NQK5DUvOOhx">
                               <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -29840,7 +29846,7 @@
                               <Pin Id="DMVOuuyb2SOO5dm2beQwtC" Name="Index" Kind="InputPin" />
                               <Pin Id="FBN9oWe9YNIQI5sFLtKkW1" Name="Result" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="452,321,85,13" Id="DlR7KBDHhk2LANF7znaTbZ">
+                            <Node Bounds="452,321,85,19" Id="DlR7KBDHhk2LANF7znaTbZ">
                               <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers" LastDependency="VL.Skia.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="Circle" />
@@ -29858,7 +29864,7 @@
                               <Pin Id="IAL9pvn59T2MYkL8YzGpOx" Name="Enabled" Kind="InputPin" />
                               <Pin Id="U4eKhEI6iqiNlHFcWxG2jA" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="510,282,45,13" Id="AaOE9DKokzWOVqKDtrwuRb">
+                            <Node Bounds="510,282,45,19" Id="AaOE9DKokzWOVqKDtrwuRb">
                               <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="Fill" />
@@ -29880,14 +29886,14 @@
                             <Choice Kind="TypeFlag" Name="Boolean" />
                           </p:TypeAnnotation>
                         </Pad>
-                        <Node Bounds="671,-93,238,227" Id="D94MPiMJYQVNXVTTwkFJrr">
+                        <Node Bounds="671,-95,238,235" Id="D94MPiMJYQVNXVTTwkFJrr">
                           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                             <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                             <Choice Kind="ProcessStatefulRegion" Name="Cache" />
                             <FullNameCategoryReference ID="Primitive" />
                           </p:NodeReference>
-                          <ControlPoint Id="Gs5ISH9UGaPL5tQ6fPGwHP" Bounds="739,128" Alignment="Bottom" />
-                          <ControlPoint Id="DELZD3DIcWvN1RVlYOzAgH" Bounds="782,-55" Alignment="Top" />
+                          <ControlPoint Id="Gs5ISH9UGaPL5tQ6fPGwHP" Bounds="739,134" Alignment="Bottom" />
+                          <ControlPoint Id="DELZD3DIcWvN1RVlYOzAgH" Bounds="782,-89" Alignment="Top" />
                           <Pin Id="C815WJXCaS9OipR51FCb5R" Name="Force" Kind="InputPin" DefaultValue="True">
                             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Boolean" />
@@ -29898,7 +29904,7 @@
                           <Patch Id="SdPnatKmZx2Oc8mTFu5pHh" ManuallySortedPins="true">
                             <Patch Id="JwpvmS5TjUqPR6CqV0HH0y" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="KgIkRxmN8VpNgGREmobepQ" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="731,101,73,13" Id="HcdzaVXTxFTQPEPLjHNsFy">
+                            <Node Bounds="731,101,73,19" Id="HcdzaVXTxFTQPEPLjHNsFy">
                               <p:NodeReference LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="GridPoints (2d)" />
@@ -29909,7 +29915,7 @@
                               <Pin Id="FINTpn3tD26LpdPg4el7Vo" Name="Resolution" Kind="InputPin" />
                               <Pin Id="KTNpr3K8WskOpGoRF7NWMQ" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="733,67,25,13" Id="FZ09wIZrHeyMlZfrVZBU6j">
+                            <Node Bounds="733,67,25,19" Id="FZ09wIZrHeyMlZfrVZBU6j">
                               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="-" />
@@ -29922,7 +29928,7 @@
                               </Pin>
                               <Pin Id="KaEPWHEBpeALMCUchYZgVZ" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="768,-73,129,95" Id="Ho57iDwuScINFa8TW7qIde">
+                            <Node Bounds="768,-75,129,97" Id="Ho57iDwuScINFa8TW7qIde">
                               <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                                 <Choice Kind="OperationCallFlag" Name="ProcessElements (Vector2)" />
                                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -29934,7 +29940,7 @@
                                 <Pin Id="PjG3XmBUOVCPHoHmOMy2d4" Name="Result" Kind="OutputPin" />
                                 <ControlPoint Id="G1bNmRm63pNMSqCadYjAOO" Bounds="772,-67" />
                                 <ControlPoint Id="JlS7c1rkvEoMYuGmLKtMh2" Bounds="772,13" />
-                                <Node Bounds="785,-36,100,13" Id="NKQzUQHq7DAPkDvlJGEvuv">
+                                <Node Bounds="785,-36,100,19" Id="NKQzUQHq7DAPkDvlJGEvuv">
                                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                     <Choice Kind="OperationCallFlag" Name="RoundUpToOdd" />
@@ -29946,7 +29952,7 @@
                             </Node>
                           </Patch>
                         </Node>
-                        <Node Bounds="683,218,111,13" Id="KQ9AiVnnA6iPDrh2XMi7EL">
+                        <Node Bounds="683,218,111,19" Id="KQ9AiVnnA6iPDrh2XMi7EL">
                           <p:NodeReference LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="SequenceChanged" />
@@ -29958,7 +29964,7 @@
                         </Node>
                         <ControlPoint Id="VrfkYCC6AuWPCGTjtb9NES" Bounds="602,-6" />
                         <ControlPoint Id="Noz0VYXgGa5PfMWc2AglZR" Bounds="777,-114" />
-                        <Node Bounds="1046,-2,355,219" Id="RcjC4MmhyXbNIe6zP9Fcsc">
+                        <Node Bounds="1038,-22,375,260" Id="RcjC4MmhyXbNIe6zP9Fcsc">
                           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                             <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                             <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -30051,7 +30057,7 @@
                             </Node>
                           </Patch>
                         </Node>
-                        <Node Bounds="697,-183" Id="QRwIANgpwi3NgoVH5bETTi">
+                        <Node Bounds="697,-183,16,19" Id="QRwIANgpwi3NgoVH5bETTi">
                           <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="OnOpen" />
@@ -31835,268 +31841,11 @@
                     </p:NodeReference>
                     <Patch Id="SZcDKm0D1QvO5AAwqw5NL8">
                       <Canvas Id="LsKh1b29Ai5OiaqmKYK78K" CanvasType="Group">
-                        <Node Bounds="599,291,73,13" Id="VyauIvVw9ilPWZWsSpUE4I">
-                          <p:NodeReference LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GridPoints (2d)" />
-                          </p:NodeReference>
-                          <Pin Id="NqADlS5YEDtOyBwxeNF1x6" Name="Center" Kind="InputPin" />
-                          <Pin Id="KwIx3LsAJfALnFg2tqrcd0" Name="Size" Kind="InputPin" />
-                          <Pin Id="UhGZTuzMZGcNcWxRrhSe6C" Name="Centered" Kind="InputPin" />
-                          <Pin Id="M6fvZNnn8QfNHhXwd1CxYS" Name="Resolution" Kind="InputPin" />
-                          <Pin Id="CQeQEqMdhp9QSsA9Rmj2t5" Name="Output" Kind="OutputPin" />
-                        </Node>
-                        <Pad Id="NdDrseWRMWnL52UCxgjl1b" Comment="Resolution" Bounds="793,252,33,38" ShowValueBox="true" isIOBox="true" Value="2, 2">
-                          <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="TypeFlag" Name="Vector2" />
-                          </p:TypeAnnotation>
-                        </Pad>
-                        <Node Bounds="611,422,234,146" Id="SOqqQOyJJtlM7qtlkX6lt4">
-                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                            <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                            <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-                            <CategoryReference Kind="Category" Name="Primitive" />
-                          </p:NodeReference>
-                          <Pin Id="OyWG2taVYU0NzhSasOy6fr" Name="Break" Kind="OutputPin" />
-                          <ControlPoint Id="NXxkzwZPv0eQIJMle8DOTd" Bounds="628,428" Alignment="Top" />
-                          <ControlPoint Id="V0MOQFBX6beLF6zc5Enlj8" Bounds="641,546" Alignment="Bottom" />
-                          <ControlPoint Id="MVza5LaHea1ObhCbcUqwWq" Bounds="731,562" Alignment="Bottom" />
-                          <Patch Id="Uq7L3hkhuZqQVAOYqTtKv7" ManuallySortedPins="true">
-                            <Patch Id="VAX4RSwFi1PQWnUCdlE7Um" Name="Create" ManuallySortedPins="true" />
-                            <Patch Id="Na9RGOMEXEROJfe98qzht1" Name="Update" ManuallySortedPins="true" />
-                            <Patch Id="OL4XY6C9vEZMeWzUVEI1Dc" Name="Dispose" ManuallySortedPins="true" />
-                            <Node Bounds="625,458,42,13" Id="JUfu0gUuvDFPlal3KlmTxy">
-                              <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="XyZ" />
-                              </p:NodeReference>
-                              <Pin Id="CfXuWuuGzZCP2XpyzsodUQ" Name="Input" Kind="StateInputPin" />
-                              <Pin Id="RWAHzIEPDqHLE7UNd5Tg4Y" Name="Y" Kind="InputPin" />
-                              <Pin Id="JgNv3gvdWXdLJPSlsPHO3M" Name="Output" Kind="StateOutputPin" />
-                            </Node>
-                            <Node Bounds="623,503,94,13" Id="HPgvXyWtL2QMvBIVscFuQk">
-                              <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="ProjectPosition" />
-                              </p:NodeReference>
-                              <Pin Id="DqJJ6R4eXSbNcqOWRyAZY2" Name="Source" Kind="InputPin" />
-                              <Pin Id="CVtIOCPtHBtOn9epPltp35" Name="Matrix" Kind="InputPin" />
-                              <Pin Id="CjcpZahUBibOSkvcx375fx" Name="Flip Y" Kind="InputPin" DefaultValue="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                                  <Choice Kind="TypeFlag" Name="Boolean" />
-                                </p:TypeAnnotation>
-                              </Pin>
-                              <Pin Id="Eko6PvIIqGQPrdEAI27MSF" Name="Output" Kind="OutputPin" />
-                              <Pin Id="BhGSHOZzboxLDrSnzeDswn" Name="Z" Kind="OutputPin" />
-                            </Node>
-                            <Node Bounds="739,502,94,13" Id="IUiIdTeFtxhMXrfzEYbTmj">
-                              <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="ProjectPosition" />
-                              </p:NodeReference>
-                              <Pin Id="DrfohNzVxWNQcLyyiBwCGl" Name="Source" Kind="InputPin" />
-                              <Pin Id="Tez6pqcxp7kOnkdNM2fUFT" Name="Matrix" Kind="InputPin" />
-                              <Pin Id="U0aJhUI9Cm0Ps0VpHCX0Hy" Name="Flip Y" Kind="InputPin" DefaultValue="True">
-                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                                  <Choice Kind="TypeFlag" Name="Boolean" />
-                                </p:TypeAnnotation>
-                              </Pin>
-                              <Pin Id="EJve3gWr7CSM9khDEJH45b" Name="Output" Kind="OutputPin" />
-                              <Pin Id="L9oELqBA80uLd1xbnwmDXY" Name="Z" Kind="OutputPin" />
-                            </Node>
-                            <Node Bounds="702,460,42,13" Id="Q62uCD5QUDKLLpKgw9w1qL">
-                              <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="OperationCallFlag" Name="XyZ" />
-                              </p:NodeReference>
-                              <Pin Id="TMgYQdLf23CPXOwqIHQ03h" Name="Input" Kind="StateInputPin" />
-                              <Pin Id="GbbC67KVBVUNvAaD0zMSC4" Name="Y" Kind="InputPin" />
-                              <Pin Id="H2aDB2DV6gWNGnU1SyHlYF" Name="Output" Kind="StateOutputPin" />
-                            </Node>
-                          </Patch>
-                        </Node>
-                        <ControlPoint Id="DBrUYx6tGlfMkStfnDXElF" Bounds="756,179" />
-                        <Node Bounds="641,612,85,13" Id="BUUo58KKlK1NX8srTcs6Ju">
-                          <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers" LastDependency="VL.Skia.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="ProcessAppFlag" Name="Polygon" />
-                          </p:NodeReference>
-                          <Pin Id="VrKsXdcHGWtMFGtTo5TRNI" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                          <Pin Id="RtaCBQ1TIVgP3N9Oij3qQQ" Name="Points" Kind="InputPin" />
-                          <Pin Id="O7luzdGcYyyNVUYst7uxs3" Name="Closed" Kind="InputPin" DefaultValue="True">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                              <Choice Kind="TypeFlag" Name="Boolean" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="IYYiNQyDQThLd3YxPKo3xr" Name="Paint" Kind="InputPin" />
-                          <Pin Id="QqsIJiofVJ2PtZjTN6y1Ua" Name="Winding" Kind="InputPin" />
-                          <Pin Id="ICJBOhcrDg4MnQtnuEQZX3" Name="Enabled" Kind="InputPin" />
-                          <Pin Id="Go4rU3XWw2XPABaccOOhr4" Name="Output" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="481,580,105,13" Id="NQU7jmtZhVjOpbphx30zMV">
-                          <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="ProcessAppFlag" Name="Stroke" />
-                          </p:NodeReference>
-                          <Pin Id="GEIpv7f1SgVLPDUdI5pQYA" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                          <Pin Id="EtCJrQ4YDNYQOR7EvMh1MQ" Name="Input" Kind="InputPin" />
-                          <Pin Id="DSP5dEX6n9EPu9pmQslTO3" Name="Color" Kind="InputPin" DefaultValue="1, 1, 1, 0.18">
-                            <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
-                              <Choice Kind="TypeFlag" Name="RGBA" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="S2mPuEi9k55PSCX4p1CTm6" Name="Stroke Width" Kind="InputPin" />
-                          <Pin Id="F8HJ2F7tr1ZMcXTjrIoSOV" Name="Join" Kind="InputPin" DefaultValue="Round">
-                            <p:TypeAnnotation LastCategoryFullName="Graphics.Skia.Unwrapped.Enums" LastDependency="VL.Skia.vl">
-                              <Choice Kind="TypeFlag" Name="SKStrokeJoin" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="RFB45Lpog8IMdOSeVnnPlH" Name="Cap" Kind="InputPin" DefaultValue="Round">
-                            <p:TypeAnnotation LastCategoryFullName="Graphics.Skia.Unwrapped.Enums" LastDependency="VL.Skia.vl">
-                              <Choice Kind="TypeFlag" Name="SKStrokeCap" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="Kf3yFlFOqEiQZ8daGnjmZ3" Name="Miter" Kind="InputPin" />
-                          <Pin Id="KhRqt8dWUx7MKw0cVXgfUL" Name="Output" Kind="OutputPin" />
-                        </Node>
-                        <ControlPoint Id="LeG7NGlMcULOYdFqJytwOu" Bounds="647,800" />
-                        <Node Bounds="581,327,46,22" Id="EtdcEOwgOYDPctMoRYJ7cw">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GetSlice" />
-                            <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true">
-                              <p:OuterCategoryReference Kind="Category" Name="Collections" NeedsToBeDirectParent="true">
-                                <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
-                              </p:OuterCategoryReference>
-                            </CategoryReference>
-                          </p:NodeReference>
-                          <Pin Id="AgAUwLjOIwmNwVqTcHKRbR" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="QpZ345fFab0LO74icKfxR5" Name="Default Value" Kind="InputPin" />
-                          <Pin Id="EVEn0kxB2ilNSrD6X56ZJh" Name="Index" Kind="InputPin" />
-                          <Pin Id="UZlKyaa06AkQSQ1SNRDouD" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="634,330,46,13" Id="GfcT3YwGtzwLM65hS7Mb1j">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GetSlice" />
-                            <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true">
-                              <p:OuterCategoryReference Kind="Category" Name="Collections" NeedsToBeDirectParent="true">
-                                <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
-                              </p:OuterCategoryReference>
-                            </CategoryReference>
-                          </p:NodeReference>
-                          <Pin Id="FG3cqvnlkT4NrqazeNHoc6" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="GYIRBT3F3HRLPqeDOvJZsi" Name="Default Value" Kind="InputPin" />
-                          <Pin Id="VejTIU5FCDePhemnQW8m7c" Name="Index" Kind="InputPin" DefaultValue="1">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                              <Choice Kind="TypeFlag" Name="Integer32" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="PRxW4IVLTUkOot7QsXExWZ" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="687,333,46,13" Id="Kmw70B7nybfQLdbc3WnHYS">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GetSlice" />
-                            <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true">
-                              <p:OuterCategoryReference Kind="Category" Name="Collections" NeedsToBeDirectParent="true">
-                                <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
-                              </p:OuterCategoryReference>
-                            </CategoryReference>
-                          </p:NodeReference>
-                          <Pin Id="KCvj5njDbUMQWxwEaJsqAl" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="VCe00LicA3PPZ91B7hfTxC" Name="Default Value" Kind="InputPin" />
-                          <Pin Id="M4iPz4HRonHOvpiMnTP7gB" Name="Index" Kind="InputPin" DefaultValue="2">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                              <Choice Kind="TypeFlag" Name="Integer32" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="FtjTdVvonHlMRokbuFz3po" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="740,336,46,13" Id="PIZYMMD6mLfPMwDxXiJtyZ">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="GetSlice" />
-                            <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true">
-                              <p:OuterCategoryReference Kind="Category" Name="Collections" NeedsToBeDirectParent="true">
-                                <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
-                              </p:OuterCategoryReference>
-                            </CategoryReference>
-                          </p:NodeReference>
-                          <Pin Id="BYI7bdAva4mORRcvniTKXm" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="G0akUM0dHFdO2eTlpxz7Cf" Name="Default Value" Kind="InputPin" />
-                          <Pin Id="Oh2huOIMoeELTABGBmCUxB" Name="Index" Kind="InputPin" DefaultValue="3">
-                            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                              <Choice Kind="TypeFlag" Name="Integer32" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="CYjVtOCEDd0NlgZ3FyyZVf" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="663,384" Id="IaGSdo7JK3lPCryaYuCNgh">
-                          <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="Cons" />
-                          </p:NodeReference>
-                          <Pin Id="GrCUK9i0Lb0PyKlfNFi5QU" Name="Input" Kind="InputPin" />
-                          <Pin Id="DTXb538LdbIN3vsLLGp1xe" Name="Input 2" Kind="InputPin" />
-                          <Pin Id="MabwCR1u9hdMTOiDFnDBIH" Name="Input 3" Kind="InputPin" />
-                          <Pin Id="Ck9plfzWdnAL8rGk1Yfmqo" Name="Input 4" Kind="InputPin" />
-                          <Pin Id="N4ne3gftbKgLb9UXBsxvb6" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <ControlPoint Id="MelH2zMgku7QFMQmFRC07N" Bounds="946,177" />
-                        <ControlPoint Id="EJVYHDnaNZAPYqG3ylyeVA" Bounds="859,184" />
-                        <Node Bounds="822,651,65,16" Id="UPfJPcv5YpMNVr0eBHNCYk">
-                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                            <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                            <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
-                            <FullNameCategoryReference ID="Primitive" />
-                          </p:NodeReference>
-                          <Pin Id="I8lTD5RwbyRPJhKVyj7cPq" Name="Break" Kind="OutputPin" />
-                          <ControlPoint Id="IkEN1Xzx1k5Po3HdycH4ri" Bounds="875,625" Alignment="Top" />
-                          <ControlPoint Id="MP93EyngRmiPihckUX2yc8" Bounds="834,625" Alignment="Top" />
-                          <ControlPoint Id="DoXtODNpXTpO9SWn2kHCTG" Bounds="827,699" Alignment="Bottom" />
-                          <Patch Id="N0iEocMy3sQNgp5BZ0nLNv" ManuallySortedPins="true">
-                            <Patch Id="Vw7UYonfeqpObIqv3PpDGZ" Name="Create" ManuallySortedPins="true" />
-                            <Patch Id="JHYrbzTYHolLmNbNgg9Evm" Name="Update" ManuallySortedPins="true" />
-                            <Patch Id="K3tRnvHeWMsPCjPRbl8WdD" Name="Dispose" ManuallySortedPins="true" />
-                            <Node Bounds="822,654,65,13" Id="PrR9CaYxUFNLdQhCynXOs1">
-                              <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers" LastDependency="VL.Skia.vl">
-                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                                <Choice Kind="ProcessAppFlag" Name="Line" />
-                              </p:NodeReference>
-                              <Pin Id="F2qeIjfwVYVOj45xZ2n7DF" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                              <Pin Id="M6qhxgAdYEaL5nlubuPRFT" Name="Point A" Kind="InputPin" />
-                              <Pin Id="VAtnaC7U5OqN6eUe9NW34s" Name="Point B" Kind="InputPin" />
-                              <Pin Id="HMqUvmlUtYSOPNhqejt8T0" Name="Paint" Kind="InputPin" />
-                              <Pin Id="DjpzTqqQwFzPReQ5csoM7P" Name="Enabled" Kind="InputPin" />
-                              <Pin Id="PVVMamFthhhP6EYSEgHkvj" Name="Output" Kind="OutputPin" />
-                            </Node>
-                          </Patch>
-                        </Node>
-                        <Node Bounds="773,737" Id="SnVhylkFKn5NycW5ab3prU">
-                          <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="ProcessAppFlag" Name="Group (Spectral)" />
-                          </p:NodeReference>
-                          <Pin Id="QOalMUCw4kPOP7PQJIiuZC" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                          <Pin Id="DhbPc5FWbQCMHPU59J4wLJ" Name="Input" Kind="InputPin" />
-                          <Pin Id="L3bKzF9ZV43LYqlq0xz0XL" Name="Debug" Kind="InputPin" />
-                          <Pin Id="PLFg96ys7XIQAfeXM3lkUw" Name="Enabled" Kind="InputPin" />
-                          <Pin Id="IjIfbuJV0ZGMsI1Xwx9psw" Name="Output" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="649,772" Id="J1HzRPRy7MbMxGBiGbhRZk">
-                          <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="ProcessAppFlag" Name="Group" />
-                          </p:NodeReference>
-                          <Pin Id="FK3E24jjZqiP8Waj1Mf5Vt" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                          <Pin Id="O8NrLTMqfKSOBvouINmz2c" Name="Input" Kind="InputPin" />
-                          <Pin Id="IHsf7dak2BWLfVDnmKiPUy" Name="Input 2" Kind="InputPin" />
-                          <Pin Id="FaFRf2tXq56OwtgAWx5gpz" Name="Debug" Kind="InputPin" />
-                          <Pin Id="TFq8U0kgoHuLRYgR0oSobc" Name="Enabled" Kind="InputPin" />
-                          <Pin Id="UUFeOatDTMWPOXlNzwXsee" Name="Output" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="622,260,120,13" Id="EaAWyIsjiv1NZuQFQjq5El">
+                        <ControlPoint Id="DBrUYx6tGlfMkStfnDXElF" Bounds="710,133" />
+                        <ControlPoint Id="LeG7NGlMcULOYdFqJytwOu" Bounds="543,1069" />
+                        <ControlPoint Id="MelH2zMgku7QFMQmFRC07N" Bounds="624,132" />
+                        <ControlPoint Id="EJVYHDnaNZAPYqG3ylyeVA" Bounds="813,133" />
+                        <Node Bounds="625,228,120,19" Id="EaAWyIsjiv1NZuQFQjq5El">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetFloorDimensions" />
@@ -32104,55 +31853,307 @@
                           <Pin Id="VntPtVxRS3GLE9YT0Xl2hu" Name="State" Kind="InputPin" />
                           <Pin Id="IGut6zV8b9NOSys204apZb" Name="Output" Kind="OutputPin" />
                         </Node>
+                        <Pad Id="Nbm2UZMdN3MMJQlDr2oedM" Comment="Count" Bounds="764,237,35,28" ShowValueBox="true" isIOBox="true" Value="2, 2">
+                          <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                            <Choice Kind="TypeFlag" Name="Int2" />
+                          </p:TypeAnnotation>
+                        </Pad>
+                        <Node Bounds="613,268,151,170" Id="UVziSzRbeSaM0zWJgApikk">
+                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                            <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                            <CategoryReference Kind="Category" Name="Primitive" />
+                            <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                          </p:NodeReference>
+                          <Pin Id="BKK9f9vpcjYLb6ix6IoNpy" Name="Force" Kind="InputPin" />
+                          <Pin Id="Il0BNMdR45SL0eOm4oPWLv" Name="Dispose Cached Outputs" Kind="InputPin" />
+                          <Pin Id="Dbhh7cLGX0NPzcFroF5GA9" Name="Has Changed" Kind="OutputPin" />
+                          <Patch Id="FniTqULkxWeNY0zaHA1mVN" ManuallySortedPins="true">
+                            <Patch Id="AKYfY6SgBDsOmkLcwYERUK" Name="Create" ManuallySortedPins="true" />
+                            <Patch Id="Nb0l1LkfH3sLqE6rARK1iw" Name="Then" ManuallySortedPins="true" />
+                            <Node Bounds="625,327,125,19" Id="VyauIvVw9ilPWZWsSpUE4I">
+                              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="ProcessAppFlag" Name="GridSpread (2D)" />
+                              </p:NodeReference>
+                              <Pin Id="PuyRwmc2CKKQdbdgvJOFYC" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                              <Pin Id="NqADlS5YEDtOyBwxeNF1x6" Name="Center" Kind="InputPin" />
+                              <Pin Id="IvqjsNFrelFMSVATvs21ho" Name="Width" Kind="InputPin" />
+                              <Pin Id="Iw3fDVEnuUUMOncEEgdQKh" Name="Alignment" Kind="InputPin" />
+                              <Pin Id="EPk8JCSaOXnOoYsNTzP9np" Name="Phase" Kind="InputPin" />
+                              <Pin Id="M4fX0eq2QeSPaQsA4tXJoe" Name="Count" Kind="InputPin" />
+                              <Pin Id="CQeQEqMdhp9QSsA9Rmj2t5" Name="Output" Kind="OutputPin" />
+                            </Node>
+                            <Node Bounds="625,399,65,19" Id="IaGSdo7JK3lPCryaYuCNgh">
+                              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="OperationCallFlag" Name="Cons" />
+                              </p:NodeReference>
+                              <Pin Id="GrCUK9i0Lb0PyKlfNFi5QU" Name="Input" Kind="InputPin" />
+                              <Pin Id="DTXb538LdbIN3vsLLGp1xe" Name="Input 2" Kind="InputPin" />
+                              <Pin Id="MabwCR1u9hdMTOiDFnDBIH" Name="Input 3" Kind="InputPin" />
+                              <Pin Id="Ck9plfzWdnAL8rGk1Yfmqo" Name="Input 4" Kind="InputPin" />
+                              <Pin Id="N4ne3gftbKgLb9UXBsxvb6" Name="Result" Kind="OutputPin" />
+                            </Node>
+                            <Node Bounds="625,363,65,19" Id="H47xiupgyTOOKbvki2vahN">
+                              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <CategoryReference Kind="4026531840" Name="Spread" NeedsToBeDirectParent="true">
+                                  <p:OuterCategoryReference Kind="Category" Name="Collections" NeedsToBeDirectParent="true">
+                                    <p:OuterCategoryReference Kind="Category" NeedsToBeDirectParent="true" />
+                                  </p:OuterCategoryReference>
+                                </CategoryReference>
+                                <Choice Kind="OperationCallFlag" Name="Decons" />
+                              </p:NodeReference>
+                              <Pin Id="J1t3vbiICvfOsKUOuVyOdL" Name="Input" Kind="StateInputPin" />
+                              <Pin Id="INCSSgGfnwkL4CRzOHalnm" Name="Result" Kind="OutputPin" />
+                              <Pin Id="HFrAY80S42qOomYObYG7Hs" Name="Result 2" Kind="OutputPin" />
+                              <Pin Id="It7jKFmOdfFMljyhnxaCve" Name="Result 3" Kind="OutputPin" />
+                              <Pin Id="HpFe0AqnOnvNFwTndxUheY" Name="Result 4" Kind="OutputPin" />
+                            </Node>
+                            <Node Bounds="625,291,25,19" Id="OK4UCc5GFT7P4pQrSUFym6">
+                              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="OperationCallFlag" Name="* (Scale)" />
+                              </p:NodeReference>
+                              <Pin Id="Cp0JVBIXpA4Mseg9aHDTc4" Name="Input" Kind="InputPin" />
+                              <Pin Id="JJvPhaPPaH5N9leZBI9wRm" Name="Scalar" Kind="InputPin" DefaultValue="2" />
+                              <Pin Id="OqaUCfvc4HBNQgn3Qrl3Cg" Name="Output" Kind="OutputPin" />
+                            </Node>
+                          </Patch>
+                          <ControlPoint Id="RXJuroiTKUHNwTrcnnVoPJ" Bounds="627,274" Alignment="Top" />
+                          <ControlPoint Id="NQqfsEbHXerMFF8wY3G3c3" Bounds="749,274" Alignment="Top" />
+                          <ControlPoint Id="NhQ48qd48zmOpm4jMkIVyI" Bounds="628,432" Alignment="Bottom" />
+                        </Node>
+                        <Node Bounds="551,493,306,517" Id="DMYEKJ3dMl6PdjRYPj8rSu">
+                          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                            <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                            <CategoryReference Kind="Category" Name="Primitive" />
+                            <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                          </p:NodeReference>
+                          <Pin Id="UV2MvRLp9uqQBIlnDKxAVN" Name="Force" Kind="InputPin" />
+                          <Pin Id="RoNWMYoCVvcNqcbDEYvyfo" Name="Dispose Cached Outputs" Kind="InputPin" />
+                          <Pin Id="Rr94HrjhTOUNXyDJOpv5ZE" Name="Has Changed" Kind="OutputPin" />
+                          <Patch Id="Fpcxp5vJT0eMgFJCYD09Lj" ManuallySortedPins="true">
+                            <Patch Id="OkD7q3FVsDOLXnZWdMQSz1" Name="Create" ManuallySortedPins="true" />
+                            <Patch Id="P1dvmyQB3oFNHSL7y7teC5" Name="Then" ManuallySortedPins="true" />
+                            <Node Bounds="611,513,234,146" Id="SOqqQOyJJtlM7qtlkX6lt4">
+                              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                                <CategoryReference Kind="Category" Name="Primitive" />
+                              </p:NodeReference>
+                              <Pin Id="OyWG2taVYU0NzhSasOy6fr" Name="Break" Kind="OutputPin" />
+                              <ControlPoint Id="NXxkzwZPv0eQIJMle8DOTd" Bounds="628,519" Alignment="Top" />
+                              <ControlPoint Id="V0MOQFBX6beLF6zc5Enlj8" Bounds="641,653" Alignment="Bottom" />
+                              <ControlPoint Id="MVza5LaHea1ObhCbcUqwWq" Bounds="731,653" Alignment="Bottom" />
+                              <Patch Id="Uq7L3hkhuZqQVAOYqTtKv7" ManuallySortedPins="true">
+                                <Patch Id="VAX4RSwFi1PQWnUCdlE7Um" Name="Create" ManuallySortedPins="true" />
+                                <Patch Id="Na9RGOMEXEROJfe98qzht1" Name="Update" ManuallySortedPins="true" />
+                                <Patch Id="OL4XY6C9vEZMeWzUVEI1Dc" Name="Dispose" ManuallySortedPins="true" />
+                                <Node Bounds="625,549,42,19" Id="JUfu0gUuvDFPlal3KlmTxy">
+                                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                    <Choice Kind="OperationCallFlag" Name="XyZ" />
+                                  </p:NodeReference>
+                                  <Pin Id="CfXuWuuGzZCP2XpyzsodUQ" Name="Input" Kind="StateInputPin" />
+                                  <Pin Id="RWAHzIEPDqHLE7UNd5Tg4Y" Name="Y" Kind="InputPin" />
+                                  <Pin Id="JgNv3gvdWXdLJPSlsPHO3M" Name="Output" Kind="StateOutputPin" />
+                                </Node>
+                                <Node Bounds="623,594,94,19" Id="HPgvXyWtL2QMvBIVscFuQk">
+                                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
+                                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                    <Choice Kind="OperationCallFlag" Name="ProjectPosition" />
+                                  </p:NodeReference>
+                                  <Pin Id="DqJJ6R4eXSbNcqOWRyAZY2" Name="Source" Kind="InputPin" />
+                                  <Pin Id="CVtIOCPtHBtOn9epPltp35" Name="Matrix" Kind="InputPin" />
+                                  <Pin Id="CjcpZahUBibOSkvcx375fx" Name="Flip Y" Kind="InputPin" DefaultValue="True">
+                                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="TypeFlag" Name="Boolean" />
+                                    </p:TypeAnnotation>
+                                  </Pin>
+                                  <Pin Id="Eko6PvIIqGQPrdEAI27MSF" Name="Output" Kind="OutputPin" />
+                                  <Pin Id="BhGSHOZzboxLDrSnzeDswn" Name="Z" Kind="OutputPin" />
+                                </Node>
+                                <Node Bounds="739,593,94,19" Id="IUiIdTeFtxhMXrfzEYbTmj">
+                                  <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
+                                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                    <Choice Kind="OperationCallFlag" Name="ProjectPosition" />
+                                  </p:NodeReference>
+                                  <Pin Id="DrfohNzVxWNQcLyyiBwCGl" Name="Source" Kind="InputPin" />
+                                  <Pin Id="Tez6pqcxp7kOnkdNM2fUFT" Name="Matrix" Kind="InputPin" />
+                                  <Pin Id="U0aJhUI9Cm0Ps0VpHCX0Hy" Name="Flip Y" Kind="InputPin" DefaultValue="True">
+                                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                      <Choice Kind="TypeFlag" Name="Boolean" />
+                                    </p:TypeAnnotation>
+                                  </Pin>
+                                  <Pin Id="EJve3gWr7CSM9khDEJH45b" Name="Output" Kind="OutputPin" />
+                                  <Pin Id="L9oELqBA80uLd1xbnwmDXY" Name="Z" Kind="OutputPin" />
+                                </Node>
+                                <Node Bounds="702,551,42,19" Id="Q62uCD5QUDKLLpKgw9w1qL">
+                                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                    <Choice Kind="OperationCallFlag" Name="XyZ" />
+                                  </p:NodeReference>
+                                  <Pin Id="TMgYQdLf23CPXOwqIHQ03h" Name="Input" Kind="StateInputPin" />
+                                  <Pin Id="GbbC67KVBVUNvAaD0zMSC4" Name="Y" Kind="InputPin" />
+                                  <Pin Id="H2aDB2DV6gWNGnU1SyHlYF" Name="Output" Kind="StateOutputPin" />
+                                </Node>
+                              </Patch>
+                            </Node>
+                            <Node Bounds="563,910,85,19" Id="BUUo58KKlK1NX8srTcs6Ju">
+                              <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers" LastDependency="VL.Skia.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="ProcessAppFlag" Name="Polygon" />
+                              </p:NodeReference>
+                              <Pin Id="VrKsXdcHGWtMFGtTo5TRNI" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                              <Pin Id="RtaCBQ1TIVgP3N9Oij3qQQ" Name="Points" Kind="InputPin" />
+                              <Pin Id="O7luzdGcYyyNVUYst7uxs3" Name="Closed" Kind="InputPin" DefaultValue="True">
+                                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="TypeFlag" Name="Boolean" />
+                                </p:TypeAnnotation>
+                              </Pin>
+                              <Pin Id="IYYiNQyDQThLd3YxPKo3xr" Name="Paint" Kind="InputPin" />
+                              <Pin Id="QqsIJiofVJ2PtZjTN6y1Ua" Name="Winding" Kind="InputPin" />
+                              <Pin Id="ICJBOhcrDg4MnQtnuEQZX3" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="Go4rU3XWw2XPABaccOOhr4" Name="Output" Kind="OutputPin" />
+                            </Node>
+                            <Node Bounds="563,746,105,19" Id="NQU7jmtZhVjOpbphx30zMV">
+                              <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="ProcessAppFlag" Name="Stroke" />
+                              </p:NodeReference>
+                              <Pin Id="GEIpv7f1SgVLPDUdI5pQYA" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                              <Pin Id="EtCJrQ4YDNYQOR7EvMh1MQ" Name="Input" Kind="InputPin" />
+                              <Pin Id="DSP5dEX6n9EPu9pmQslTO3" Name="Color" Kind="InputPin" DefaultValue="1, 1, 1, 0.18">
+                                <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
+                                  <Choice Kind="TypeFlag" Name="RGBA" />
+                                </p:TypeAnnotation>
+                              </Pin>
+                              <Pin Id="S2mPuEi9k55PSCX4p1CTm6" Name="Stroke Width" Kind="InputPin" />
+                              <Pin Id="F8HJ2F7tr1ZMcXTjrIoSOV" Name="Join" Kind="InputPin" DefaultValue="Round">
+                                <p:TypeAnnotation LastCategoryFullName="Graphics.Skia.Unwrapped.Enums" LastDependency="VL.Skia.vl">
+                                  <Choice Kind="TypeFlag" Name="SKStrokeJoin" />
+                                </p:TypeAnnotation>
+                              </Pin>
+                              <Pin Id="RFB45Lpog8IMdOSeVnnPlH" Name="Cap" Kind="InputPin" DefaultValue="Round">
+                                <p:TypeAnnotation LastCategoryFullName="Graphics.Skia.Unwrapped.Enums" LastDependency="VL.Skia.vl">
+                                  <Choice Kind="TypeFlag" Name="SKStrokeCap" />
+                                </p:TypeAnnotation>
+                              </Pin>
+                              <Pin Id="Kf3yFlFOqEiQZ8daGnjmZ3" Name="Miter" Kind="InputPin" />
+                              <Pin Id="KhRqt8dWUx7MKw0cVXgfUL" Name="Output" Kind="OutputPin" />
+                            </Node>
+                            <Node Bounds="710,798,98,86" Id="UPfJPcv5YpMNVr0eBHNCYk">
+                              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                                <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
+                                <FullNameCategoryReference ID="Primitive" />
+                              </p:NodeReference>
+                              <Pin Id="I8lTD5RwbyRPJhKVyj7cPq" Name="Break" Kind="OutputPin" />
+                              <ControlPoint Id="IkEN1Xzx1k5Po3HdycH4ri" Bounds="772,804" Alignment="Top" />
+                              <ControlPoint Id="MP93EyngRmiPihckUX2yc8" Bounds="731,804" Alignment="Top" />
+                              <ControlPoint Id="DoXtODNpXTpO9SWn2kHCTG" Bounds="724,878" Alignment="Bottom" />
+                              <Patch Id="N0iEocMy3sQNgp5BZ0nLNv" ManuallySortedPins="true">
+                                <Patch Id="Vw7UYonfeqpObIqv3PpDGZ" Name="Create" ManuallySortedPins="true" />
+                                <Patch Id="JHYrbzTYHolLmNbNgg9Evm" Name="Update" ManuallySortedPins="true" />
+                                <Patch Id="K3tRnvHeWMsPCjPRbl8WdD" Name="Dispose" ManuallySortedPins="true" />
+                                <Node Bounds="731,833,65,19" Id="PrR9CaYxUFNLdQhCynXOs1">
+                                  <p:NodeReference LastCategoryFullName="Graphics.Skia.Layers" LastDependency="VL.Skia.vl">
+                                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                    <Choice Kind="ProcessAppFlag" Name="Line" />
+                                  </p:NodeReference>
+                                  <Pin Id="F2qeIjfwVYVOj45xZ2n7DF" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                                  <Pin Id="M6qhxgAdYEaL5nlubuPRFT" Name="Point A" Kind="InputPin" />
+                                  <Pin Id="VAtnaC7U5OqN6eUe9NW34s" Name="Point B" Kind="InputPin" />
+                                  <Pin Id="HMqUvmlUtYSOPNhqejt8T0" Name="Paint" Kind="InputPin" />
+                                  <Pin Id="DjpzTqqQwFzPReQ5csoM7P" Name="Enabled" Kind="InputPin" />
+                                  <Pin Id="PVVMamFthhhP6EYSEgHkvj" Name="Output" Kind="OutputPin" />
+                                </Node>
+                              </Patch>
+                            </Node>
+                            <Node Bounds="721,909,45,19" Id="SnVhylkFKn5NycW5ab3prU">
+                              <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="ProcessAppFlag" Name="Group (Spectral)" />
+                              </p:NodeReference>
+                              <Pin Id="QOalMUCw4kPOP7PQJIiuZC" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                              <Pin Id="DhbPc5FWbQCMHPU59J4wLJ" Name="Input" Kind="InputPin" />
+                              <Pin Id="L3bKzF9ZV43LYqlq0xz0XL" Name="Debug" Kind="InputPin" />
+                              <Pin Id="PLFg96ys7XIQAfeXM3lkUw" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="IjIfbuJV0ZGMsI1Xwx9psw" Name="Output" Kind="OutputPin" />
+                            </Node>
+                            <Node Bounds="563,971,65,19" Id="J1HzRPRy7MbMxGBiGbhRZk">
+                              <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
+                                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                                <Choice Kind="ProcessAppFlag" Name="Group" />
+                              </p:NodeReference>
+                              <Pin Id="FK3E24jjZqiP8Waj1Mf5Vt" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                              <Pin Id="O8NrLTMqfKSOBvouINmz2c" Name="Input" Kind="InputPin" />
+                              <Pin Id="IHsf7dak2BWLfVDnmKiPUy" Name="Input 2" Kind="InputPin" />
+                              <Pin Id="FaFRf2tXq56OwtgAWx5gpz" Name="Debug" Kind="InputPin" />
+                              <Pin Id="TFq8U0kgoHuLRYgR0oSobc" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="UUFeOatDTMWPOXlNzwXsee" Name="Output" Kind="OutputPin" />
+                            </Node>
+                            <Pad Id="ALLTAbDJvCEOUVvYjV3YmH" Comment="" Bounds="761,677,39,80" ShowValueBox="true" isIOBox="true" />
+                          </Patch>
+                          <ControlPoint Id="HsT6RnMMxobLWooSTFN3Ae" Bounds="584,499" Alignment="Top" />
+                          <ControlPoint Id="HpW3i16Tc7jOOujUuwzxqM" Bounds="715,499" Alignment="Top" />
+                          <ControlPoint Id="SZI7F5JPK7YMjdhkMr6K1d" Bounds="566,1004" Alignment="Bottom" />
+                        </Node>
                       </Canvas>
                       <Patch Id="Shz0UDAr5pxOOL1mh09sHR" Name="Create" />
                       <Patch Id="MWfcYtmJNbPN5jOrAegG5S" Name="Update">
-                        <Pin Id="UqhQ4vyHSUaOX652bt12Ul" Name="Camera" Kind="InputPin" Bounds="756,179" />
-                        <Pin Id="TEJ2OUDJ3GSOnjwPRoe6BZ" Name="Floor Height" Kind="InputPin" Bounds="859,184" />
                         <Pin Id="PpfFcEWkeW6MVHutz1wvXn" Name="State" Kind="InputPin" Bounds="622,39" />
                         <Pin Id="Vi1ueJ8Z9UkQBIDcgD8mD7" Name="Output" Kind="OutputPin" Bounds="666,613" />
+                        <Pin Id="UqhQ4vyHSUaOX652bt12Ul" Name="Camera" Kind="InputPin" Bounds="756,179" />
+                        <Pin Id="TEJ2OUDJ3GSOnjwPRoe6BZ" Name="Floor Height" Kind="InputPin" Bounds="859,184" />
                       </Patch>
                       <ProcessDefinition Id="By5woOFTuOvMy3Q27JBsy8">
                         <Fragment Id="SYqeGD9s4gXQFXhZsNSL6y" Patch="Shz0UDAr5pxOOL1mh09sHR" Enabled="true" />
                         <Fragment Id="U3HyvpP4Rh6NNROtu1LFlM" Patch="MWfcYtmJNbPN5jOrAegG5S" Enabled="true" />
                       </ProcessDefinition>
-                      <Link Id="HqdeIgxw5gTMHEsxpVLqjm" Ids="NdDrseWRMWnL52UCxgjl1b,M6fvZNnn8QfNHhXwd1CxYS" />
-                      <Link Id="Rhtrce4wFevMj10bJxOuAt" Ids="NXxkzwZPv0eQIJMle8DOTd,CfXuWuuGzZCP2XpyzsodUQ" />
-                      <Link Id="TvUKN3FM8lSOd8BiYii3P8" Ids="JgNv3gvdWXdLJPSlsPHO3M,DqJJ6R4eXSbNcqOWRyAZY2" />
-                      <Link Id="LYCSAzm0gq9QW5sN7EavFV" Ids="DBrUYx6tGlfMkStfnDXElF,CVtIOCPtHBtOn9epPltp35" />
                       <Link Id="QQ0I5OO00XmOPQbif3h7Y8" Ids="UqhQ4vyHSUaOX652bt12Ul,DBrUYx6tGlfMkStfnDXElF" IsHidden="true" />
-                      <Link Id="PMDrNCNyfhOP0OgLZEQvOl" Ids="Eko6PvIIqGQPrdEAI27MSF,V0MOQFBX6beLF6zc5Enlj8" />
-                      <Link Id="K3k2B7aYSycNvopj0snq64" Ids="KhRqt8dWUx7MKw0cVXgfUL,IYYiNQyDQThLd3YxPKo3xr" />
-                      <Link Id="IIpp23p2y3zMc5jkbZpUDm" Ids="Go4rU3XWw2XPABaccOOhr4,O8NrLTMqfKSOBvouINmz2c" />
                       <Link Id="RELorJfdAwBQL676aevbqH" Ids="LeG7NGlMcULOYdFqJytwOu,Vi1ueJ8Z9UkQBIDcgD8mD7" IsHidden="true" />
-                      <Link Id="E9EnnpVz8raLB5H6hvhnTH" Ids="CQeQEqMdhp9QSsA9Rmj2t5,AgAUwLjOIwmNwVqTcHKRbR" />
-                      <Link Id="TGeQk0U6Hh7OBamxBcyVru" Ids="CQeQEqMdhp9QSsA9Rmj2t5,FG3cqvnlkT4NrqazeNHoc6" />
-                      <Link Id="DXWfW6YXzYhLHxBeAo47c9" Ids="CQeQEqMdhp9QSsA9Rmj2t5,KCvj5njDbUMQWxwEaJsqAl" />
-                      <Link Id="K8hcu1z5RwjM5UmhctDQy6" Ids="CQeQEqMdhp9QSsA9Rmj2t5,BYI7bdAva4mORRcvniTKXm" />
-                      <Link Id="RSiA7wEOptqNs2MqOi4Sck" Ids="UZlKyaa06AkQSQ1SNRDouD,GrCUK9i0Lb0PyKlfNFi5QU" />
-                      <Link Id="TNoMyexbPIlNBOWUtfoRXi" Ids="PRxW4IVLTUkOot7QsXExWZ,DTXb538LdbIN3vsLLGp1xe" />
-                      <Link Id="T5I1HSUOmYWO2GEpHKyGWg" Ids="CYjVtOCEDd0NlgZ3FyyZVf,MabwCR1u9hdMTOiDFnDBIH" />
-                      <Link Id="BxxnZNLSGxPO7ZByTy4SVY" Ids="FtjTdVvonHlMRokbuFz3po,Ck9plfzWdnAL8rGk1Yfmqo" />
-                      <Link Id="PnlSdE1SHTQMr3ZBfQuPla" Ids="N4ne3gftbKgLb9UXBsxvb6,NXxkzwZPv0eQIJMle8DOTd" />
                       <Link Id="BkWROqZvBSIOCH6QXEtrRA" Ids="PpfFcEWkeW6MVHutz1wvXn,MelH2zMgku7QFMQmFRC07N" IsHidden="true" />
                       <Link Id="FuL1VRSvh7vNaeqrVhwCl2" Ids="EJVYHDnaNZAPYqG3ylyeVA,RWAHzIEPDqHLE7UNd5Tg4Y" />
                       <Link Id="D3qAG7PnBajOaWy4LNQgNq" Ids="TEJ2OUDJ3GSOnjwPRoe6BZ,EJVYHDnaNZAPYqG3ylyeVA" IsHidden="true" />
+                      <Link Id="Nl4chrz8Wb5Mky7hsRxkuu" Ids="MelH2zMgku7QFMQmFRC07N,VntPtVxRS3GLE9YT0Xl2hu" />
+                      <Link Id="IXmbTrifIliOTEzJwGGChr" Ids="CQeQEqMdhp9QSsA9Rmj2t5,J1t3vbiICvfOsKUOuVyOdL" />
+                      <Link Id="VGAOJrdIIC4L1X6oxjaArq" Ids="INCSSgGfnwkL4CRzOHalnm,GrCUK9i0Lb0PyKlfNFi5QU" />
+                      <Link Id="Oqi3bYkid3RNRWpbB1sDVc" Ids="HFrAY80S42qOomYObYG7Hs,DTXb538LdbIN3vsLLGp1xe" />
+                      <Link Id="CfbD6BRwGkLL6ncQelZ57O" Ids="It7jKFmOdfFMljyhnxaCve,Ck9plfzWdnAL8rGk1Yfmqo" />
+                      <Link Id="DuZputh9eBLMntX4zCvnXv" Ids="HpFe0AqnOnvNFwTndxUheY,MabwCR1u9hdMTOiDFnDBIH" />
+                      <Link Id="OJ7foPWLAr0PCodnIAX2Oh" Ids="OqaUCfvc4HBNQgn3Qrl3Cg,IvqjsNFrelFMSVATvs21ho" />
+                      <Link Id="CRNuu808uNQM2hDrWzZM8j" Ids="RXJuroiTKUHNwTrcnnVoPJ,Cp0JVBIXpA4Mseg9aHDTc4" />
+                      <Link Id="C72NcFzzgy5L8ZQXHei18g" Ids="IGut6zV8b9NOSys204apZb,RXJuroiTKUHNwTrcnnVoPJ" />
+                      <Link Id="INhbxnnenV9P2hov2uK3De" Ids="Nbm2UZMdN3MMJQlDr2oedM,NQqfsEbHXerMFF8wY3G3c3" />
+                      <Link Id="KxpZV3pWEauPMOHmJ5OVoO" Ids="NQqfsEbHXerMFF8wY3G3c3,M4fX0eq2QeSPaQsA4tXJoe" />
+                      <Link Id="JDvLwoLZsh2PI4QXEoiqYO" Ids="N4ne3gftbKgLb9UXBsxvb6,NhQ48qd48zmOpm4jMkIVyI" />
+                      <Link Id="BVOdFnXD5dhQT5o1sykXID" Ids="NhQ48qd48zmOpm4jMkIVyI,NXxkzwZPv0eQIJMle8DOTd" />
+                      <Link Id="Rhtrce4wFevMj10bJxOuAt" Ids="NXxkzwZPv0eQIJMle8DOTd,CfXuWuuGzZCP2XpyzsodUQ" />
+                      <Link Id="TvUKN3FM8lSOd8BiYii3P8" Ids="JgNv3gvdWXdLJPSlsPHO3M,DqJJ6R4eXSbNcqOWRyAZY2" />
+                      <Link Id="PMDrNCNyfhOP0OgLZEQvOl" Ids="Eko6PvIIqGQPrdEAI27MSF,V0MOQFBX6beLF6zc5Enlj8" />
                       <Link Id="L46TaHDq53OQFlKnCEBvkg" Ids="NXxkzwZPv0eQIJMle8DOTd,TMgYQdLf23CPXOwqIHQ03h" />
                       <Link Id="RZ1ITV6SST1MpQohfAtJZc" Ids="H2aDB2DV6gWNGnU1SyHlYF,DrfohNzVxWNQcLyyiBwCGl" />
                       <Link Id="PaElZXQ59FJNGcJyxWW5wc" Ids="EJve3gWr7CSM9khDEJH45b,MVza5LaHea1ObhCbcUqwWq" />
-                      <Link Id="DOFPiSS3j8GMVvJIxniPC5" Ids="MVza5LaHea1ObhCbcUqwWq,IkEN1Xzx1k5Po3HdycH4ri" />
-                      <Link Id="GA9L8SEKEIeNH1ZS4VbI8x" Ids="V0MOQFBX6beLF6zc5Enlj8,MP93EyngRmiPihckUX2yc8" />
+                      <Link Id="FHAkQeKhP6uPbA7CrawBTP" Ids="IGut6zV8b9NOSys204apZb,HsT6RnMMxobLWooSTFN3Ae" />
+                      <Link Id="N5jaOCftDahPi4duYzKRs2" Ids="DBrUYx6tGlfMkStfnDXElF,HpW3i16Tc7jOOujUuwzxqM" />
+                      <Link Id="HCZqzDZ3zuYMx3SxNzKGA7" Ids="HpW3i16Tc7jOOujUuwzxqM,CVtIOCPtHBtOn9epPltp35" />
+                      <Link Id="ErlNQ0bOKglOVQm3nhHGNV" Ids="HpW3i16Tc7jOOujUuwzxqM,Tez6pqcxp7kOnkdNM2fUFT" />
+                      <Link Id="K3k2B7aYSycNvopj0snq64" Ids="KhRqt8dWUx7MKw0cVXgfUL,IYYiNQyDQThLd3YxPKo3xr" />
+                      <Link Id="IIpp23p2y3zMc5jkbZpUDm" Ids="Go4rU3XWw2XPABaccOOhr4,O8NrLTMqfKSOBvouINmz2c" />
                       <Link Id="DIAmhpV9lh1PeVS33KJniC" Ids="MP93EyngRmiPihckUX2yc8,M6qhxgAdYEaL5nlubuPRFT" />
                       <Link Id="VboW5pH55KxMDA79Oua50N" Ids="IkEN1Xzx1k5Po3HdycH4ri,VAtnaC7U5OqN6eUe9NW34s" />
                       <Link Id="PIEUpJe4xyiOIIcLURoI5A" Ids="PVVMamFthhhP6EYSEgHkvj,DoXtODNpXTpO9SWn2kHCTG" />
                       <Link Id="LABMVjv10uyP5kcgLhJXA4" Ids="DoXtODNpXTpO9SWn2kHCTG,DhbPc5FWbQCMHPU59J4wLJ" />
-                      <Link Id="FkthNqg6xX8OFxaWa1Zzjh" Ids="UUFeOatDTMWPOXlNzwXsee,LeG7NGlMcULOYdFqJytwOu" />
                       <Link Id="Vd02tVulFgdL3rTDvzWTRi" Ids="IjIfbuJV0ZGMsI1Xwx9psw,IHsf7dak2BWLfVDnmKiPUy" />
                       <Link Id="U5w618xLsRIO4LwVhp21w5" Ids="KhRqt8dWUx7MKw0cVXgfUL,HMqUvmlUtYSOPNhqejt8T0" />
-                      <Link Id="PZIQjPZvBVxO5qXPLAybkt" Ids="DBrUYx6tGlfMkStfnDXElF,Tez6pqcxp7kOnkdNM2fUFT" />
-                      <Link Id="LvzRemJ9Nl7OcDeDAaONAl" Ids="MVza5LaHea1ObhCbcUqwWq,RtaCBQ1TIVgP3N9Oij3qQQ" />
-                      <Link Id="Nl4chrz8Wb5Mky7hsRxkuu" Ids="MelH2zMgku7QFMQmFRC07N,VntPtVxRS3GLE9YT0Xl2hu" />
-                      <Link Id="RO54c0O174YPR4KbmVzBQn" Ids="IGut6zV8b9NOSys204apZb,KwIx3LsAJfALnFg2tqrcd0" />
+                      <Link Id="OvNfay8DgWONLvCz3dbsmZ" Ids="ALLTAbDJvCEOUVvYjV3YmH,IkEN1Xzx1k5Po3HdycH4ri" />
+                      <Link Id="EBJCGm79uxjQEduKBnbfFy" Ids="ALLTAbDJvCEOUVvYjV3YmH,RtaCBQ1TIVgP3N9Oij3qQQ" />
+                      <Link Id="U8PZllmtRxKMsT35bPdYCo" Ids="V0MOQFBX6beLF6zc5Enlj8,MP93EyngRmiPihckUX2yc8" />
+                      <Link Id="VrJ8JENQHltL8srWsKT5Vn" Ids="MVza5LaHea1ObhCbcUqwWq,ALLTAbDJvCEOUVvYjV3YmH" />
+                      <Link Id="J8YSYqkTTz5PXuqt2q2V5Q" Ids="UUFeOatDTMWPOXlNzwXsee,SZI7F5JPK7YMjdhkMr6K1d" />
+                      <Link Id="EMeIoaMIszDMoAlN4dKdrc" Ids="SZI7F5JPK7YMjdhkMr6K1d,LeG7NGlMcULOYdFqJytwOu" />
                     </Patch>
                   </Node>
                   <!--
@@ -32929,6 +32930,7 @@
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="Line" />
                                     </p:NodeReference>
+                                    <Pin Id="TpFEv9hsqT0OyWcyfAFr7f" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                     <Pin Id="C0TcpbIMAiQMbCgGagU4Mw" Name="Point A" Kind="InputPin" />
                                     <Pin Id="M265GNUZtTcNe0Q7e5hInG" Name="Point B" Kind="InputPin" />
                                     <Pin Id="GDT5DrD9BQ2NWgwIPq7Gqq" Name="Paint" Kind="InputPin" />
@@ -32970,6 +32972,7 @@
                                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                       <Choice Kind="ProcessAppFlag" Name="Stroke" />
                                     </p:NodeReference>
+                                    <Pin Id="HK3MZfTQh8pP0RryC0puwK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                     <Pin Id="QxZl4IpZreRPrKR49EMw3E" Name="Input" Kind="InputPin" />
                                     <Pin Id="AaxEkQ4oUsKPKDK65llGqu" Name="Color" Kind="InputPin" DefaultValue="0.79, 0.79, 0.79, 1">
                                       <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
@@ -33038,6 +33041,7 @@
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="Group (Spectral)" />
                                 </p:NodeReference>
+                                <Pin Id="Ehkiy9Lx3q3MFInoSdGjRC" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="LBUHPCzpoTrLtSIAqGLBw6" Name="Input" Kind="InputPin" />
                                 <Pin Id="IYORo7uCg9VLBKLA8NKKOq" Name="Debug" Kind="InputPin" />
                                 <Pin Id="V3BMk2OEKAZND4mtDSG2zt" Name="Enabled" Kind="InputPin" />
@@ -33472,7 +33476,7 @@
                       <Canvas Id="SldXTo3fXE8MDnWDUkNepM" CanvasType="Group">
                         <ControlPoint Id="Rfus7biS6OJPrlXVU96tpe" Bounds="330,125" />
                         <ControlPoint Id="ECxqzYLlwBCNxmon6A9cUR" Bounds="362,349" />
-                        <Node Bounds="343,200,131,121" Id="JSSqqQvMqOpNJTI1Jz5Og3">
+                        <Node Bounds="343,200,137,121" Id="JSSqqQvMqOpNJTI1Jz5Og3">
                           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                             <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                             <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -33484,18 +33488,18 @@
                           <Patch Id="RmXVX2STKMpNPrqwXrIENS" ManuallySortedPins="true">
                             <Patch Id="JJj6GgOVSJVM6JIYN2ply9" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="PXAGpeHZPxKNUC2mqABxTD" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="386,232,76,13" Id="EWJjjFBCkIvNuxC9QnfFuh">
+                            <Node Bounds="386,232,82,19" Id="EWJjjFBCkIvNuxC9QnfFuh">
                               <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="DrawFloorplan" />
                               </p:NodeReference>
                               <Pin Id="HL1Ef9ofQWMLbW6p6qg8VY" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                              <Pin Id="QEyC3GgyO8ZPfeQePwSWo0" Name="Camera" Kind="InputPin" />
-                              <Pin Id="H1pqF91nehhLt4iFCO3gzR" Name="Floor Height" Kind="InputPin" />
                               <Pin Id="GJkjQqyA7c1MXI29PwfZKR" Name="State" Kind="InputPin" />
                               <Pin Id="CdJ4RzmzK7wNOUY3hGoGjL" Name="Output" Kind="OutputPin" />
+                              <Pin Id="QEyC3GgyO8ZPfeQePwSWo0" Name="Camera" Kind="InputPin" />
+                              <Pin Id="H1pqF91nehhLt4iFCO3gzR" Name="Floor Height" Kind="InputPin" />
                             </Node>
-                            <Node Bounds="356,270,37,13" Id="SnjF8vK2YzCOGkJ8pyGR9A">
+                            <Node Bounds="356,270,65,19" Id="SnjF8vK2YzCOGkJ8pyGR9A">
                               <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="Group" />
@@ -33513,7 +33517,7 @@
                           </Patch>
                         </Node>
                         <ControlPoint Id="GHUZmHO0IDNPiLH70RHGEX" Bounds="721,10" />
-                        <Node Bounds="433,-27,91,22" Id="LAyfaOCNao4QSguBUHae1R">
+                        <Node Bounds="433,-27,97,26" Id="LAyfaOCNao4QSguBUHae1R">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewContext" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="ClassType" Name="SchematicViewContext" />
@@ -33526,7 +33530,7 @@
                           <Pin Id="VDSvP6l9ytyOCEEJju8tvS" Name="Schematic State" Kind="OutputPin" />
                         </Node>
                         <ControlPoint Id="E5Pq87HxWSJMatk5oJCobL" Bounds="434,-58" />
-                        <Node Bounds="513,13,77,22" Id="LiYZVvV5LkBOgDFm3Qqp4F">
+                        <Node Bounds="513,13,77,26" Id="LiYZVvV5LkBOgDFm3Qqp4F">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicState" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetCamera" />
@@ -33536,7 +33540,7 @@
                           <Pin Id="Rv4AYksFMpUP6glTscSBqK" Name="Output" Kind="StateOutputPin" />
                           <Pin Id="B0HqC4AJkWnP061iyCTluE" Name="Camera" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="585,50,85,22" Id="RPHrgRs1Q35P6HwZHOyvPM">
+                        <Node Bounds="585,50,105,26" Id="RPHrgRs1Q35P6HwZHOyvPM">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Camera" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="RecordType" Name="Camera" />
@@ -33551,7 +33555,7 @@
                           <Pin Id="FyqnaKAwxRhLOqmB6nsWe5" Name="Position" Kind="OutputPin" />
                           <Pin Id="ThRzdvXre1JOxssEsKAvyM" Name="Is Perspective" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="514,101,65,22" Id="IWATY8fXszJNbwUVyZZ4GT">
+                        <Node Bounds="514,101,85,26" Id="IWATY8fXszJNbwUVyZZ4GT">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicState" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetFloorHeight" />
@@ -34300,7 +34304,7 @@
                           </p:NodeReference>
                           <Patch Id="RbApfyrntEhNht8ieZjkzX">
                             <Canvas Id="KFEDhXgp4DXPB6lqiEiEiN" CanvasType="Group">
-                              <Node Bounds="142,426,46,13" Id="D8FtM5Ch2QWPZITrvWlCWD">
+                              <Node Bounds="142,426,53,19" Id="D8FtM5Ch2QWPZITrvWlCWD">
                                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="Sampler" />
@@ -34309,7 +34313,7 @@
                                 <Pin Id="IinmzEXBJ72LcaWIs5gFVM" Name="Notifications" Kind="OutputPin" />
                                 <Pin Id="RpUkwikroc8Nh7QB5t1hgF" Name="On Data" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="143,452,45,22" Id="Tr4hECtCz3sLu6vk98ovRj">
+                              <Node Bounds="142,452,52,26" Id="Tr4hECtCz3sLu6vk98ovRj">
                                 <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="IsEmpty" />
@@ -34318,7 +34322,7 @@
                                 <Pin Id="NYoZuxybElWLcKKGKlqyzD" Name="Input" Kind="StateInputPin" />
                                 <Pin Id="GWVKxAf0mQ9OUQnp3MSSYq" Name="Is Empty" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="142,486,29,13" Id="FbnsizuS2xoPvjRVSe58BP">
+                              <Node Bounds="142,486,37,19" Id="FbnsizuS2xoPvjRVSe58BP">
                                 <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -34326,18 +34330,19 @@
                                 <Pin Id="Bz7Ja9F47ipNbIycPxxOQp" Name="Input" Kind="StateInputPin" />
                                 <Pin Id="Aa4spOxvraxLT1OZkgCeVK" Name="Output" Kind="StateOutputPin" />
                               </Node>
-                              <Node Bounds="142,397,54,13" Id="RKEsh5a5l0fPlIr8aRX6Da">
+                              <Node Bounds="142,397,54,19" Id="RKEsh5a5l0fPlIr8aRX6Da">
                                 <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="ProcessAppFlag" Name="Where" />
                                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 </p:NodeReference>
+                                <Pin Id="SJGCeK9sFfDL8UdugOiLe0" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="H1KcZoj9nyINIcWkFwpdtU" Name="Value" Kind="InputPin" />
                                 <Pin Id="FXCicH9oSupMF0fTU5hXNQ" Name="Predicate" Kind="InputPin" />
                                 <Pin Id="Kl1b9LhMjwTN5zacunzOd1" Name="Result" Kind="OutputPin" />
                                 <Pin Id="N1kXojH0oHGNNyZdpBLWaq" Name="Changed" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="191,369,119,13" Id="GgEnywZOEdPPzZrpa07goa">
+                              <Node Bounds="191,369,119,19" Id="GgEnywZOEdPPzZrpa07goa">
                                 <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner.DrawAddFixture" LastDependency="Schema.UI.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationNode" Name="IsMouseDoubleClick" />
@@ -34346,7 +34351,7 @@
                                 <Pin Id="KpzoneAXxNPMAkspPvpWC5" Name="Output" Kind="OutputPin" />
                               </Node>
                               <ControlPoint Id="AkW7M2T8kjvORnjL616dob" Bounds="142,318" />
-                              <ControlPoint Id="SmFwIkN945sLlN1kQKTf0K" Bounds="146,501" />
+                              <ControlPoint Id="SmFwIkN945sLlN1kQKTf0K" Bounds="144,530" />
                             </Canvas>
                             <Patch Id="B3ezByFJ4ggN2JtDO6iGyq" Name="Create" />
                             <Patch Id="THgNK8l4Vo2M7cqe0XYoZO" Name="Update">
@@ -34865,7 +34870,7 @@
                           <Patch Id="I8Ds6cRrNSDMbl2iVdhTbt" ManuallySortedPins="true">
                             <Patch Id="CHKrP6cDRaXMzt7xdQjHWk" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="AlubalFrsA5LXFFEBlGTmG" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="226,444,76,13" Id="EbRtGO3QebUOnmjoz6eVXk">
+                            <Node Bounds="226,444,76,19" Id="EbRtGO3QebUOnmjoz6eVXk">
                               <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="DrawGrid" />
@@ -34877,7 +34882,7 @@
                               <Pin Id="ObLQoEV0pnHL5idFtPhmqu" Name="Floor Dimensions" Kind="InputPin" />
                               <Pin Id="BhehTGRkX74OrOc7oNEaEC" Name="Output" Kind="OutputPin" />
                             </Node>
-                            <Node Bounds="196,482,37,13" Id="TZstcJCGUXSPQ58As81xPL">
+                            <Node Bounds="196,482,65,19" Id="TZstcJCGUXSPQ58As81xPL">
                               <p:NodeReference LastCategoryFullName="Graphics.Skia" LastDependency="VL.Skia.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="Group" />
@@ -34896,7 +34901,7 @@
                         </Node>
                         <ControlPoint Id="Q6EdLqPH1LWMzJDqG1Bn5w" Bounds="595,337" />
                         <ControlPoint Id="Tbn3185p29nM8kwa6GNU8c" Bounds="253,142" />
-                        <Node Bounds="253,163,91,22" Id="VThsuypissqPlWcF6CfOSp">
+                        <Node Bounds="253,163,97,26" Id="VThsuypissqPlWcF6CfOSp">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewContext" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetCamera" />
@@ -34906,7 +34911,7 @@
                           <Pin Id="FmvWUsBxsrmOVzb1snmrIR" Name="Output" Kind="StateOutputPin" />
                           <Pin Id="DutNMRXA7vpNMWjuoboFdf" Name="Camera" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="338,202,85,22" Id="R8VFY0bYQMpPNz74MjTbdm">
+                        <Node Bounds="338,202,105,26" Id="R8VFY0bYQMpPNz74MjTbdm">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Camera" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="RecordType" Name="Camera" />
@@ -34921,7 +34926,7 @@
                           <Pin Id="UtSFtogLaaxPUXzPeAcwKF" Name="Position" Kind="OutputPin" />
                           <Pin Id="SkypHJS5J0YQRQlbN9CXyG" Name="Is Perspective" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="250,246,96,22" Id="TyXw7Lbc5VfMFrJBoEP9jA">
+                        <Node Bounds="250,246,97,26" Id="TyXw7Lbc5VfMFrJBoEP9jA">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewContext" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetFloorHeight" />
@@ -34931,7 +34936,7 @@
                           <Pin Id="HIGQzGZwAdyORZ79liBy2Z" Name="Output" Kind="StateOutputPin" />
                           <Pin Id="FPyptKVObSlLnxJZokYbJR" Name="Floor Height" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="250,287,91,22" Id="BsZJseuuafxLkFFBNNjyrQ">
+                        <Node Bounds="250,287,97,26" Id="BsZJseuuafxLkFFBNNjyrQ">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewContext" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetState" />
@@ -34941,7 +34946,7 @@
                           <Pin Id="F5Itxud5N6BPqd6KfaCyDX" Name="Output" Kind="StateOutputPin" />
                           <Pin Id="QBrEsJ916eYMJlt9v6NzH9" Name="State" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="328,348,120,13" Id="KS649UuyVovNeVT4ZjT69P">
+                        <Node Bounds="328,348,120,19" Id="KS649UuyVovNeVT4ZjT69P">
                           <p:NodeReference LastCategoryFullName="Schema.UI.View.Editor.Schematic.SchematicViewInner" LastDependency="Schema.UI.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetFloorDimensions" />
@@ -36657,6 +36662,7 @@
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="FixtureConfigLayer" />
                                 </p:NodeReference>
+                                <Pin Id="OBNJcpZKISmMpLAAL6IJYl" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="GqjQRpXnxE1M7EwRNToghe" Name="State" Kind="InputPin" />
                                 <Pin Id="JKMZXazOrUHOCgsdi3qt8C" Name="Input" Kind="InputPin" />
                                 <Pin Id="Ub2Mmqf3wxxM7Z2eDa8twf" Name="Open" Kind="InputPin" />
@@ -36669,6 +36675,7 @@
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="FixtureGroupLayer" />
                                 </p:NodeReference>
+                                <Pin Id="QD13oE5YV6cLGDAGLaRhYY" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="Q5MqY4vyLwiNlajYD3ReoC" Name="Context" Kind="InputPin" />
                                 <Pin Id="Rm57vkaWCOxN1fqZPm5wEF" Name="Selector Manager" Kind="InputPin" />
                                 <Pin Id="Jco5NksErHEQCG6Ck047bq" Name="State" Kind="InputPin" />
@@ -36722,6 +36729,7 @@
                                       </p:NodeReference>
                                       <Pin Id="U3d1NUytk80O57DKcDLE3x" Name="Radius" Kind="OutputPin" />
                                       <Pin Id="EpH3RcsjggfPUbfjyf5yMi" Name="Highlight" Kind="OutputPin" />
+                                      <Pin Id="GFV13fgHNMBQBI45hVChX6" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                     </Node>
                                     <ControlPoint Id="FgBg2PyYon9OGZG7xtaypA" Bounds="1078,1185" />
                                     <Node Bounds="888,-380,53,26" Id="MqZfkeU4HxKNnJujh9ldhb">
@@ -36731,6 +36739,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                       </p:NodeReference>
                                       <Pin Id="Eetw5C4U5KcOP6SKGYxkAa" Name="Result" Kind="StateOutputPin" />
+                                      <Pin Id="En1tkGQ9DJ4MXGg9rG7BFe" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                     </Node>
                                     <Node Bounds="888,-325,65,26" Id="IO71sQ3w1IUM9HgerMrAXE">
                                       <p:NodeReference LastCategoryFullName="Collections.Dictionary" LastDependency="VL.CoreLib.vl">
@@ -36749,6 +36758,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                         <CategoryReference Kind="Category" Name="SliderWidget" NeedsToBeDirectParent="true" />
                                       </p:NodeReference>
+                                      <Pin Id="FcZRJTLIWVELWy5REUUpki" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="CWthOs4G0PJMH8r9b5XB3d" Name="Initial Value" Kind="InputPin" />
                                       <Pin Id="OUIotO6avVeOIN3JaLgDpv" Name="From" Kind="InputPin" />
                                       <Pin Id="P4Rwm6PyTFqLxf9xVSUjTS" Name="To" Kind="InputPin" DefaultValue="511">
@@ -36801,6 +36811,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                         <CategoryReference Kind="Category" Name="SliderWidget" NeedsToBeDirectParent="true" />
                                       </p:NodeReference>
+                                      <Pin Id="H4nVG0tFBdcLhpRjVNWdEz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="SeqSKPoyAXjPR9vTY5ZSd5" Name="Initial Value" Kind="InputPin" DefaultValue="1">
                                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="TypeFlag" Name="Float32" />
@@ -36991,6 +37002,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessNode" Name="RoundRectangle (Bounds)" />
                                       </p:NodeReference>
+                                      <Pin Id="Rm3agcnxSKwP09ngE9YtIX" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="OtQnXUieMI0PbEFIkuXfZ0" Name="Bounds" Kind="InputPin" />
                                       <Pin Id="HJ6u0zYrh1sMsIJCz3gQeC" Name="Radius" Kind="InputPin" />
                                       <Pin Id="M8syVAOfnSnNoRiQif5bqE" Name="Paint" Kind="InputPin" />
@@ -37015,6 +37027,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="Fill" />
                                       </p:NodeReference>
+                                      <Pin Id="U5SukHuPgBFOrRLEMfqWrH" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="GeUsT8OK1XSN1z4MoIFLgO" Name="Input" Kind="InputPin" />
                                       <Pin Id="KH2c3mbvKUTOE7eovNqyqB" Name="Color" Kind="InputPin" DefaultValue="1, 1, 1, 0.72">
                                         <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
@@ -37029,6 +37042,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="Group (Spectral)" />
                                       </p:NodeReference>
+                                      <Pin Id="VuPATMUgVnINdBKtbpoNFy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="BPUtDE23tdtOOFHAwTI4LU" Name="Input" Kind="InputPin" />
                                       <Pin Id="OJylTQUr82dORPoOLBq9yj" Name="Debug" Kind="InputPin" />
                                       <Pin Id="MRbyojCe8KUPrhtvwF869A" Name="Enabled" Kind="InputPin" />
@@ -37040,6 +37054,7 @@
                                         <CategoryReference Kind="Category" Name="Skia" />
                                         <Choice Kind="ProcessAppFlag" Name="TransformSRT" />
                                       </p:NodeReference>
+                                      <Pin Id="Cy4Nol7WcYiM9uBAEGcVSN" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="Fwfkf14WaH5QGmivxAc89e" Name="Input" Kind="InputPin" />
                                       <Pin Id="QZKaK2Y3MOsOJL9kQ18nG0" Name="Scaling" Kind="InputPin" DefaultValue="0.2, 0.2">
                                         <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
@@ -37055,6 +37070,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="Group" />
                                       </p:NodeReference>
+                                      <Pin Id="Od1pBZYVPCVNyjbv9zXx4h" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="ESgAebmgM8PL3XMgbRU1M3" Name="Input" Kind="InputPin" />
                                       <Pin Id="LkIv882mExsN8sMpDyXQ9L" Name="Input 2" Kind="InputPin" />
                                       <Pin Id="RvxBuneirXXLycT52Pub42" Name="Debug" Kind="InputPin" />
@@ -37078,6 +37094,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                         <CategoryReference Kind="ClassType" Name="SelectorWidget" NeedsToBeDirectParent="true" />
                                       </p:NodeReference>
+                                      <Pin Id="MVYcrzS9qEUMYliet0roIK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="OSM9FWvziaZOfdWk13u52J" Name="Type" Kind="InputPin" />
                                       <Pin Id="RSsNK0zbVyCOPQalYqRiWO" Name="Allow New" Kind="InputPin" />
                                       <Pin Id="MeCdzGf1vwqO3EBGzkgNod" Name="Output" Kind="StateOutputPin" />
@@ -37099,6 +37116,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                         <CategoryReference Kind="ClassType" Name="SelectorWidget" NeedsToBeDirectParent="true" />
                                       </p:NodeReference>
+                                      <Pin Id="TW0UQHSkIlXMotXMPUBvNU" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="CJRyRK38vtaNYS6NvBuDNw" Name="Type" Kind="InputPin" />
                                       <Pin Id="MBC378ljxz3NSuqtdmeZ3W" Name="Allow New" Kind="InputPin" />
                                       <Pin Id="H0BsVHr1TCUMmObeamoYJU" Name="Output" Kind="StateOutputPin" />
@@ -37121,6 +37139,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                         <CategoryReference Kind="ClassType" Name="SelectorWidget" NeedsToBeDirectParent="true" />
                                       </p:NodeReference>
+                                      <Pin Id="EbVhCrXBDZsOOMWFWP1Fp7" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="Cgpfj4CRNVpP3jFFa6l2a9" Name="Type" Kind="InputPin" />
                                       <Pin Id="D6NdM2lavBTLTU0h2MIBvJ" Name="Allow New" Kind="InputPin" DefaultValue="True">
                                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -37146,6 +37165,7 @@
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                         <CategoryReference Kind="ClassType" Name="ToggleWidget" NeedsToBeDirectParent="true" />
                                       </p:NodeReference>
+                                      <Pin Id="QBp7lQgI5DiM3bz5dtsRql" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="MDQT0TVuj0lPfza9uQvh8h" Name="Initial Value" Kind="InputPin" />
                                       <Pin Id="AGzZS8LAgbIN6A3OOpUjxz" Name="Output" Kind="StateOutputPin" />
                                     </Node>
@@ -37166,6 +37186,7 @@
                                         <CategoryReference Kind="ClassType" Name="SelectorWidget" NeedsToBeDirectParent="true" />
                                         <Choice Kind="OperationCallFlag" Name="Create" />
                                       </p:NodeReference>
+                                      <Pin Id="DuHjvi83IVLN3i8sU1E4ad" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="R4lDmiJ0ywrMk86Po3ojjv" Name="Type" Kind="InputPin" DefaultValue="Address">
                                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                                           <Choice Kind="TypeFlag" Name="String" />
@@ -37493,6 +37514,7 @@
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <Choice Kind="ProcessAppFlag" Name="FixtureOverviewGroupCircle" />
                                           </p:NodeReference>
+                                          <Pin Id="KbbPhyxm1trQRHiPiMXnZ0" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="KmkArby1jH2PpheWv8cr3Z" Name="Index" Kind="InputPin" />
                                           <Pin Id="Epgc3ta7TtsLi6cLKnzw5Q" Name="Position" Kind="InputPin" />
                                           <Pin Id="MiCcUcPaWmXQW7NugYvYKB" Name="Color" Kind="InputPin" />
@@ -37508,6 +37530,7 @@
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <Choice Kind="ProcessAppFlag" Name="ButtonBehavior" />
                                           </p:NodeReference>
+                                          <Pin Id="HHxFAwAAeJoNpwq7JZKZWV" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="RzeBjDUwTeUO4ngiVTddjT" Name="Bounds" Kind="InputPin" />
                                           <Pin Id="UGOWXRLMUIbO5WJlerbome" Name="Button" Kind="InputPin" DefaultValue="Middle">
                                             <p:TypeAnnotation LastCategoryFullName="IO.Mouse" LastDependency="VL.CoreLib.vl">
@@ -37524,6 +37547,7 @@
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <Choice Kind="ProcessAppFlag" Name="SetBehavior" />
                                           </p:NodeReference>
+                                          <Pin Id="EGXcs628dKnNbb8mzaLvCA" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="U5PAYz24lOTOaUkn9TSZ7Z" Name="Input" Kind="InputPin" />
                                           <Pin Id="KAypFEcIMJjOi65rkDGYWF" Name="Behavior" Kind="InputPin" />
                                           <Pin Id="QkixwwCS3iaNgJ4vSBnIhn" Name="Output" Kind="OutputPin" />
@@ -37533,6 +37557,7 @@
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <Choice Kind="ProcessAppFlag" Name="Group" />
                                           </p:NodeReference>
+                                          <Pin Id="Mncvic5dIc0LTdgHdEjAQr" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="S5yxi9GOsBLP4w9s3sc7zK" Name="Input" Kind="InputPin" />
                                           <Pin Id="PD6V4MjhbG4LXln435Wgoz" Name="Input 2" Kind="InputPin" />
                                           <Pin Id="JBAo9gM2Y4EPv5Je6NPfig" Name="Debug" Kind="InputPin" />
@@ -37544,6 +37569,7 @@
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <Choice Kind="ProcessAppFlag" Name="SetBehavior" />
                                           </p:NodeReference>
+                                          <Pin Id="TELDTYLc9qfNnYcjOpS3Fy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="Gh886Re3D8lN381tovVPWY" Name="Input" Kind="InputPin" />
                                           <Pin Id="IOb1iQKP2JaMNUSiT2xiOs" Name="Behavior" Kind="InputPin" />
                                           <Pin Id="BmW8mEjI9FtLIQAj5k5erV" Name="Output" Kind="OutputPin" />
@@ -37553,6 +37579,7 @@
                                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                             <Choice Kind="ProcessAppFlag" Name="ButtonBehavior" />
                                           </p:NodeReference>
+                                          <Pin Id="QJcsbdCT40jLxWjT5UH7hk" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="CfgMbEYFHKmNHstuaStsPY" Name="Bounds" Kind="InputPin" />
                                           <Pin Id="FLK7JjCYgEKQKnhGiQJzcd" Name="Button" Kind="InputPin" />
                                           <Pin Id="VZTRL63Pqr9NY2j1qWKAC9" Name="Output" Kind="StateOutputPin" />
@@ -37579,6 +37606,7 @@
                                                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                                               </p:NodeReference>
+                                              <Pin Id="EGe4VwffRLnNSEs9SI3FeQ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                               <Pin Id="EWEqxwq6C2XMeeyYFXcBdU" Name="Value" Kind="InputPin" />
                                               <Pin Id="BtC6qBw3zsxLoioBG3hv6o" Name="Result" Kind="OutputPin" />
                                               <Pin Id="LIRs0qUg4ecLj4bPM0EaZa" Name="Changed" Kind="OutputPin" />
@@ -37611,6 +37639,7 @@
                                                 <Choice Kind="ProcessAppFlag" Name="Subscribe" />
                                                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                               </p:NodeReference>
+                                              <Pin Id="MWb6biZFUtlQEU2BOy22Rx" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                               <Pin Id="Ibqo9NqS9nzQd1yBT8Qecb" Name="Input" Kind="InputPin" />
                                             </Node>
                                             <Node Bounds="946,666,140,137" Id="MOmMHBat8OWOTNSm0RnjMg">
@@ -37619,6 +37648,7 @@
                                                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                                 <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                                               </p:NodeReference>
+                                              <Pin Id="QkKzliKHuLDN7XwdmEDTnI" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                               <Pin Id="ERJCftTNGmROq3E9BY8Ihq" Name="Value" Kind="InputPin" />
                                               <Pin Id="DcUuXdlJDAPPa5D8JPHXkW" Name="Result" Kind="OutputPin" />
                                               <Pin Id="LDcVbPa4rJ0OTfnclzU5U5" Name="Changed" Kind="OutputPin" />
@@ -37652,6 +37682,7 @@
                                                 <Choice Kind="ProcessAppFlag" Name="Subscribe" />
                                                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                               </p:NodeReference>
+                                              <Pin Id="AshwdC8tqNkLgwovbg5FUt" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                               <Pin Id="KVJG1SyqdhIOSFxC9Tk9RU" Name="Input" Kind="InputPin" />
                                             </Node>
                                           </Patch>
@@ -37663,6 +37694,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="FixtureOverviewGroupCircle" />
                                       </p:NodeReference>
+                                      <Pin Id="IvI2w6qc5HxOI42deCGBb4" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="KlyN7AzUrHdLTONHdvUsL6" Name="Index" Kind="InputPin" />
                                       <Pin Id="RYzNVMwbjeRLezfk36zD8v" Name="Position" Kind="InputPin" />
                                       <Pin Id="Lm4vtYpoxKKN46TKDK8w5X" Name="Color" Kind="InputPin" />
@@ -37705,6 +37737,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="ButtonBehavior" />
                                       </p:NodeReference>
+                                      <Pin Id="GXRucJ8jc7FPS4RXI3g5xN" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="VgReyOAz0mhPM1E18lvLbX" Name="Bounds" Kind="InputPin" />
                                       <Pin Id="NCZ38KQasEoNzzRZ4vllGG" Name="Button" Kind="InputPin" />
                                       <Pin Id="Sz7bUrzgNoZMR5XyZCew5m" Name="Output" Kind="StateOutputPin" />
@@ -37717,6 +37750,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="SetBehavior" />
                                       </p:NodeReference>
+                                      <Pin Id="RzSOpWAmg7rLklF3XbaCc4" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="MJ0CgybEWfbOLmvJUgU523" Name="Input" Kind="InputPin" />
                                       <Pin Id="JW1YZJh09DNPyiozcKmyFZ" Name="Behavior" Kind="InputPin" />
                                       <Pin Id="GQFyTdK1lwBPtZSUBB1dUf" Name="Output" Kind="OutputPin" />
@@ -37745,6 +37779,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
                                       </p:NodeReference>
+                                      <Pin Id="B1wcwtZjDikMWQrUJNaPaV" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="Lig8MSLdxk9Nk2hr8W4bvA" Name="Initial Value" Kind="InputPin" />
                                       <Pin Id="L5peGTBQ84TMMse0630DCa" Name="Value" Kind="InputPin" />
                                       <Pin Id="JWkDe9A38wUPHyjlDhp9AW" Name="Value" Kind="OutputPin" />
@@ -37757,6 +37792,7 @@
                                           <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true" />
                                         </CategoryReference>
                                       </p:NodeReference>
+                                      <Pin Id="QPZcYvH7hAROU79tNn2MyT" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="H7Dvyhabc6qPXIf9HMb2kU" Name="Input" Kind="InputPin" />
                                       <Pin Id="DZ0EJ2su1bVPdHpfnvSO6A" Name="Debug" Kind="InputPin" />
                                       <Pin Id="OrEeWf2PBb4QRl0Ik8iunw" Name="Enabled" Kind="InputPin" />
@@ -37819,6 +37855,7 @@
                                             <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                             <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                                           </p:NodeReference>
+                                          <Pin Id="FI2R58bffHaPyaCYaolHA7" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="KMuEMV7rn1fLJAEUqFv9si" Name="Value" Kind="InputPin" />
                                           <Pin Id="PfThyhslEDFOek35TvCAvb" Name="Result" Kind="OutputPin" />
                                           <Pin Id="ONWKEG0KzmVNkEx2ITvrRG" Name="Changed" Kind="OutputPin" />
@@ -37882,6 +37919,7 @@
                                             <Choice Kind="ProcessAppFlag" Name="Subscribe" />
                                             <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                                           </p:NodeReference>
+                                          <Pin Id="IjIO65ryxUuQDlKSEAwVFK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="FHmwuVjHgcgMt7AGYR9o1A" Name="Input" Kind="InputPin" />
                                         </Node>
                                       </Patch>
@@ -37891,6 +37929,7 @@
                                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                         <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                                       </p:NodeReference>
+                                      <Pin Id="IJjePmshIeqN5TKMyy69zq" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="LAQT2xUvDv2O9z4LYVJeVC" Name="Simulate" Kind="InputPin" />
                                       <Pin Id="JrhRtvVpS6MLVEOUx4U0O1" Name="Output" Kind="OutputPin" />
                                     </Node>
@@ -38001,6 +38040,7 @@
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="ProcessAppFlag" Name="Group" />
                                 </p:NodeReference>
+                                <Pin Id="H6zIrEMaBtzQch3REZKsiH" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                 <Pin Id="L7wplu9QnmvLVM7pqWh52H" Name="Input" Kind="InputPin" />
                                 <Pin Id="QSFMd7aQwbCLLB50qju7Mk" Name="Input 2" Kind="InputPin" />
                                 <Pin Id="AccAPF5xBlfMEKAkGPOZmt" Name="Debug" Kind="InputPin" />
@@ -45373,7 +45413,7 @@
                       <Node Bounds="644,868,65,19" Id="Jb9Vv5x8DkzMiOdJOsobF2">
                         <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                          <Choice Kind="ProcessAppFlag" Name="MonoFlop (FrameBased)" />
+                          <Choice Kind="ProcessNode" Name="MonoFlop (FrameBased Version 1)" />
                         </p:NodeReference>
                         <Pin Id="IWik7WKpyhsPqkw8YZyrhl" Name="Node Context" Kind="InputPin" IsHidden="true" />
                         <Pin Id="QbunBkATz04PG9TscUh1lL" Name="Set" Kind="InputPin" />
@@ -46551,7 +46591,7 @@
                         <Node Bounds="869,1036,71,13" Id="HEiK4Gu135hMfLp2YV9oIa">
                           <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="ProcessAppFlag" Name="MonoFlop (FrameBased)" />
+                            <Choice Kind="ProcessNode" Name="MonoFlop (FrameBased Version 1)" />
                           </p:NodeReference>
                           <Pin Id="BJ5Ku5exSJcM8dIYmZLGjR" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="Hmg9u8n2nacO656eyRySH5" Name="Set" Kind="InputPin" />
@@ -48538,6 +48578,7 @@
                           </Node>
                         </Patch>
                       </Node>
+                      <Patch Id="JeOXhoIU6b6OMEfX9c9Ygh" Name="Dispose" />
                     </Patch>
                   </Node>
                   <Node Bounds="555,327,165,26" Id="BGG6MfcJNGCNZaKcB7dZvv">
@@ -60033,10 +60074,10 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="NmO8BLlLkkrLhmrxGJlRkg" Location="VL.Skia" Version="2024.6.2" />
+  <NugetDependency Id="NmO8BLlLkkrLhmrxGJlRkg" Location="VL.Skia" Version="2024.6.7" />
   <DocumentDependency Id="ETE2iTXTdoxQGRj8Tzm6em" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="OF1xjDW2Ka9Nl5uUpZUJbE" Location="../domj.Skia.UI.vl" />
-  <NugetDependency Id="P0X3ARZHTqQPYAg7ph7ovu" Location="VL.EditingFramework" Version="2024.6.2" />
+  <NugetDependency Id="P0X3ARZHTqQPYAg7ph7ovu" Location="VL.EditingFramework" Version="2024.6.7" />
   <DocumentDependency Id="Scv1As6OHMbMvwmfrzy4lT" Location="../VL.LinearSpread.vl" />
   <PlatformDependency Id="FqHYafFksHVLzQvxf8hUve" Location="System.Windows.Forms" />
   <PlatformDependency Id="HCnVHuXL8C8Pi2cSxQZBkF" Location="System.Drawing.Primitives" />
@@ -60051,13 +60092,13 @@
   <DocumentDependency Id="KuZQxMb7w5aLgdTxe5xZdr" Location="./Schema.UI.FontAndParagraph.vl" IsForward="true" />
   <DocumentDependency Id="AcvK6vyZkb5N7NZg2YuKBd" Location="./Logo/Schema.UI.Logo.Screensaver.vl" />
   <DocumentDependency Id="VRNvC7zHqpSLZ1clroWWKK" Location="./Schema.UI.Style.vl" IsForward="true" />
-  <NugetDependency Id="F1uniR0S3HqQWzQpoZM8Ql" Location="VL.WinFormsUtils" Version="1.0.9" />
+  <NugetDependency Id="F1uniR0S3HqQWzQpoZM8Ql" Location="VL.WinFormsUtils" Version="1.0.11" />
   <DocumentDependency Id="RxR6r1KBM3KLjQXfoFozLo" Location="../Utilities/Schema.Utilities.FileSystem.vl" />
   <DocumentDependency Id="QCCwCGiR5c8ObCKJTL9d3P" Location="./Schema.UI.Shapes.vl" />
   <DocumentDependency Id="Sa5niKD1Rj7PhRDuBGDykj" Location="../Extensions/Links/Schema.Extensions.Links.vl" />
   <DocumentDependency Id="HasfByo9rSgPIzXcKeZ0VT" Location="../Persistence/Schema.Persistence.vl" />
   <PlatformDependency Id="K1DWgAhI7W2NpxjtTEe8qM" Location="../../lib/SchemaIcon.dll" />
-  <NugetDependency Id="CFsHKaVoXRBNwfGOpldAex" Location="VL.CoreLib.Windows" Version="2024.6.2" />
+  <NugetDependency Id="CFsHKaVoXRBNwfGOpldAex" Location="VL.CoreLib.Windows" Version="2024.6.7" />
   <DocumentDependency Id="TFRHJSuabFXOylziJpQObq" Location="../VL.Schema.Windows.vl" />
   <ProjectDependency Id="LhCR3C4lielLJ7SwdxJqof" Location="./csharp/Schema.UI/Schema.UI.csproj" />
   <DocumentDependency Id="EzlYRjJ0mHxQOqWpaZZXDr" Location="./Input/Schema.UI.Input.vl" />

--- a/Main/vl/UI/Schema.UI.vl
+++ b/Main/vl/UI/Schema.UI.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="HY4bvk8C4UaOvYdOJXseM9" LanguageVersion="2024.6.7" Version="0.128">
-  <NugetDependency Id="NkBh4OWx9oGOPU9o04edoW" Location="VL.CoreLib" Version="2024.6.7" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="HY4bvk8C4UaOvYdOJXseM9" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="NkBh4OWx9oGOPU9o04edoW" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="O2XeIgrncFrPtJVEvrUA3W">
     <Canvas Id="Ci7VwEE3fBNLj4DZqA1kki" DefaultCategory="Schema.UI" CanvasType="FullCategory">
       <!--
@@ -225,6 +225,7 @@
                 <Choice Kind="ProcessAppFlag" Name="Console" />
               </p:NodeReference>
               <Pin Id="TyarArCy9jwOM2GA8NgMOm" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="A15JIbtI5wXL3b2RhDhz9j" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="M1wtAmNz4SQQVryuda9gu7" Name="Output" Kind="OutputPin" />
               <Pin Id="BXSpIyU5KiwPgWDyq87kze" Name="Mouse" Kind="OutputPin" />
               <Pin Id="IXwUF4pYENJP9S6LkYXQsS" Name="Keyboard" Kind="OutputPin" />
@@ -1387,6 +1388,7 @@
                         <Choice Kind="TypeFlag" Name="RectangleAnchor" />
                       </p:TypeAnnotation>
                     </Pin>
+                    <Pin Id="Osmp5cGnlFaL9Gw3Ak3YTl" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="ApZJmXDSISKMV7wLBY3B26" Name="Output" Kind="OutputPin" />
                   </Node>
                   <ControlPoint Id="DOgreuy364sNv2xB58ljua" Bounds="781,889" />
@@ -1642,6 +1644,7 @@
                     <Pin Id="FdGeRvHISrMMxPL5pR8PJe" Name="Initial Result" Kind="InputPin" />
                     <Pin Id="AHAcesyCUH0Qc16LJbnrK5" Name="Async Notifications" Kind="InputPin" />
                     <Pin Id="H941D7ur254NFbw7sl4tQL" Name="Reset" Kind="InputPin" />
+                    <Pin Id="RqMRo9EYXbCPLn6G9gRkwr" Name="Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="Aota8VLJxLNNVmNnHAJKQG" Name="Value" Kind="OutputPin" />
                     <Pin Id="PmW5iOKScnZLq4wtIeLOhv" Name="On Data" Kind="OutputPin" />
                   </Node>
@@ -1654,6 +1657,7 @@
                     <Pin Id="RC00H0k6g2BO78ZALzOKfw" Name="Initial Result" Kind="InputPin" />
                     <Pin Id="KgsCF8UzhN2OfkpGNie1kh" Name="Async Notifications" Kind="InputPin" />
                     <Pin Id="E2yyDOopPHpPRObJHzhCqy" Name="Reset" Kind="InputPin" />
+                    <Pin Id="T3tyTNqoWWjL0iiLYCckav" Name="Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="LiDxuH6jDvzLhuyDkiVOxZ" Name="Value" Kind="OutputPin" />
                     <Pin Id="RWvKePhMzlvPgndTdI3x11" Name="On Data" Kind="OutputPin" />
                   </Node>
@@ -1680,6 +1684,7 @@
                     <Pin Id="GdBDKxwbhTfOIqdQblX2Km" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="MGZQaZCyShQOyDbElOr2s5" Name="Input" Kind="InputPin" />
                     <Pin Id="Cztt5HLg6wyLbmt7a52JTo" Name="Behavior" Kind="InputPin" />
+                    <Pin Id="M7v9U8OlqkyLsFBF0j8xJ7" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="NC71s4oLfhkNGUOKN7ZE9S" Name="Output" Kind="OutputPin" />
                   </Node>
                   <!--
@@ -1728,6 +1733,7 @@
                           <Pin Id="QS75pTGUnStMSJI6bzWaLu" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="H1a75TO851yPKsU36RgHEM" Name="Input" Kind="InputPin" />
                           <Pin Id="DHlOy8jlgXuO26pA2nAdlI" Name="Behavior" Kind="InputPin" />
+                          <Pin Id="SvMOSgA6x06NypbkWWUzeU" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="VcyzoJU0Z5TMNudGDyPvsj" Name="Output" Kind="OutputPin" />
                         </Node>
                         <ControlPoint Id="R2EfYdIDK9PM0vhy2A4jfR" Bounds="380,862" />
@@ -2070,6 +2076,7 @@
                 <Choice Kind="ProcessAppFlag" Name="Sampler" />
               </p:NodeReference>
               <Pin Id="IobYZcmgM5rPU99bsTLSSs" Name="Async Notifications" Kind="InputPin" />
+              <Pin Id="AVZLMCHhmUqMS52mCj9fcE" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="G64WZUzR395MgFtFo8pV1e" Name="Notifications" Kind="OutputPin" />
               <Pin Id="CtrmXsaUgOnNx9txrHoEap" Name="On Data" Kind="OutputPin" />
             </Node>
@@ -3114,6 +3121,7 @@
               <Pin Id="PoMsDb2NU8TM54I7Re0YSJ" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="I0gV9LmwJgiPPjIxDwcMsn" Name="Input" Kind="InputPin" />
               <Pin Id="Qr97CgmwgQJOlr1FCmHef7" Name="Behavior" Kind="InputPin" />
+              <Pin Id="IgFJsINTzTsLUUcR5MUlaZ" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="Vdt7wT7Lbu4NcdnYPWqB38" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="1060,1668,66,19" Id="Kaerhx39ApwOL9vwWsDJQ6">
@@ -3191,6 +3199,7 @@
                 <Choice Kind="ProcessAppFlag" Name="Console" />
               </p:NodeReference>
               <Pin Id="QN29sPZA3uaLY66sXFud86" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="EJnFcRBzzjjMoAOxQXdO73" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="AfPAoKg4gXzNERb7aQY0ym" Name="Output" Kind="OutputPin" />
               <Pin Id="Mr1chb9hmIdNSPgTKl4MSA" Name="Mouse" Kind="OutputPin" />
               <Pin Id="GKJlHXeZSvfQXUxZhXEiMl" Name="Keyboard" Kind="OutputPin" />
@@ -4015,6 +4024,7 @@
               <Pin Id="OLaqYfFckEvMeAwDAZmHnh" Name="Radius" Kind="InputPin" />
               <Pin Id="GvkDTOgsKUhLTPyXNku5wB" Name="Paint" Kind="InputPin" />
               <Pin Id="Np39tF8HstENLlFlvI3HDa" Name="Enabled" Kind="InputPin" />
+              <Pin Id="P05ZRtNqNi0MHiRZaftwLl" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="LtJeiPWMIzqOh4aXKnzMzi" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="495,933,51,26" Id="A3EW6ZO6ZGHOsytOzwxqFO">
@@ -4194,7 +4204,6 @@
                   </Pin>
                 </Patch>
               </Patch>
-              <Pin Id="FdZWfEL4naxN8LBcCYM2Pj" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="Nd5vpQKU80GOsNy1n2Zn16" Name="Default Output" Kind="InputPin" />
               <Pin Id="M4g00BVnaMALaSMMWMgcKz" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
               <Pin Id="AuwoemiFP7EOC1MNNDsGxh" Name="Result" Kind="OutputPin" />
@@ -4294,6 +4303,7 @@
                     <Pin Id="Q7X5C9zAUJyN6OXQ82kTaK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="M47aK8kKZk9QaR8WDtDQEc" Name="Trigger" Kind="InputPin" />
                     <Pin Id="JZnbhyslMg5NyOI1HisSD7" Name="Abort" Kind="InputPin" />
+                    <Pin Id="EU9E3gidvS5NF0rhrwkYth" Name="Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="A6bWUC8hjqSPJZsb9fXahf" Name="Result" Kind="OutputPin" />
                     <Pin Id="VVLhJpjCqDfLKe9oa5eyHa" Name="In Progress" Kind="OutputPin" />
                     <Patch Id="C3tmF8tas05Lxgu45nISBi" ManuallySortedPins="true">
@@ -4328,6 +4338,7 @@
                     <Pin Id="CoUoVv1jk6XOCY3EK3xGYU" Name="Initial Result" Kind="InputPin" />
                     <Pin Id="JzmvxhmDdgoOSDCnf58iBx" Name="Async Notifications" Kind="InputPin" />
                     <Pin Id="D4UYKJROG2cPVX7OkTjB0v" Name="Reset" Kind="InputPin" />
+                    <Pin Id="N45ESjCFa42PXbiv0Y2U2w" Name="Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="L3q5RsRsUMjQEn9EKM8WZy" Name="Value" Kind="OutputPin" />
                     <Pin Id="Vp9DdCdvzXVNsL5wEIhYRG" Name="On Data" Kind="OutputPin" />
                   </Node>
@@ -4653,6 +4664,7 @@
               <Pin Id="AHLO6bPXQLHOuBMlODagKg" Name="Initial Result" Kind="InputPin" IsHidden="true" />
               <Pin Id="BgMSretVgGpOE3DLVV1sY2" Name="Async Notifications" Kind="InputPin" />
               <Pin Id="UBTaoCgDmQlMPvVGai7ckd" Name="Reset" Kind="InputPin" />
+              <Pin Id="SAATINw6aHkPQWmaxVvo5h" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="B8UUqPRpEYHPSZYpJfLVJs" Name="Value" Kind="OutputPin" />
               <Pin Id="MnDJAkZfLe6OZIX8Ede7YH" Name="On Data" Kind="OutputPin" />
             </Node>
@@ -5483,6 +5495,7 @@
                   <Pin Id="EkzYDJ1u25kOc7DtiVsmKM" Name="Radius" Kind="InputPin" />
                   <Pin Id="S87aAAWGXgBOxDU0jKUEjg" Name="Paint" Kind="InputPin" />
                   <Pin Id="O4jfj1PUXILPAXzjYNGySt" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="N4CnqFM7J08PDfqtnB40wz" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="G0ZDIY9oTH9PGLtIXK9ZDP" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="300,498,65,19" Id="BNQQQ1DEaKAPI9E9Kh6LDa">
@@ -5577,6 +5590,7 @@
                   <Pin Id="GCKaJyFXZZ5L11pJMM702e" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="G0DyqZz5lcjLvKp9p3RCkz" Name="Input" Kind="InputPin" />
                   <Pin Id="RPkfXPqC8rAL3IcJwBVbYJ" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="TKSbrWqDCiDPmHe2rZH8Fg" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="CyczGgRyjNPMU28icrX9KB" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="379,256,45,19" Id="BrarVnOUoW5QSfT3rIBv6d">
@@ -5643,6 +5657,7 @@
                   <Pin Id="LG3wk8aHPt9Lj4wOBAtwab" Name="Radius" Kind="InputPin" />
                   <Pin Id="Qu8HFD3jeZFMuKldG6Fmlf" Name="Paint" Kind="InputPin" />
                   <Pin Id="N8CNcOmogYePpLOaTbqY06" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="FngZiaRAtLeLLA71oLPuAf" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="MTdBNQHoh48QYnBnUIqIJ8" Name="Output" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="KtUlbfIAz8MLsFUyJZkbKi" Bounds="564,217" />
@@ -5761,6 +5776,7 @@
               <Pin Id="Dy4AFOTKRnsNrQFFp2uiFH" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="U7wFvkilUZwO4aFhM6eyFs" Name="Restart" Kind="InputPin" />
               <Pin Id="QREViajYUoeMOnQukBj3cW" Name="Abort" Kind="InputPin" />
+              <Pin Id="ROc4XoUk4nWPjVwRoWagI9" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="IaLv2F5gufYMcSHkrEieHy" Name="Result" Kind="OutputPin" />
               <Pin Id="EnHNWumyhwVLQilZ3ZM4Xt" Name="In Progress" Kind="OutputPin" />
               <Patch Id="CJWFGo7ZTEiPTrrPwAZSul" ManuallySortedPins="true">
@@ -5778,7 +5794,6 @@
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
                   </p:NodeReference>
-                  <Pin Id="B3s9Vun6idfPeq9mdTTMYh" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LdTC4XCW1YUPR5S2nbygMN" Name="Default Output" Kind="InputPin" />
                   <Pin Id="PlCX4GiwbfBMYR2KgMdN8T" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FgD3FHLc0kOMUVHcxw4s05" Name="Result" Kind="OutputPin" />
@@ -5828,6 +5843,7 @@
               <Pin Id="LwEI5yuoTecLIaEOHV6wi9" Name="Initial Result" Kind="InputPin" />
               <Pin Id="QWJTKd4VEtgPh9RBeQkpfL" Name="Async Notifications" Kind="InputPin" />
               <Pin Id="Sqlm7vGrZ1eOoJPDjLVIEP" Name="Reset" Kind="InputPin" />
+              <Pin Id="SZdqhhDtgw5QEUKSunEZoh" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="VsxzY2x45JjOkkR0ei7xhH" Name="Value" Kind="OutputPin" />
               <Pin Id="NM4FyHuD0KiMTiwGzdWE9Z" Name="On Data" Kind="OutputPin" />
             </Node>
@@ -6177,6 +6193,7 @@
                   <Pin Id="HoYGhkNthXKNVEuQDAyXQr" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="NubCROhIQwQLpYMwql6fD7" Name="Input" Kind="InputPin" />
                   <Pin Id="U1S2cFLCmwUNPqU8RZK7TX" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="A3TnZRuoSHGP16s9o9wZH8" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="DBtugC9QJtrMDE2prQQ1Xa" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="717,594,30,13" Id="CTTHX3WSV47L4zQPoeIjZm">
@@ -7945,6 +7962,7 @@
               <Pin Id="HniJgL3sffeOUpMPGYbm4K" Name="Radius" Kind="InputPin" />
               <Pin Id="SaDScuTWHWTPeomc17YN3k" Name="Paint" Kind="InputPin" />
               <Pin Id="S4QIyKGiIKwMEAJcioXIGv" Name="Enabled" Kind="InputPin" />
+              <Pin Id="NNplMx8flvmNm8IuqcIqgp" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="EUIfbt6vj5lQS0Dq4lrXAf" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="490,304,45,19" Id="H1O9AKF7j50OTYtYxxYGKM">
@@ -8015,6 +8033,7 @@
               <Pin Id="TJmqccmsGC7NFSXIIdIGqN" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="RO5fHVKJEd0Ouz0MsU64K2" Name="Input" Kind="InputPin" />
               <Pin Id="C4ythh92TqRMShBxfnISMc" Name="Behavior" Kind="InputPin" />
+              <Pin Id="LUYzUH8E3ZgNsLz1m7e4GP" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="KN2Nqd6GfIIQKTLLJOyTSl" Name="Output" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="OdbvzSZFNCtNx3HipxTbjS" Bounds="609,169" />
@@ -8375,6 +8394,7 @@
               <Pin Id="VirJ7Z17HbIMvyi0CB6AY7" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="IzF5XrNsF5ZP6IKp3uzJCH" Name="Messages" Kind="InputPin" />
               <Pin Id="LJg7sOisFbvOZij08ySszI" Name="Reset" Kind="InputPin" />
+              <Pin Id="NFP7BmcEWeGNnU20bNREQ7" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="UnNiPOsYckkNIAeXVEbbMn" Name="Result" Kind="OutputPin" />
             </Node>
             <Node Bounds="453,603,84,19" Id="NMxGmP1bQcpNKUPWhFm1DM">
@@ -8537,6 +8557,7 @@
               <Pin Id="FDN9lGQS1UuMJb9SIQ5fNf" Name="Bounds" Kind="InputPin" />
               <Pin Id="R3RrisKy6LhOXnfyCwzz14" Name="Paint" Kind="InputPin" />
               <Pin Id="UGwNEmVrLFzM3WtdGibWHj" Name="Enabled" Kind="InputPin" />
+              <Pin Id="SLBWmwwt4usPvCZ7i0RipY" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="IZPvKMSgqpUOfu1BF8kR0k" Name="Output" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="GF6Yp0X3NCeQBF3hlSP9Q4" Bounds="336,512" />
@@ -9831,6 +9852,7 @@
                 <Choice Kind="ProcessAppFlag" Name="Console" />
               </p:NodeReference>
               <Pin Id="I3ACPDIzjrRNYeRUWY308w" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="F8QzTY7HBKYNDeJHgy0ox2" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="OfgVqFHBtX0OZ8WuIbLZMF" Name="Output" Kind="OutputPin" />
               <Pin Id="GreFw86CiqKPyg3NVYfHih" Name="Mouse" Kind="OutputPin" />
               <Pin Id="VMjmdb2YFbsM8uAk1nTcxO" Name="Keyboard" Kind="OutputPin" />
@@ -10876,7 +10898,7 @@
                 <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
               </p:ValueBoxSettings>
             </Pad>
-            <Node Bounds="2080,1819,112,19" Id="FTLnwVogEkmOlpVVhbWP2o">
+            <Node Bounds="2080,1819,142,19" Id="FTLnwVogEkmOlpVVhbWP2o">
               <p:NodeReference LastCategoryFullName="Schema.UI.Cursor" LastDependency="Schema.UI.Cursor.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="SetCursorNavigationBounds" />
@@ -11842,6 +11864,7 @@
                     <Choice Kind="ProcessAppFlag" Name="Console" />
                   </p:NodeReference>
                   <Pin Id="JZGhZlcjsTuLeTJq43WqC8" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="Vvyi6sEQUA0MIOn6pxKV5g" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="NL86cnhiwODPTJXzDfgFV5" Name="Output" Kind="OutputPin" />
                   <Pin Id="JfDMDVW88LIK9yB8fgJIB1" Name="Mouse" Kind="OutputPin" />
                   <Pin Id="CCUNpPZTz4TOu5dYHbVZd7" Name="Keyboard" Kind="OutputPin" />
@@ -11940,6 +11963,7 @@
                   <Pin Id="RY1AVyYJwqnMhc6qXdHSzp" Name="Radius" Kind="InputPin" />
                   <Pin Id="Jdq6zEe4qd3OHmLFwTgetC" Name="Paint" Kind="InputPin" />
                   <Pin Id="QmfdkAPcdmSLNRwCeCx6hs" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="JsFALfYbLnbOsWa3qaUEkX" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="Nphx18Zaq0HP28uqQm3JbK" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="683,710,45,19" Id="Tc0IundQ7KGLogW3QBrNXu">
@@ -12066,6 +12090,7 @@
                   <Pin Id="GuLmhUSju87PwNgkwgSIj0" Name="Radius" Kind="InputPin" />
                   <Pin Id="T1VNeTKYjBEPJ31LZVHwn5" Name="Paint" Kind="InputPin" />
                   <Pin Id="R1WLi9zAEwDNiD8hYBgW7y" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="TxblETbcLuDPWIB5mZxunc" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="Qd0WazVPCqiMx6TxTksWh2" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="548,1405,142,19" Id="ERaXmGHvyRxNjw2QpzYCvy">
@@ -12112,6 +12137,7 @@
                   <Pin Id="APxHCj1q60sN7x1Trfrzwt" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="AuAca1k18ggPS3zZtanCfh" Name="Input" Kind="InputPin" />
                   <Pin Id="OYJlzIOS1L0PoCqYKnMfCE" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="UQUmoSM0g1XNIVfnsJwZGj" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="RhxWdn9ITIZPy5r6NvR4Ti" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="670,775,66,19" Id="LfGfm5CTQfkPTG1O4cGpXA">
@@ -12457,6 +12483,7 @@
                       <Pin Id="ObcEiV7ywvtNuXKNIBbLhl" Name="Radius" Kind="InputPin" />
                       <Pin Id="FlGis8rLwbkMzugOoXYKXj" Name="Paint" Kind="InputPin" />
                       <Pin Id="K7XrNRpxfuBNxCp0fUNRJJ" Name="Enabled" Kind="InputPin" />
+                      <Pin Id="AeUrhGY2sodQUShTGZuvgn" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="Q8Nd9VpTFhcNCO9NSPIhYN" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="734,1234,105,19" Id="FiabQn397NMQIAmTA0cEl6">
@@ -12490,6 +12517,7 @@
                   <Pin Id="Dyd8TNItApdNtgmpsAULKO" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="D2ph2wxalWiPTPlpW3Emir" Name="Message" Kind="InputPin" />
                   <Pin Id="IOFdqfgdKtANo2Uae0OXKL" Name="Send" Kind="InputPin" />
+                  <Pin Id="DwTNoiBRHN4PNrXRwY22yV" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="Gjv1z2CTZDeNtriYQLLat3" Name="Result" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="SuCTWsfSmLeNzkdbN9USJa" Bounds="755,1545" />
@@ -13217,6 +13245,7 @@
                     <Pin Id="Qew8pm1VyBdMhQdhjU6FRC" Name="Point B" Kind="InputPin" />
                     <Pin Id="EuozHxWEkV9MVfibohxKS5" Name="Paint" Kind="InputPin" />
                     <Pin Id="LBvWbzDezs7MK63tXSl7UO" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="RcaydE7t5R9Ljb3r8gcxVl" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="FQUdWzEjr9MOX1CFFPQFiA" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="892,328,39,13" Id="T1Asfda89rMLc0AuG4RQkN">
@@ -13900,6 +13929,7 @@
                     <Pin Id="EZK6H32jGUqMrquJgYAC2I" Name="Radius" Kind="InputPin" />
                     <Pin Id="EbcMXhVL4cLOoZOlEYvZr9" Name="Paint" Kind="InputPin" />
                     <Pin Id="QtvTaJNz0u2P4F30aiU9GU" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="HjVkOrpkDbnM6dP9YdlVIA" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="M09T9b9NjcrL2pfrHqOAM5" Name="Output" Kind="OutputPin" />
                   </Node>
                   <!--
@@ -16390,6 +16420,7 @@
                     <Pin Id="EaKVoLvuaRdNcmNfoPoFKN" Name="Point B" Kind="InputPin" />
                     <Pin Id="TrnGEtvSKmqNeqVQDbtm2K" Name="Paint" Kind="InputPin" />
                     <Pin Id="G3aWdevuBeANJbGTMPufNm" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="RL2FAPZYn6rPVb69NaAFEr" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="MdtfepKPHhnLG12IjAXuus" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="658,122,39,13" Id="GkFKQhcrozHP4jnJCOMyRn">
@@ -16767,6 +16798,7 @@
                     <Pin Id="T47lcgoA1SROpZFnmw8cXn" Name="Radius" Kind="InputPin" />
                     <Pin Id="OVsZ50WiuEILFj3TeQHaP0" Name="Paint" Kind="InputPin" />
                     <Pin Id="OYhW3w2dGUZNVMghvSmDeu" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="GswAK5UBV3KQHZ9RLfroeW" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="NvPiqsY3e1zLIphjwm3Mof" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="596,330,65,19" Id="Ierw7t7J7w1P8fygUVAh5F">
@@ -17120,6 +17152,7 @@
                     <Pin Id="SprsE9oOdq9LT6rSTZwhaa" Name="Bounds" Kind="InputPin" />
                     <Pin Id="LfT8oYmBObpO3jeVh1HMVR" Name="Paint" Kind="InputPin" />
                     <Pin Id="PCDYTbRFreLLfOGzJbOrMr" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="DOWzK7O2AKTOVI59lUJkWz" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="KLO0aWo2PKRP8XPW4dwXDx" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="881,148,105,13" Id="PVHMIU5smYuMFIZ4VvedlK">
@@ -17228,6 +17261,7 @@
                     </Pin>
                     <Pin Id="AKimRde6llGLM7xZzHREXT" Name="Paint" Kind="InputPin" />
                     <Pin Id="UHihjLboCUbOZ2lW5E9Opp" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="NnqMkRxqFvwLYjCjZH0xzO" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="FkvfrFIDFl1LCoPl4y7C7s" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="809,291,91,13" Id="Tg83dB0wXbJMfciP1u5pJJ">
@@ -17343,6 +17377,7 @@
                     </Pin>
                     <Pin Id="POYvDgdB4mwNNuO5HZ8vFJ" Name="Paint" Kind="InputPin" />
                     <Pin Id="SgP9K9SVJyxMOKuAEZaVjS" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="SQD4AbMRhYiOn7EO2AMRY2" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="CqxOGndusvvNK5URkOLN5A" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="920,339,91,13" Id="BnF9FZRCsYvLy9VWC2NWV9">
@@ -17512,6 +17547,7 @@
                     <Pin Id="D1qN6Buj9frMc0RuReaIp0" Name="Bounds" Kind="InputPin" />
                     <Pin Id="VeVpLyZEY3pL5BXo4M5rLL" Name="Paint" Kind="InputPin" />
                     <Pin Id="B4S9ZjELkF0N6vjfNz7AnV" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="LEM6ic8r4lPNEHqvSpSwkJ" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="PAVExnntLLDNmYc3ttwRcw" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="880,143,105,13" Id="N0uOlhdgf5IPQHDkQsmwFB">
@@ -17840,6 +17876,7 @@
                     <Pin Id="IEW1CodtOn9OIFSZZdCkPw" Name="Bounds" Kind="InputPin" />
                     <Pin Id="Rkg5N4CkCe7NykUD3s7BMw" Name="Paint" Kind="InputPin" />
                     <Pin Id="EhzORYfniPeLIKlPU01dh8" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="Tp9MyOYyJrEM3UlIKo60A3" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="HOjvtQo71dAPGEh6khnbPL" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="952,380,105,19" Id="JovvHDZnV4kNZ7Y4crcB7h">
@@ -18243,6 +18280,7 @@
                     <Pin Id="FS81wNQ0z2sNCYOC4h5REu" Name="Point B" Kind="InputPin" />
                     <Pin Id="IuaYJr0YPn3NeiGp6y3GxB" Name="Paint" Kind="InputPin" />
                     <Pin Id="Qcdxxrl0uCBQHVZ5xbdlNI" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="I5YCLpCY5J4LrZs3eqWsFw" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="FMEVeA3GhCGMTAwsYEuLsC" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="QP5BimSvpTaPoFaD1VYmqb" Comment="Radius" Bounds="853,83,33,19" ShowValueBox="true" isIOBox="true" Value="0.2">
@@ -18377,6 +18415,7 @@
                     <Pin Id="KHWxrOkfQZuLXbsqrPDvEI" Name="Point B" Kind="InputPin" />
                     <Pin Id="B3oihJKyo3gM0yucmzSp9m" Name="Paint" Kind="InputPin" />
                     <Pin Id="GciFuR1an23NAegRku0suu" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="C4RW0Jul7f9NA6Dn88KKtO" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="QrDFDeg7O3ZL3IIMQa5frB" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="870,255,105,19" Id="OhGcUGjqmfHNL9mOBe40fW">
@@ -18439,6 +18478,7 @@
                     <Pin Id="Aciz5Wkx3LNM0sZlW0rWk9" Name="Point B" Kind="InputPin" />
                     <Pin Id="VXgVNpVCEqnQKzF1QAmJsg" Name="Paint" Kind="InputPin" />
                     <Pin Id="HdzZYTS4jh8LapwVxyoPPt" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="UYJbNYFi6JrPgi1lpipm11" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="IRUiNyYrRgbO7vQi9MIqgz" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="895,496,45,19" Id="GqlXKiV4XnqPz7WMsU65UO">
@@ -18880,6 +18920,7 @@
                         <Pin Id="R9udlFtwIbxPdfWBZpHXgC" Name="Point B" Kind="InputPin" />
                         <Pin Id="PMXwkbOFN84NEL5Zi5PQyx" Name="Paint" Kind="InputPin" />
                         <Pin Id="DS96Zs5plCsPsX0f6GyHMs" Name="Enabled" Kind="InputPin" />
+                        <Pin Id="A91yZB9Q91QL3UCKiZyfgH" Name="State Output" Kind="OutputPin" IsHidden="true" />
                         <Pin Id="NgDVbwskOZnPjrvh6KL8PY" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="721,255,39,13" Id="ORCnBESPStzMRA6Vxhso46">
@@ -19127,6 +19168,7 @@
                     <Pin Id="V0VzcRGLhy7LkO4P4t3nNf" Name="Radius" Kind="InputPin" />
                     <Pin Id="Oiood1aJBeBQXlKSAm22eb" Name="Paint" Kind="InputPin" />
                     <Pin Id="M0prCvsuXKRO5zHkadEE14" Name="Enabled" Kind="InputPin" />
+                    <Pin Id="AmiyunEnJCALjTN3h4rOse" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="BgqI3eiRFCkPI7KFjzcpw8" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="1269,152,66,19" Id="TnV7t4qv2OlNbDgWZnYohj">
@@ -19407,6 +19449,7 @@
                   </Pin>
                   <Pin Id="PiEjCPcsRW0PaOUi0SViLX" Name="Paint" Kind="InputPin" />
                   <Pin Id="LQczMdhzsFENSZma0GIqil" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="EhriRSxLLJvPDJJG4qnAbq" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="BPHPdYH1TaiLXqBDco3HfW" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="506,2216,421,19" Id="DD8xXCenQvCNaGFxrIHvPS">
@@ -19457,6 +19500,7 @@
                     <Choice Kind="ProcessAppFlag" Name="Console" />
                   </p:NodeReference>
                   <Pin Id="URIBE0XsiXZQZsdelR8Vr0" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="F2zn2IRDF62K9X7YveOKY0" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="Jz2DBp0as8FO03MNg0K4b2" Name="Output" Kind="OutputPin" />
                   <Pin Id="SHFY8RTcQP2MS4P7T81RLg" Name="Mouse" Kind="OutputPin" />
                   <Pin Id="LhhZcwSsJUIOjRTish0bw5" Name="Keyboard" Kind="OutputPin" />
@@ -20053,6 +20097,7 @@
                   <Pin Id="FPpjB0kDVviL53HCYo1hrB" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Ny4E7bEzlK9NZkV6bThhoI" Name="Input" Kind="InputPin" />
                   <Pin Id="OZZHhdnPIQrLpO8vCuScfP" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="Vf3FyowdL5vQckDklJ9Y3P" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="GMQMP3C3tiVP2sHE0u5KGH" Name="Output" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="QHciUXHKEQQMoYlWTDvVB3" Bounds="543,12" />
@@ -20549,6 +20594,7 @@
                             </Pin>
                             <Pin Id="PjycgsLAdCoQElTFbIwKpX" Name="Paint" Kind="InputPin" />
                             <Pin Id="OZom6fBadcvN0gFyRmWHrJ" Name="Enabled" Kind="InputPin" />
+                            <Pin Id="HncO9avvzIOQCtrZjyug4G" Name="State Output" Kind="OutputPin" IsHidden="true" />
                             <Pin Id="EW3w7mUJQAJLfCbV416QyM" Name="Output" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="625,811,46,19" Id="BXB5w9i586aO3TBGyTVH8t">
@@ -20638,6 +20684,7 @@
                             <Pin Id="UnirzI6N9DlOkWUspnBPID" Name="Node Context" Kind="InputPin" IsHidden="true" />
                             <Pin Id="LmLjGGeReNQOxz6U7FiRk2" Name="Input" Kind="InputPin" />
                             <Pin Id="Fb0mSxk2gHsMaQVcFrD5so" Name="Behavior" Kind="InputPin" />
+                            <Pin Id="KlBJr108iwcOciudAlZdmo" Name="State Output" Kind="OutputPin" IsHidden="true" />
                             <Pin Id="VuAFsu4abahLb1pxD4wEw4" Name="Output" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="717,844,85,26" Id="LOff8Ww6dUOOYd6xDW4Atp">
@@ -20790,6 +20837,7 @@
                             </Pin>
                             <Pin Id="Nm4TD93ygypPN9cplOaqIT" Name="Paint" Kind="InputPin" />
                             <Pin Id="LdXtXWo7RUDQJkRC95Gm4d" Name="Enabled" Kind="InputPin" />
+                            <Pin Id="VcObyR4NJI2LJEoSgP2RlW" Name="State Output" Kind="OutputPin" IsHidden="true" />
                             <Pin Id="Hktt03PAQnGMudRFjsDw71" Name="Output" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1145,1135,48,19" Id="RTJBcsfibpGM24Y1fEiOan">
@@ -20968,6 +21016,7 @@
                             <Pin Id="Bjq3tSnaJxfMXa5gfUo1TG" Name="Node Context" Kind="InputPin" IsHidden="true" />
                             <Pin Id="NPFFcyuCANXO39QJHJ0m43" Name="Input" Kind="InputPin" />
                             <Pin Id="QDg9nvpGrsyO5M4P2TsXsu" Name="Behavior" Kind="InputPin" />
+                            <Pin Id="Sxngot2GSrDLxOUmsCxbw3" Name="State Output" Kind="OutputPin" IsHidden="true" />
                             <Pin Id="HI9qCluokqTObfNCWLtbbn" Name="Output" Kind="OutputPin" />
                           </Node>
                           <Node Bounds="1184,1294,124,19" Id="KeDTqrfUqG7OoLXC0msRWM">
@@ -21729,6 +21778,7 @@
                         <Pin Id="GnTeG1tgYJHMvnITEZvaRo" Name="Node Context" Kind="InputPin" IsHidden="true" />
                         <Pin Id="OlDBzmg7WmSNl4MnBzynSO" Name="Messages" Kind="InputPin" />
                         <Pin Id="HmdweJG092dPlOHWOK1YK2" Name="Reset" Kind="InputPin" />
+                        <Pin Id="E9WRu8ZlPhkOv06dQrfEne" Name="Output" Kind="OutputPin" IsHidden="true" />
                         <Pin Id="EcKo4QYRd5NOs05wiWRnY5" Name="Result" Kind="OutputPin" />
                         <Patch Id="HiVoTdzx3wIQawp8UWPwlJ" ManuallySortedPins="true">
                           <Patch Id="JatpTUkbJg1PqVHiCedD1K" Name="Create" ManuallySortedPins="true" />
@@ -21853,6 +21903,7 @@
                         <Pin Id="SJSxjjZXdZLLrPXyK3kNsq" Name="Node Context" Kind="InputPin" IsHidden="true" />
                         <Pin Id="Bh11J9CLbg1QLgAbZ82n1X" Name="Messages" Kind="InputPin" />
                         <Pin Id="R9KaTfO3bsmLAhXDL0NQxJ" Name="Reset" Kind="InputPin" />
+                        <Pin Id="ArX82Q5aYK2MdlXILimgc1" Name="Output" Kind="OutputPin" IsHidden="true" />
                         <Pin Id="GbIDASY6zvmMiAnJFy76Nf" Name="Result" Kind="OutputPin" />
                         <Patch Id="EaoXKbZMW6PNOGUkTxuIFh" ManuallySortedPins="true">
                           <Patch Id="UYHa33JNMMsOqOlYhn2nPM" Name="Create" ManuallySortedPins="true" />
@@ -21934,6 +21985,7 @@
                         <Pin Id="AzZYGmNDfBUPfdfa6P2RjX" Name="Node Context" Kind="InputPin" IsHidden="true" />
                         <Pin Id="DrWxcLaK41cMeXqJsudACX" Name="Messages" Kind="InputPin" />
                         <Pin Id="QrJtOUZFiUBOhkPOkUuA0e" Name="Reset" Kind="InputPin" />
+                        <Pin Id="SoO3XtA8cM1QLsbQhtRBcv" Name="Output" Kind="OutputPin" IsHidden="true" />
                         <Pin Id="FwK2WCZrsItPz2u8uuGIqz" Name="Result" Kind="OutputPin" />
                       </Node>
                       <Pad Id="BxdDrm6flz4PJA4XM6fOHw" SlotId="VlALEoG9y37PLziTcnliBe" Bounds="1302,1767" />
@@ -22850,6 +22902,7 @@
                   </Pin>
                   <Pin Id="Ur3HXA2k8gYPclU7YasuxQ" Name="Paint" Kind="InputPin" />
                   <Pin Id="RNx47xllfpOO3lh3Pas4TV" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="DqMJa1FwClhLig3NMraYjQ" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="NvrKs5aYIenMIlSqb2ChNn" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="230,280,51,26" Id="GfkPYkeWoGAPStDHortkD9">
@@ -25894,6 +25947,7 @@
                   <Pin Id="PFGvTGBQ5NqPcVs5ylNZAw" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VD2qMSEr1TqPNGDCSJOQjj" Name="Messages" Kind="InputPin" />
                   <Pin Id="JEdsjCVmG8HMqEuKVJ3SNl" Name="Reset" Kind="InputPin" />
+                  <Pin Id="KPJbMQHd43JMqBknI0wOW8" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="B5kylpn5LR7LvqWzNhIjLK" Name="Result" Kind="OutputPin" />
                   <Patch Id="MOHYNEksZiLL5mKmKnEnvF" ManuallySortedPins="true">
                     <Patch Id="NLUYWLtIJvRPmh3c48qca1" Name="Create" ManuallySortedPins="true" />
@@ -26419,6 +26473,7 @@
                   <Pin Id="IT7Tj1lICfRPdblIQPoDR9" Name="Bounds" Kind="InputPin" />
                   <Pin Id="U37odMan42wNsh7GbkuFsZ" Name="Paint" Kind="InputPin" />
                   <Pin Id="DBwJmMTwTgSM7IrNOhNeWL" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="MA6weeJXvgzLbXskLbVYtW" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="AGQAkvOXgrcLJQj2JHH0XN" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="289,192" Id="GTSZjxPepGMLAzf8eXMGLM">
@@ -26476,6 +26531,7 @@
                   <Pin Id="ELg0ldqH1q5QctmjIkkNf0" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HYomBDzs6LNMiuQ8oNLN8p" Name="Input" Kind="InputPin" />
                   <Pin Id="GuJdrhq0oa8LYtsr3alDt2" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="IHBnpGiIfxJMe90HxUduX6" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="VCOFv0XRqUaPCJQ5HSH1l9" Name="Output" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="MvPMeWWqoYLMYu1lmtBUQT" Bounds="267,122" />
@@ -26526,6 +26582,7 @@
                       <Pin Id="PKc5KCKfrqJPw1Be8jfifl" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="I3qlpySfjtqNWZVBTKzEzJ" Name="Input" Kind="InputPin" />
                       <Pin Id="MzbNfiw5tiZLqk2ytikbkH" Name="Behavior" Kind="InputPin" />
+                      <Pin Id="AbForZsAgBpLWiFM0GZfvU" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="Ooh0zCLSHvqLduUWQ9EhCM" Name="Output" Kind="OutputPin" />
                     </Node>
                   </Patch>
@@ -26854,7 +26911,7 @@
                   </Node>
                   <ControlPoint Id="GwNoIrjZ6aNOmyrqqk1FmG" Bounds="214,142" />
                   <ControlPoint Id="Nczpe56qLgxLYalf1Sj6l3" Bounds="310,674" />
-                  <Node Bounds="262,337,249,249" Id="Q7zIfaCAfVZOKvGGxDhupn">
+                  <Node Bounds="262,337,269,249" Id="Q7zIfaCAfVZOKvGGxDhupn">
                     <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                       <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                       <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -26868,7 +26925,7 @@
                     <Patch Id="BmjXDCMhKm1Oy8CLrzn22e" ManuallySortedPins="true">
                       <Patch Id="TdMZFsRDML1NwaGiy0QrHW" Name="Create" ManuallySortedPins="true" />
                       <Patch Id="VBgbpS7pLmCNqK2FMEMcva" Name="Then" ManuallySortedPins="true" />
-                      <Node Bounds="274,360,225,19" Id="CagymV2zsD5NMTNhyJbuaY">
+                      <Node Bounds="274,360,245,19" Id="CagymV2zsD5NMTNhyJbuaY">
                         <p:NodeReference LastCategoryFullName="Schema.UI" LastDependency="Schema.UI.vl">
                           <Choice Kind="ProcessAppFlag" Name="NodeTreeLayer" />
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -26934,6 +26991,7 @@
                             <Choice Kind="TypeFlag" Name="RectangleAnchor" />
                           </p:TypeAnnotation>
                         </Pin>
+                        <Pin Id="M80OpTNzKAPM3SOwBUIlcQ" Name="State Output" Kind="OutputPin" IsHidden="true" />
                         <Pin Id="QwwQoMHJNBoPLJk2smopvk" Name="Output" Kind="OutputPin" />
                       </Node>
                       <Node Bounds="347,488,105,19" Id="Ce2AATXWnJhOw0ooHZcmoi">
@@ -27143,6 +27201,7 @@
                         <Choice Kind="TypeFlag" Name="RectangleAnchor" />
                       </p:TypeAnnotation>
                     </Pin>
+                    <Pin Id="A9KmvUi1Mq6NA00MMCnQg9" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="Vn3c3RouH3tO9ESdZz6nvk" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Pad Id="QTZyWZvSvwmOzsxvdVhkIA" Comment="Format" Bounds="1012,152,120,33" ShowValueBox="true" isIOBox="true" Value="yy\/MM\/dd">
@@ -29038,6 +29097,7 @@
                           <Choice Kind="ProcessAppFlag" Name="Console" />
                         </p:NodeReference>
                         <Pin Id="R0I6JxXpZO5MOkODKovaDA" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                        <Pin Id="AZwvjn7PMvfQPMtKeMyxhg" Name="State Output" Kind="OutputPin" IsHidden="true" />
                         <Pin Id="DSywjBy8Y1xPw1Joxckz3O" Name="Output" Kind="OutputPin" />
                         <Pin Id="I6mHRAiiMZ5LPrqrmQcTbR" Name="Mouse" Kind="OutputPin" />
                         <Pin Id="LMwcLdEc99RL57VrypENfB" Name="Keyboard" Kind="OutputPin" />
@@ -30497,6 +30557,7 @@
                                       <Pin Id="ELG1bFs2kU1NdWxEUJL479" Name="Point B" Kind="InputPin" />
                                       <Pin Id="UoJucVyT8m5OiH2E8XR5Tf" Name="Paint" Kind="InputPin" />
                                       <Pin Id="J4ebj41kv2CMhLpivIDW6e" Name="Enabled" Kind="InputPin" />
+                                      <Pin Id="VEH4UGPD3JmLGDexF4EOEt" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                       <Pin Id="OUTfoCfUoEnLzRu429jpBw" Name="Output" Kind="OutputPin" />
                                     </Node>
                                     <Node Bounds="504,912,45,19" Id="DwWuVT6RTIPQPJ8HvBxK5s">
@@ -31319,6 +31380,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="Q5oLqI9ji1tNIY7yHUm2s0" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="TQnRPYQyG3tOfOQWj12hm1" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="LP1UuzMhAWaLa4Nr4tfUaC" Name="Output" Kind="OutputPin" />
                           <Pin Id="P9upKM8Xp6QMAXSowQgYAj" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="UF5dp3wKluAMnsryeRlP6d" Name="Keyboard" Kind="OutputPin" />
@@ -32067,6 +32129,7 @@
                                   <Pin Id="VAtnaC7U5OqN6eUe9NW34s" Name="Point B" Kind="InputPin" />
                                   <Pin Id="HMqUvmlUtYSOPNhqejt8T0" Name="Paint" Kind="InputPin" />
                                   <Pin Id="DjpzTqqQwFzPReQ5csoM7P" Name="Enabled" Kind="InputPin" />
+                                  <Pin Id="PAB2L84SWsfODEX9MfhcSs" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                   <Pin Id="PVVMamFthhhP6EYSEgHkvj" Name="Output" Kind="OutputPin" />
                                 </Node>
                               </Patch>
@@ -32935,6 +32998,7 @@
                                     <Pin Id="M265GNUZtTcNe0Q7e5hInG" Name="Point B" Kind="InputPin" />
                                     <Pin Id="GDT5DrD9BQ2NWgwIPq7Gqq" Name="Paint" Kind="InputPin" />
                                     <Pin Id="QzxdmE3oUZ5PClE7LcT08W" Name="Enabled" Kind="InputPin" />
+                                    <Pin Id="Oy6Qq7XRZstQGP9hjZp5Xp" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                     <Pin Id="T1VyNfQ94QIQC10Z4xEwCE" Name="Output" Kind="OutputPin" />
                                   </Node>
                                   <Node Bounds="629,610,94,19" Id="JGlZGo4ATKINRNiZBLKubZ">
@@ -33248,6 +33312,7 @@
                               <Pin Id="RT3vTG6rQVmLU2V1Qvnxbb" Name="Node Context" Kind="InputPin" IsHidden="true" />
                               <Pin Id="UguAcYEFfHIL39x22krJpL" Name="Restart" Kind="InputPin" />
                               <Pin Id="DixDqjMogG3OHicAlC0tnU" Name="Abort" Kind="InputPin" />
+                              <Pin Id="NoGn2zwhWNzLf1q4ESZ1dg" Name="Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="I5iTPPVfoH2NbsZV50owyn" Name="Result" Kind="OutputPin" />
                               <Pin Id="UJnleL7IAE5PbHu0DKBPxH" Name="In Progress" Kind="OutputPin" />
                               <Patch Id="BZUF6YuCclZPYMGZWqD4Sp" ManuallySortedPins="true">
@@ -33281,6 +33346,7 @@
                               <Pin Id="KXr3QWeTkC2L4BqgVUB90e" Name="Initial Result" Kind="InputPin" IsHidden="true" />
                               <Pin Id="KBeqiwMx68nLSkiE60KeXU" Name="Async Notifications" Kind="InputPin" />
                               <Pin Id="OayEBKwyqqFPGdX0RW2CqG" Name="Reset" Kind="InputPin" />
+                              <Pin Id="UNQQW8y8BhMLXkhvPTHsgF" Name="Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="F6ZFXwsOv95Opl0YXRyRQu" Name="Value" Kind="OutputPin" />
                               <Pin Id="QcvZyb5FEl0OWRDizFnu4q" Name="On Data" Kind="OutputPin" />
                             </Node>
@@ -34106,6 +34172,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="Kj5KCSad8mvOssN16uBwvy" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="UFe4BxINoBsL2YSkap3sDw" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="PNPwhQ9iigAQTeYGEDJE6L" Name="Output" Kind="OutputPin" />
                           <Pin Id="KXlQNWpoIBeLTZf3Ios9iY" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="Dqcuwg7XVpRLzTdbqXCDi0" Name="Keyboard" Kind="OutputPin" />
@@ -34310,6 +34377,7 @@
                                   <Choice Kind="ProcessAppFlag" Name="Sampler" />
                                 </p:NodeReference>
                                 <Pin Id="MDxeftjxxsQO7PrB10tQBh" Name="Async Notifications" Kind="InputPin" />
+                                <Pin Id="U2KW2MhxMKgQUJigpco0iF" Name="Output" Kind="OutputPin" IsHidden="true" />
                                 <Pin Id="IinmzEXBJ72LcaWIs5gFVM" Name="Notifications" Kind="OutputPin" />
                                 <Pin Id="RpUkwikroc8Nh7QB5t1hgF" Name="On Data" Kind="OutputPin" />
                               </Node>
@@ -34687,6 +34755,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="SV3fNvh0jvRLRDolnL0zeU" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="EB093ZgzlJBLMHGElWukow" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="IMf2WIwEhvIN3JO0iKfkaA" Name="Output" Kind="OutputPin" />
                           <Pin Id="AdINZJsUM7NQIMv9R3y40q" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="URaflGVO7zmOFci1Xd9Nq3" Name="Keyboard" Kind="OutputPin" />
@@ -35274,6 +35343,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="HSJ0F3uCSsgNcWShIFIRvz" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="NiHGKSBe0dXLz4pRUO1Dgu" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="N4z8jOvifgsNTnfbCswlq0" Name="Output" Kind="OutputPin" />
                           <Pin Id="QgwaBRHbeZQQId1NnTvumg" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="VwtSpyjfSb4NqtYVi8gKWH" Name="Keyboard" Kind="OutputPin" />
@@ -35517,6 +35587,7 @@
                               <Pin Id="VUYDUJCwqGsQEURFse3Jdh" Name="Bounds" Kind="InputPin" />
                               <Pin Id="R35TvImbdMgMh187kJDFVo" Name="Paint" Kind="InputPin" />
                               <Pin Id="NzP3TDms08NMe86YIrPEGT" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="MXBZMign2muNRkfrmm2ciq" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="JZDiSdXXtpOPS7XDYURROL" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="762,403,25,13" Id="Ek4g40tC22XOakmHsiYzsS">
@@ -35592,6 +35663,7 @@
                               <Pin Id="E66J9L8heLGMrXGn8aH7Zs" Name="Node Context" Kind="InputPin" IsHidden="true" />
                               <Pin Id="CKIxPaMO8ZALmCtWCuKUkz" Name="Input" Kind="InputPin" />
                               <Pin Id="T5VRa7yj4LZLHoH9Vlj2E1" Name="Behavior" Kind="InputPin" />
+                              <Pin Id="KTuKme6uO6SNJhMSkgXHXu" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="Q3nY5SJfc2oQR7OHpv37wD" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="974,595" Id="A58FhAoNwbfNl81rBtkNYS">
@@ -35624,6 +35696,7 @@
                               <Pin Id="NMssUwqYZQqOuq4cvl6qfP" Name="Point B" Kind="InputPin" />
                               <Pin Id="GeH8xvirvJ8NwzttTry5HV" Name="Paint" Kind="InputPin" />
                               <Pin Id="QbMMOAEEACzPfuYx1gg0nc" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="Qs3d7HSZmlJLkzX7CUiAR8" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="JR4zHLSGoP2MiWFp88CWmX" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="823,625" Id="LGqj5zxdCb0Ns6YmK1lr6I">
@@ -35790,6 +35863,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="RCLLIuGevqyLrkdgDscCi2" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="KHaq3P3o2SFP63w7OsbD5v" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="GtRYOSrZ7yfMTwcSsapT2p" Name="Output" Kind="OutputPin" />
                           <Pin Id="MIHNa21BiiBODnZ0tjFZ4Y" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="Edw4e8ZDGwfOXSKJMWdMvV" Name="Keyboard" Kind="OutputPin" />
@@ -37007,6 +37081,7 @@
                                       <Pin Id="HJ6u0zYrh1sMsIJCz3gQeC" Name="Radius" Kind="InputPin" />
                                       <Pin Id="M8syVAOfnSnNoRiQif5bqE" Name="Paint" Kind="InputPin" />
                                       <Pin Id="IbRM9NMJSYYMcj47Nokw3Z" Name="Enabled" Kind="InputPin" />
+                                      <Pin Id="TA1TkXH942sOWuO3TJZWTm" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                       <Pin Id="RA6BTxH2ShnOMGVHOZ6CCf" Name="Output" Kind="OutputPin" />
                                     </Node>
                                     <Node Bounds="976,1022,85,26" Id="LLKLT6XKE2ANWgZs2ZoVOJ">
@@ -37550,6 +37625,7 @@
                                           <Pin Id="EGXcs628dKnNbb8mzaLvCA" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="U5PAYz24lOTOaUkn9TSZ7Z" Name="Input" Kind="InputPin" />
                                           <Pin Id="KAypFEcIMJjOi65rkDGYWF" Name="Behavior" Kind="InputPin" />
+                                          <Pin Id="FXzkixPRscNP3F7OGMpy6M" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                           <Pin Id="QkixwwCS3iaNgJ4vSBnIhn" Name="Output" Kind="OutputPin" />
                                         </Node>
                                         <Node Bounds="591,602,65,19" Id="VQLaSkS3HTxOrBlLkBhYkE">
@@ -37572,6 +37648,7 @@
                                           <Pin Id="TELDTYLc9qfNnYcjOpS3Fy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                           <Pin Id="Gh886Re3D8lN381tovVPWY" Name="Input" Kind="InputPin" />
                                           <Pin Id="IOb1iQKP2JaMNUSiT2xiOs" Name="Behavior" Kind="InputPin" />
+                                          <Pin Id="MO5eqlzT35eOoZTeVjU33v" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                           <Pin Id="BmW8mEjI9FtLIQAj5k5erV" Name="Output" Kind="OutputPin" />
                                         </Node>
                                         <Node Bounds="660,522,85,19" Id="G160x1Q9jY5OIG9PfPPN6K">
@@ -37753,6 +37830,7 @@
                                       <Pin Id="RzSOpWAmg7rLklF3XbaCc4" Name="Node Context" Kind="InputPin" IsHidden="true" />
                                       <Pin Id="MJ0CgybEWfbOLmvJUgU523" Name="Input" Kind="InputPin" />
                                       <Pin Id="JW1YZJh09DNPyiozcKmyFZ" Name="Behavior" Kind="InputPin" />
+                                      <Pin Id="HD7nLlvcedZPJu27bWp6Xi" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                       <Pin Id="GQFyTdK1lwBPtZSUBB1dUf" Name="Output" Kind="OutputPin" />
                                     </Node>
                                     <Node Bounds="555,1025,61,19" Id="SJZotKerkE4MmWyidpZDMf">
@@ -38669,6 +38747,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="IPzCNAvHoXkMHupyhyJ5wD" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="Fw7LaKjNM8IPoRWadbMJ1J" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="RUROi4nBl9CN8Zp6iYPN0Z" Name="Output" Kind="OutputPin" />
                           <Pin Id="TmMGziZ32pmMV0iF08ZHcd" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="RkNwOVXcoZtNzwvv146Jrd" Name="Keyboard" Kind="OutputPin" />
@@ -38763,6 +38842,7 @@
                               <Pin Id="ARnpW1XKRCNLuAPmfwvA8R" Name="Radius" Kind="InputPin" />
                               <Pin Id="IcY1DmW3JxjPPuWlY7ZAf3" Name="Paint" Kind="InputPin" />
                               <Pin Id="Pr3JZUdC13lN6yltn5C8bp" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="EQRu7SQauo2LlkW5SSb37g" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="H8jcXw0JFWjQRyQDWHdYtG" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="705,983,269,389" Id="KTPO3s6kFe3MeXjXGVzPrN">
@@ -39058,6 +39138,7 @@
                               <Pin Id="FUP8vhl86y2Oa3TK1YAYCY" Name="Bounds" Kind="InputPin" />
                               <Pin Id="U1OGZFO3G7bLRM9mWDgF0k" Name="Paint" Kind="InputPin" />
                               <Pin Id="JOo2PV2MvSNPTtQFg84sF0" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="RJgELfU019nPk5sAwwvNB2" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="Vb9ewMtWOi1MCiZsCtBAAS" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="1196,1505,136,13" Id="ASLqX6lem9POHeJWE5Efg7">
@@ -39096,6 +39177,7 @@
                               <Pin Id="AOYTD3FabpLLV7voA53Zjz" Name="Node Context" Kind="InputPin" IsHidden="true" />
                               <Pin Id="UBtOnYJbo6jLTYHPZ2fsR3" Name="Input" Kind="InputPin" />
                               <Pin Id="KRgUz3XxVdpPWMzlZltOiv" Name="Behavior" Kind="InputPin" />
+                              <Pin Id="MWOnBAGRsY0MxXLmwUZB5q" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="OjrYC7Dn5JiO8IbLEdc1sN" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="1250,1541,66,13" Id="JzJomN1MVt9Phg3j5oj7lX">
@@ -39152,6 +39234,7 @@
                               <Pin Id="EN0Fw3LOrDEQPyqsgJ5RfG" Name="Bounds" Kind="InputPin" />
                               <Pin Id="O8NPYugj6sLOq5fdAUe7yW" Name="Paint" Kind="InputPin" />
                               <Pin Id="FH0XnImfT7GP2sGZqCKaWk" Name="Enabled" Kind="InputPin" />
+                              <Pin Id="Qz5sdDUFoPPNZ3wchNNAX8" Name="State Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="CiqncgGqAkHOUNMaOLhYIs" Name="Output" Kind="OutputPin" />
                             </Node>
                             <Node Bounds="1228,1791,45,13" Id="TuI0RrozSE6Mdzm6Uk3DEQ">
@@ -39338,6 +39421,7 @@
                                   <Pin Id="U0raYPRftR7O6R3EEZVfzZ" Name="Point B" Kind="InputPin" />
                                   <Pin Id="VFYN9nNIaB5MYiIbRFQZN0" Name="Paint" Kind="InputPin" />
                                   <Pin Id="UX2EaFdw26zLGK4yDirMs7" Name="Enabled" Kind="InputPin" />
+                                  <Pin Id="BorOY2iUzsUPOTyjdAPU4j" Name="State Output" Kind="OutputPin" IsHidden="true" />
                                   <Pin Id="OKk5dOW0cyAMXAno40qhKP" Name="Output" Kind="OutputPin" />
                                 </Node>
                                 <Node Bounds="1452,1567,77,26" Id="HwXn5ce7BYxN6pUgiB6CiT">
@@ -39480,6 +39564,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="UEKz0EI6w5JMD51ZO3uhW1" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="OLnGyOsrPo3PKpHKkf2ZBX" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="VVAwODUFQcMOUqetnHUpsJ" Name="Output" Kind="OutputPin" />
                           <Pin Id="TsJYMbyLkBULS3j0HwnvhF" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="QCMFw0q4xXQOd2NbeY97jk" Name="Keyboard" Kind="OutputPin" />
@@ -40340,7 +40425,6 @@
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="ProcessAppFlag" Name="BusyWaitTimer" />
                           </p:NodeReference>
-                          <Pin Id="MWw9DpHYKJcQRAM0BiI6Da" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="PHw2RalPc5vNsRA2qTuvTZ" Name="Period" Kind="InputPin" DefaultValue="30">
                             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="TypeFlag" Name="Float32" />
@@ -40363,6 +40447,7 @@
                           <Pin Id="QARBhLxhX3zLz0nBmKZYOo" Name="Node Context" Kind="InputPin" IsHidden="true" />
                           <Pin Id="JgkT8zcX7JKMO2vT320w6O" Name="Messages" Kind="InputPin" />
                           <Pin Id="JufMbeTqBWMLm2Cj0goyJg" Name="Reset" Kind="InputPin" />
+                          <Pin Id="ErE3CpEffjwM2DQXMfcTZo" Name="Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="RRxdBMGYxK3MjyBp1JBqpl" Name="Result" Kind="OutputPin" />
                           <Patch Id="TZa4Hh0K2HwPIiky83egx8" ManuallySortedPins="true">
                             <Patch Id="PDDqVmc1KW4QUSLLdA4e46" Name="Create" ManuallySortedPins="true" />
@@ -40440,6 +40525,7 @@
                           <Pin Id="M7gWjEn2AJXNcZG3kxPA3W" Name="Initial Result" Kind="InputPin" />
                           <Pin Id="NAOExMJDyVwPGItcLe2HTY" Name="Async Notifications" Kind="InputPin" />
                           <Pin Id="LzPwN88uhwZOPsP6uPZnAQ" Name="Reset" Kind="InputPin" />
+                          <Pin Id="JM9JiL2jIypNggvlAFe0tF" Name="Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="RGTzpzYYfr6MT9Uz6v24wF" Name="Value" Kind="OutputPin" />
                           <Pin Id="LmtbZQmkxa7QT455tzdEe0" Name="On Data" Kind="OutputPin" />
                         </Node>
@@ -42608,6 +42694,7 @@
                               <Pin Id="PZWi9dnBccFQVmRvl6PEHe" Name="Node Context" Kind="InputPin" IsHidden="true" />
                               <Pin Id="DxPbsvR0tWzOp9kN9kPY7d" Name="Restart" Kind="InputPin" />
                               <Pin Id="M8hD7mP6glsPydQipVMhg7" Name="Abort" Kind="InputPin" />
+                              <Pin Id="Py6B79mufFBQUfzY7rsMXA" Name="Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="EvZDUXfCCoVOypL8RZDwfm" Name="Result" Kind="OutputPin" />
                               <Pin Id="DaE2zbjx1OAN2E8OQDXatt" Name="In Progress" Kind="OutputPin" />
                               <Patch Id="LdTXCOT91pEMdCMzYIzTUM" ManuallySortedPins="true">
@@ -42641,6 +42728,7 @@
                               <Pin Id="RrHqkiYnaw0QTBhPNacsNX" Name="Initial Result" Kind="InputPin" IsHidden="true" />
                               <Pin Id="F28OBCzkoXGNmzBjD1hocv" Name="Async Notifications" Kind="InputPin" />
                               <Pin Id="OixVGTtzn5KOqmgNG4Q4QH" Name="Reset" Kind="InputPin" />
+                              <Pin Id="PvEmzbAUNqmLUX55GwfSjK" Name="Output" Kind="OutputPin" IsHidden="true" />
                               <Pin Id="RNgKzzkXfgoL3UtGow1JKD" Name="Value" Kind="OutputPin" />
                               <Pin Id="MXWy6wC6gcqNgftZTtOW1a" Name="On Data" Kind="OutputPin" />
                             </Node>
@@ -42931,6 +43019,7 @@
                             <Choice Kind="ProcessAppFlag" Name="Console" />
                           </p:NodeReference>
                           <Pin Id="L0649vgWG71Ls2fqgRllzm" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                          <Pin Id="Efbs7XOQy2yLrrpflR388F" Name="State Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="Htnivp2BMVPMtlXl7CXpn7" Name="Output" Kind="OutputPin" />
                           <Pin Id="NsIqMSsS9J9PHdwNWptjz2" Name="Mouse" Kind="OutputPin" />
                           <Pin Id="GVHVwkOALReO6lVKsUUyMb" Name="Keyboard" Kind="OutputPin" />
@@ -45039,12 +45128,15 @@
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Renderer" />
                   </p:NodeReference>
+                  <Pin Id="HRA7ZVuwzIHOVJHqa2Ogmi" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FzOjPqPonQcOb5wCC7RtF5" Name="Bounds" Kind="InputPin" />
                   <Pin Id="LfsdOoa2UY7OCT9M5FtWMy" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Nz6NW582eUKM5s9AE9y4W3" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
-                  <Pin Id="HRA7ZVuwzIHOVJHqa2Ogmi" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="TU8Ve8SfIGMPTKTi3pSXEl" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="Tsc5vr8utzCPfWPebwMvXE" Name="Always On Top" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="CyHJH0MNrnQMm7UqlAn4PM" Name="Extend Into Title Bar" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VNjJnQTIhncPknu180pxUA" Name="Input" Kind="InputPin" />
+                  <Pin Id="MP2hrOsjHc2OVmMCEqHv9W" Name="Title" Kind="InputPin" />
                   <Pin Id="NbY7uWUDpRjLOtoa5EewOU" Name="Color" Kind="InputPin" />
                   <Pin Id="HBBhfxdv5UPNENpefrJJuy" Name="Clear" Kind="InputPin" />
                   <Pin Id="GR21nNFKfRVNN8yqdYWwRC" Name="Space" Kind="InputPin" />
@@ -46247,6 +46339,7 @@
                       <Pin Id="CyuXUvXAckIOD4fx2IbOHu" Name="Bounds" Kind="InputPin" />
                       <Pin Id="Jra60k21nzcMswqCDoK4U2" Name="Paint" Kind="InputPin" />
                       <Pin Id="PiNOXX1xJrZMue70iG1G5J" Name="Enabled" Kind="InputPin" />
+                      <Pin Id="P1iL9IxRjvNMUglwATxhRZ" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="MguDDVgMHk4QDJWFCHLKvO" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="213,250,44,22" Id="Ppmfh1zOt8yNcsCmeuLFzu">
@@ -46483,6 +46576,7 @@
                       <Pin Id="PDT1XI5DmlFMFTEhLR7yHD" Name="Bounds" Kind="InputPin" />
                       <Pin Id="Dkmx0iSyDeiP6OoMHoY8Gu" Name="Paint" Kind="InputPin" />
                       <Pin Id="C91sn0nelICPcOxXgxqj9L" Name="Enabled" Kind="InputPin" />
+                      <Pin Id="ITDQme8QIM5L9vzGBQYPko" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="JRAE8QPnsHtNHwDSbK42mk" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="776,363,45,13" Id="HIfaIypWy5ON6msqaDVo8s">
@@ -47141,6 +47235,7 @@
                       <Choice Kind="ProcessAppFlag" Name="Console" />
                     </p:NodeReference>
                     <Pin Id="AvMAlerOuHlOXBJJ4z72P1" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="Rp6HjnCQrKuPXnIrNaP1Bk" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="NgpSjiphBuaQbLmQ8eLPDb" Name="Output" Kind="OutputPin" />
                     <Pin Id="TJO7P2kQSHNMOAvhWsAcoN" Name="Mouse" Kind="OutputPin" />
                     <Pin Id="V3jMmGn2fiXNtP12Ibm6NV" Name="Keyboard" Kind="OutputPin" />
@@ -47188,6 +47283,7 @@
                     <Pin Id="QRKBXqyCEuHNyD0boZkm0d" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="AVTwmfoNJm6OEuIf8BEthp" Name="Input" Kind="InputPin" />
                     <Pin Id="Do26QYgLNBtMF8IieY2ySj" Name="Behavior" Kind="InputPin" />
+                    <Pin Id="CD6DnRpsWO6Oa06el5gsxP" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="MkashBsQzlgNqoj6iTuWZL" Name="Output" Kind="OutputPin" />
                   </Node>
                   <ControlPoint Id="KvIcr3M31reQaYfsrihwgY" Bounds="568,799" />
@@ -47240,6 +47336,7 @@
                         <Choice Kind="TypeFlag" Name="Boolean" />
                       </p:TypeAnnotation>
                     </Pin>
+                    <Pin Id="N137kiKR8dAMeuFnqjofYB" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="V1685qxAQD6QVp5We5dx90" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="498,511,45,19" Id="D4B7FPjm5jLM4etFCwsVuL">
@@ -48422,6 +48519,7 @@
                     <Pin Id="Rk97SygZBaDOyiosf4uInq" Name="Value" Kind="InputPin" />
                     <Pin Id="FrV6PbeyR3FOjcQTp0rB4n" Name="Output" Kind="OutputPin" />
                     <Pin Id="LMieEqxt3xgQbQeazfF1uR" Name="Value" Kind="OutputPin" />
+                    <Pin Id="EauM4opON9yLbtQzui2w6B" Name="Author" Kind="InputPin" IsHidden="true" />
                   </Node>
                   <Node Bounds="135,237,43,19" Id="Uxug9HcTXJ1O5I6GK2OYAu">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
@@ -48466,6 +48564,7 @@
                     <Pin Id="CZ68TXLPIxyQUHIt8ekD2a" Name="Value" Kind="InputPin" />
                     <Pin Id="GIANnBfV4YuN62Cy4pdBaK" Name="Output" Kind="OutputPin" />
                     <Pin Id="KMBueynkq11NCHliypVhhH" Name="Value" Kind="OutputPin" />
+                    <Pin Id="SYINmWBewdhPOzfnXIYNwz" Name="Author" Kind="InputPin" IsHidden="true" />
                   </Node>
                   <Node Bounds="366,372,454,183" Id="Dve8J7QNSncM2e6ngRy9j3">
                     <p:NodeReference LastCategoryFullName="Reactive.Channel" LastDependency="VL.CoreLib.vl">
@@ -48856,6 +48955,7 @@
                         <Choice Kind="TypeFlag" Name="RectangleAnchor" />
                       </p:TypeAnnotation>
                     </Pin>
+                    <Pin Id="VSw1X5ROWAxPYN5LIJyUkL" Name="State Output" Kind="OutputPin" IsHidden="true" />
                     <Pin Id="PdASdGFQrJXNOpK4HAAic4" Name="Output" Kind="OutputPin" />
                   </Node>
                   <Node Bounds="433,770,46,19" Id="VgI3OqOM8EjOCPVI640c3V">
@@ -49068,6 +49168,7 @@
                       <Pin Id="QQ6ZFP7osNlLWFWFcN6mKN" Name="Radius" Kind="InputPin" />
                       <Pin Id="FLzD9EVBDbuPuhUMIWVUM2" Name="Paint" Kind="InputPin" />
                       <Pin Id="FDjVzj4rgsVNw5hCYsFrS0" Name="Enabled" Kind="InputPin" />
+                      <Pin Id="MOESaUzG83MNb0v9WNyP28" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="FRofkveBH8uPDwARlyNvgk" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="583,683,45,19" Id="Emx3IguAGsgOaTnpSfJXiV">
@@ -49190,6 +49291,7 @@
                       <Pin Id="FyUvPhXEydFPIDBMGBXTxK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="Dg5BJ1q8Y96M3wfvFECXgN" Name="Input" Kind="InputPin" />
                       <Pin Id="JbepKny6BUCNe59gFERTIP" Name="Behavior" Kind="InputPin" />
+                      <Pin Id="NvkvxZF2MssMN4chCocw9Q" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="OuyvRhYyEbgOHwm82U9nmn" Name="Output" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="630,656" Id="PDTlc0v2BlNMWXNY3x1LYh">
@@ -49484,6 +49586,7 @@
                       <Pin Id="GJfjDv58jwHNYPxEavVjyC" Name="Initial Result" Kind="InputPin" />
                       <Pin Id="C9kjzb1SOzdPX77xqEkHm3" Name="Async Notifications" Kind="InputPin" />
                       <Pin Id="GAqOpqPjp0xP6XmHjoaWrh" Name="Reset" Kind="InputPin" />
+                      <Pin Id="MGRQzT4wMPbOGtuRNFqLaH" Name="Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="BuSevtsXYf6Ng6P6JOMUmW" Name="Value" Kind="OutputPin" />
                       <Pin Id="LnIVgCNCYs7LhsN4qjbPF6" Name="On Data" Kind="OutputPin" />
                     </Node>
@@ -49542,6 +49645,7 @@
                         <Choice Kind="ProcessAppFlag" Name="Console" />
                       </p:NodeReference>
                       <Pin Id="KHhrDdLtowhLuLxeHdxlbO" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="J0CwE6UyS4BO7xxzCxFtB2" Name="State Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="D5iRDbV8XGnOXY342dUdA7" Name="Output" Kind="OutputPin" />
                       <Pin Id="Eeaa17Uo04NNVDBr4SJmC1" Name="Mouse" Kind="OutputPin" />
                       <Pin Id="P27j5z8ldggNEJmJlnY4Lf" Name="Keyboard" Kind="OutputPin" />
@@ -49585,6 +49689,7 @@
                       <Pin Id="NuounElalk1MKj55HYE7eA" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="Nlhjm2UAtpjOSMSKZ9FlXL" Name="Message" Kind="InputPin" />
                       <Pin Id="C4mdBbtBNgkPSATa0MwKap" Name="Send" Kind="InputPin" />
+                      <Pin Id="O4esLHabZJLNG4G51R49IV" Name="Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="BnUTCjWWPoFNRhvKPZcgFw" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="903,860,25,19" Id="Naj2yGUyPK2MvQtJ6BYw48">
@@ -49830,6 +49935,7 @@
                   </Pin>
                   <Pin Id="Tc4eOPhgPaPQON47PyutHE" Name="Paint" Kind="InputPin" />
                   <Pin Id="G3vLLstXkYWQBNDiY0qzBS" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="A6uW2zTr7zROP0gjDXw8nn" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="K4TO7FgG6BvMtAiGnEpKlE" Name="Output" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="S8tREYcGT9hNiVBNT5EZIy" Bounds="579,322" />
@@ -51290,6 +51396,7 @@
                   <Pin Id="C0EABfbjcLwNZxyzTHYHkA" Name="Bounds" Kind="InputPin" />
                   <Pin Id="P38uZclVNjwPrqcxFLylUh" Name="Paint" Kind="InputPin" />
                   <Pin Id="N6p9nTci5wwNATpF5oNTn9" Name="Enabled" Kind="InputPin" />
+                  <Pin Id="NSUdLlMIdPKPGT0zpWkrsJ" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="KLuzgeZrHRZLoaiYDOLbUR" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="827,385" Id="SEHv0qUa4LJQaKJAATQ6j3">
@@ -51390,7 +51497,7 @@
                 <ControlPoint Id="Tb5gysgYjrMMkerEAkO5zF" Bounds="841,334" />
                 <ControlPoint Id="IrptBZ3dN9mQXoS3vI3iMD" Bounds="919,334" />
                 <ControlPoint Id="Tas0W0xDlgAMH6fIQgPV5H" Bounds="1077,745" />
-                <Node Bounds="809,671,114,93" Id="AqtsfJctPInN5HN9u1IlA9">
+                <Node Bounds="809,667,116,94" Id="AqtsfJctPInN5HN9u1IlA9">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -51411,7 +51518,7 @@
                       <Pin Id="OaGMBRfyXvJPiV2qbREi4X" Name="Value" Kind="InputPin" />
                       <Pin Id="IPxGRCjHKqDM1fnAxN55aD" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="882,694,29,13" Id="H60KwWIOgWiQWD1DAqiqy6">
+                    <Node Bounds="876,690,37,19" Id="H60KwWIOgWiQWD1DAqiqy6">
                       <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="NOT" />
@@ -51423,7 +51530,7 @@
                 </Node>
                 <ControlPoint Id="LxmZEeNFoylMbVuYZTb4ob" Bounds="997,334" />
                 <ControlPoint Id="OGmH1sw5qRMMbd4xUZcYJA" Bounds="1075,334" />
-                <Node Bounds="930,376,46,13" Id="K845lnJhvRGMezkiCE56R8">
+                <Node Bounds="930,360,46,19" Id="K845lnJhvRGMezkiCE56R8">
                   <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="StringType" Name="String" />
@@ -51438,7 +51545,7 @@
                   <Pin Id="BNiTulU68zrM1IX8upC3Lv" Name="Options" Kind="InputPin" />
                   <Pin Id="KxgcUJXGbXwOPKGiJrzPI0" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="930,401,37,22" Id="DdsWNVIlWMQMmENUYTTF5Q">
+                <Node Bounds="930,390,44,26" Id="DdsWNVIlWMQMmENUYTTF5Q">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Count" />
@@ -51447,7 +51554,7 @@
                   <Pin Id="HzXFJf3sFqcMkkrIKNWseS" Name="Input" Kind="StateInputPin" />
                   <Pin Id="H7u01VM5u5tOIqRLW2tr8U" Name="Count" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="930,436,25,13" Id="EbLwDyXlQh6OVxfNUO3hvI">
+                <Node Bounds="930,430,25,19" Id="EbLwDyXlQh6OVxfNUO3hvI">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -51633,6 +51740,7 @@
                   <Pin Id="TzJ1egiGIE9M8DBAZYyzvZ" Name="Arg" Kind="InputPin" />
                   <Pin Id="RLWH7044giKLI3VhKZX8r6" Name="Key" Kind="InputPin" />
                   <Pin Id="BIDlP8Kcau0Ly7DLjj8rG1" Name="Color" Kind="InputPin" />
+                  <Pin Id="OQWosaa1vgTMkmtJm1nbOs" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="RTBQEYNHUaYLhozovwP28u" Name="Layer" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="312,397,193,115" Id="S68QUG4XvnXP95Cg3MVM2k">
@@ -51791,6 +51899,7 @@
                   <Pin Id="B7afCvdOC0mMp5roEoceWi" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QoF2BFQicqVPG5pqDWqBOo" Name="Input" Kind="InputPin" />
                   <Pin Id="VklBJwDqxkuLQsXGvqTjpZ" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="JCl23N51RMXL3lOCPmBrzj" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="CZMgMrj4c40N5afzYARAOI" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="955,477,119,13" Id="LcLqSt8csw3NxOkwLGpX9e">
@@ -51834,6 +51943,7 @@
                     <Choice Kind="ProcessAppFlag" Name="Console" />
                   </p:NodeReference>
                   <Pin Id="G9Abn07Mzm1PutMOvjtsjB" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="BvOK4Y7H8UNNMmppV6Z39k" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="JfqlMnE5uKJM5W6RHRWADf" Name="Output" Kind="OutputPin" />
                   <Pin Id="KtBu6KJaJp3LhMh6bQZ8K8" Name="Mouse" Kind="OutputPin" />
                   <Pin Id="JVpjkdOoCX0OSy9zeb1ClS" Name="Keyboard" Kind="OutputPin" />
@@ -51851,6 +51961,7 @@
                   <Pin Id="HDy6Qxcb3PGQCrnmKGerLc" Name="Initial Result" Kind="InputPin" />
                   <Pin Id="FupmUre3g5sPf5Xu1jKepr" Name="Async Notifications" Kind="InputPin" />
                   <Pin Id="JF3TKdu34YIMlNchGkDZoJ" Name="Reset" Kind="InputPin" />
+                  <Pin Id="QEMRZP1OA38OdNlG9YsmGj" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="UeVRdJ3GbABPhTnwmGgNPT" Name="Value" Kind="OutputPin" />
                   <Pin Id="IIpTcmgEVqiQZ8wF8zfbFL" Name="On Data" Kind="OutputPin" />
                 </Node>
@@ -53998,6 +54109,7 @@
                   <Pin Id="BGW8778ZRCoMDIzY34BwWT" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="RucVLvr3A5fLH5GQ58zxqv" Name="Input" Kind="InputPin" />
                   <Pin Id="NkuTolIkRkTMWT8WPQLVjq" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="DUbJW22AZmKQNcLsqMc6S5" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="FE2o8kRLj74LHYAgx1tzTE" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="922,681,66,13" Id="CbTs76sJf9UMR28AKSAALK">
@@ -54378,6 +54490,7 @@
                       <Pin Id="BUijZ3Ew7sVMip4mwrNf9W" Name="Arg" Kind="InputPin" />
                       <Pin Id="G0fNXvIBVlmPlRFROv0rr9" Name="Key" Kind="InputPin" />
                       <Pin Id="PmsZCyKfs6qOYYKUDPE2oa" Name="Color" Kind="InputPin" />
+                      <Pin Id="Uj3sjO5joyPM0tpoF9SdJw" Name="Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="VpkczDqCof3LcfrG4zL0R9" Name="Layer" Kind="OutputPin" />
                     </Node>
                     <ControlPoint Id="Rv02pCRbBxvOMbrU4v5o7d" Bounds="999,613" />
@@ -54661,6 +54774,7 @@
                   <Pin Id="KAPmWR9ZLPOLl43CqBqgvK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OoHm9shhpDdNE1E8qNFYWY" Name="Input" Kind="InputPin" />
                   <Pin Id="RVX6VEDenjsM8ykdqkzVvc" Name="Behavior" Kind="InputPin" />
+                  <Pin Id="JFwGYrLfp26OTSbHpVqxPX" Name="State Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="U06KrkkNYgLLfJ1jLClB3j" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="922,681,66,19" Id="QDzs7OBtZJONyaQLGfYmY6">
@@ -54707,6 +54821,7 @@
                     </p:TypeAnnotation>
                   </Pin>
                   <Pin Id="RNC8E7zGyQFQIFb9IIDWup" Name="Show" Kind="InputPin" />
+                  <Pin Id="RdSgAQRmubiOMdqGKzkIVc" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="FZRnqSUQmuLNoTZ0JYvJtv" Name="Result" Kind="OutputPin" />
                   <Pin Id="VreeOLE1J7eN1K6Abtfv2A" Name="Ok" Kind="OutputPin" />
                 </Node>
@@ -57041,6 +57156,7 @@
                   <Choice Kind="ProcessAppFlag" Name="Console" />
                 </p:NodeReference>
                 <Pin Id="BN3WfG6xpKdMnlTDRzFC7C" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="CQ8VUtgIRzGLFXPBwrlUzN" Name="State Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="N5C3rRpA5sRLkXUxvdhGJy" Name="Output" Kind="OutputPin" />
                 <Pin Id="RcYtsc8kbA4PkOAkvoVPs6" Name="Mouse" Kind="OutputPin" />
                 <Pin Id="Sl4mQrGYsu7NcFUpDNz5Av" Name="Keyboard" Kind="OutputPin" />
@@ -60074,10 +60190,10 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="NmO8BLlLkkrLhmrxGJlRkg" Location="VL.Skia" Version="2024.6.7" />
+  <NugetDependency Id="NmO8BLlLkkrLhmrxGJlRkg" Location="VL.Skia" Version="2025.7.0" />
   <DocumentDependency Id="ETE2iTXTdoxQGRj8Tzm6em" Location="../VVVV.Schema.Core.vl" />
   <DocumentDependency Id="OF1xjDW2Ka9Nl5uUpZUJbE" Location="../domj.Skia.UI.vl" />
-  <NugetDependency Id="P0X3ARZHTqQPYAg7ph7ovu" Location="VL.EditingFramework" Version="2024.6.7" />
+  <NugetDependency Id="P0X3ARZHTqQPYAg7ph7ovu" Location="VL.EditingFramework" Version="2025.7.0" />
   <DocumentDependency Id="Scv1As6OHMbMvwmfrzy4lT" Location="../VL.LinearSpread.vl" />
   <PlatformDependency Id="FqHYafFksHVLzQvxf8hUve" Location="System.Windows.Forms" />
   <PlatformDependency Id="HCnVHuXL8C8Pi2cSxQZBkF" Location="System.Drawing.Primitives" />
@@ -60098,7 +60214,7 @@
   <DocumentDependency Id="Sa5niKD1Rj7PhRDuBGDykj" Location="../Extensions/Links/Schema.Extensions.Links.vl" />
   <DocumentDependency Id="HasfByo9rSgPIzXcKeZ0VT" Location="../Persistence/Schema.Persistence.vl" />
   <PlatformDependency Id="K1DWgAhI7W2NpxjtTEe8qM" Location="../../lib/SchemaIcon.dll" />
-  <NugetDependency Id="CFsHKaVoXRBNwfGOpldAex" Location="VL.CoreLib.Windows" Version="2024.6.7" />
+  <NugetDependency Id="CFsHKaVoXRBNwfGOpldAex" Location="VL.CoreLib.Windows" Version="2025.7.0" />
   <DocumentDependency Id="TFRHJSuabFXOylziJpQObq" Location="../VL.Schema.Windows.vl" />
   <ProjectDependency Id="LhCR3C4lielLJ7SwdxJqof" Location="./csharp/Schema.UI/Schema.UI.csproj" />
   <DocumentDependency Id="EzlYRjJ0mHxQOqWpaZZXDr" Location="./Input/Schema.UI.Input.vl" />

--- a/Main/vl/Utilities/Schema.Utilities.Logging.vl
+++ b/Main/vl/Utilities/Schema.Utilities.Logging.vl
@@ -1,0 +1,350 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="V2f0lfiVShiN1BTrSYn3ev" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="LMoPcYCvMYjLLson5hcfMA" Location="VL.CoreLib" Version="2025.7.0" />
+  <Patch Id="Sfe6fV5ugndNkNG1PUj62d">
+    <Canvas Id="TPyB1ZhSMUaOytHGSj5nKr" DefaultCategory="Schema.Utilities.Logging" CanvasType="FullCategory">
+      <!--
+
+    ************************ LogInfo (String) ************************
+
+-->
+      <Node Name="LogInfo (String)" Bounds="114,80,185,119" Id="E3kugocfCvXLffwgHvRJvQ">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="UOCQykreZAjPDDlGmpaUQE">
+          <Pad Id="GyGazBHeDljLLKxMnUmfs2" Comment="Category" Bounds="194,108,30,19" ShowValueBox="true" isIOBox="true" Value="Info">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="FOyNjohiyd0Pa1sMsZuslG" Bounds="129,107" />
+          <Pin Id="BVPKgSQ3IIwLwl2RS62yKD" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="MT20Qo35XmPN3K4TT0Yjkr" Ids="BVPKgSQ3IIwLwl2RS62yKD,FOyNjohiyd0Pa1sMsZuslG" IsHidden="true" />
+          <Node Bounds="126,160,72,19" Id="TkblGKnmbLrNimqT4NDMwl">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
+            </p:NodeReference>
+            <Pin Id="N4vE5devwCJPnMP17lYWGj" Name="Message" Kind="InputPin" />
+            <Pin Id="T3tqNwDzQqHPYhKQGzVrDU" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="QJQ97se49e0P5C3myc4AD4" Ids="FOyNjohiyd0Pa1sMsZuslG,N4vE5devwCJPnMP17lYWGj" />
+          <Link Id="KW52Y0cK272QKRPCaHHfTW" Ids="GyGazBHeDljLLKxMnUmfs2,T3tqNwDzQqHPYhKQGzVrDU" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogMessage (Generic) ************************
+
+-->
+      <Node Name="LogMessage (Generic)" Bounds="153,546,167,118" Id="Q9vIPCRtDtwLaFva3UuS8m">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="AbK1YKjxag1OyVFmUogbK7" IsGeneric="true">
+          <ControlPoint Id="NEmMXPYqPYkOYIW0JfWytX" Bounds="167,566" />
+          <Pin Id="K1Z8y2EwbWIPbagF1VM6fu" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="QWe78h2kLOfPOc1tozuXsG" Ids="K1Z8y2EwbWIPbagF1VM6fu,NEmMXPYqPYkOYIW0JfWytX" IsHidden="true" />
+          <ControlPoint Id="Ah7pa5bQgboQVgI0Qw1MPZ" Bounds="256,564" />
+          <Pin Id="GB8HMm6xubrL1JysgCFqRi" Name="Category" Kind="InputPin" Bounds="358,476" />
+          <Link Id="M8g37I5NNbdMc9L7nuM9Xq" Ids="GB8HMm6xubrL1JysgCFqRi,Ah7pa5bQgboQVgI0Qw1MPZ" IsHidden="true" />
+          <Node Bounds="166,588,65,19" Id="KGiMFaZnhahNEgdlGG6mve">
+            <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="ToString" />
+            </p:NodeReference>
+            <Pin Id="IF02PSTP8yFOOXegFTk1fo" Name="Input" Kind="InputPin" />
+            <Pin Id="BqQrLZqj1X8OiP8LkMRX9S" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Link Id="TfnnfzvLkRnQOW2rNHorG5" Ids="NEmMXPYqPYkOYIW0JfWytX,IF02PSTP8yFOOXegFTk1fo" />
+          <Node Bounds="166,625,72,19" Id="J6Vv790QHDMNZKECPlURSo">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
+            </p:NodeReference>
+            <Pin Id="NgZov2sbrkBL9AhfxEwG5K" Name="Message" Kind="InputPin" />
+            <Pin Id="Rq4BcZOd1haNel3vNS7qHm" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="MSpGSLNx5UoQcg77SpkGEg" Ids="BqQrLZqj1X8OiP8LkMRX9S,NgZov2sbrkBL9AhfxEwG5K" />
+          <Link Id="LBfhkQ0B2sMPcnv59laKuU" Ids="Ah7pa5bQgboQVgI0Qw1MPZ,Rq4BcZOd1haNel3vNS7qHm" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogMessage (String) ************************
+
+-->
+      <Node Name="LogMessage (String)" Bounds="378,551,170,206" Id="PnjxOofFd6FPPNhxhzkovk">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="CMbNuhRKJvpPipzSH4XCmv" IsGeneric="true">
+          <ControlPoint Id="H3XSBZ1kNsUP9gQCI4MhhL" Bounds="395,571" />
+          <Pin Id="VGPB1Waxp39P13YBGjWtcF" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="KsvgZrSHjQPPoDPFBc2LC0" Ids="VGPB1Waxp39P13YBGjWtcF,H3XSBZ1kNsUP9gQCI4MhhL" IsHidden="true" />
+          <Node Bounds="390,711,58,26" Id="HZtSdPgIzBiP4ZXjN6esEV">
+            <p:NodeReference LastCategoryFullName="System.Console" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="WriteLine" />
+              <CategoryReference Kind="ClassType" Name="Console" NeedsToBeDirectParent="true" />
+            </p:NodeReference>
+            <Pin Id="Vn21VgJWednQYbPaCoV1Ng" Name="Value" Kind="InputPin" />
+            <Pin Id="K8YEOqMSg7PPp5a91bQehT" Name="Apply" Kind="InputPin" DefaultValue="True">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
+          </Node>
+          <ControlPoint Id="NEPc6rUurn6QZ5OBT2AAjc" Bounds="484,569" />
+          <Pin Id="Ax74vNHIdCMLDTqLuYMOni" Name="Category" Kind="InputPin" Bounds="358,476" />
+          <Link Id="MQ3S5jyiNApOBcK4LgQGuk" Ids="Ax74vNHIdCMLDTqLuYMOni,NEPc6rUurn6QZ5OBT2AAjc" IsHidden="true" />
+          <Node Bounds="390,604,113,19" Id="B6Z3Slm8sbxPJfWxSPLO8B">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="GetLogMessagePrefix" />
+            </p:NodeReference>
+            <Pin Id="U3hmPBYojP1MUOIotjibww" Name="Category" Kind="InputPin" />
+            <Pin Id="CNwWDM6nYd9OgfZ5ZRdC7U" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Link Id="F1a1BxzTIDwLgM8hPv14d5" Ids="NEPc6rUurn6QZ5OBT2AAjc,U3hmPBYojP1MUOIotjibww" />
+          <Node Bounds="390,680,45,19" Id="BRIBK0gwF6tMkBter2tsAI">
+            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="+" />
+            </p:NodeReference>
+            <Pin Id="Rk9y6SXrs2pPNkLl78WzUX" Name="Input" Kind="InputPin" />
+            <Pin Id="Hw3cX8ZkbE0M34bQiXJxjY" Name="Input 2" Kind="InputPin" />
+            <Pin Id="IPQK0PlcrpkQQNimG6q2qR" Name="Output" Kind="OutputPin" />
+            <Pin Id="F7XiILVQoA7QEOoFWeQiag" Name="Input 3" Kind="InputPin" />
+          </Node>
+          <Link Id="EFnzaI84j0kMSCu8Sqyyt1" Ids="CNwWDM6nYd9OgfZ5ZRdC7U,Rk9y6SXrs2pPNkLl78WzUX" />
+          <Link Id="LBz0gE5ISRRLwOwYo3yLRE" Ids="H3XSBZ1kNsUP9gQCI4MhhL,Hw3cX8ZkbE0M34bQiXJxjY" />
+          <Link Id="U41GJgKGQ7GP5QeiUFVmrF" Ids="IPQK0PlcrpkQQNimG6q2qR,Vn21VgJWednQYbPaCoV1Ng" />
+          <Node Bounds="430,640,54,19" Id="SmDBmnlGveHQTUhbDZcd0g">
+            <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+              <Choice Kind="OperationCallFlag" Name="NewLine" />
+            </p:NodeReference>
+            <Pin Id="K6Z2pOcbOLEQZedTJgVuYj" Name="New Line" Kind="OutputPin" />
+          </Node>
+          <Link Id="RSToI3IO6mAN1I1OUf2bL7" Ids="K6Z2pOcbOLEQZedTJgVuYj,F7XiILVQoA7QEOoFWeQiag" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogInfo (Generic) ************************
+
+-->
+      <Node Name="LogInfo (Generic)" Bounds="120,274,181,111" Id="Jqnb8bynwrcMBo4anV8m03">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="IJZ7giy2ygOQUtlcsI5u9V" IsGeneric="true">
+          <Pad Id="LSNrVTYpB4XLn6jAzD5aEs" Comment="Category" Bounds="196,318,30,19" ShowValueBox="true" isIOBox="true" Value="Info">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="Mrs7YYBOAqBOPeSrqsBAzz" Bounds="140,292" />
+          <Pin Id="Or1iL8X9rLqP8H7knAG2ol" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="NQ5DtfwfABdPPAytof6NA0" Ids="Or1iL8X9rLqP8H7knAG2ol,Mrs7YYBOAqBOPeSrqsBAzz" IsHidden="true" />
+          <Node Bounds="132,346,72,19" Id="DkmCn3nUv5IME3umb3X9ha">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (Generic)" />
+            </p:NodeReference>
+            <Pin Id="COfJuCakanyOgPzQHD59hJ" Name="Message" Kind="InputPin" />
+            <Pin Id="U8XmeQsaC9NMpYznRTfg1B" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="GtjNEgzXW5rLUMpFElJ0zy" Ids="Mrs7YYBOAqBOPeSrqsBAzz,COfJuCakanyOgPzQHD59hJ" />
+          <Link Id="QFxssN4QoBIPyeCiMMU8Hl" Ids="LSNrVTYpB4XLn6jAzD5aEs,U8XmeQsaC9NMpYznRTfg1B" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogWarning (String) ************************
+
+-->
+      <Node Name="LogWarning (String)" Bounds="330,88,185,119" Id="B23w2ZEpX8JPnt8OjNHoNc">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="Ax6gE0p3QC6NQcmop24Snh">
+          <Pad Id="Rovv2c00VYIMmIVMqzldfQ" Comment="Category" Bounds="410,116,30,19" ShowValueBox="true" isIOBox="true" Value="Warning">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="Q3BOy7sLeqcLBMo32EjySy" Bounds="345,115" />
+          <Pin Id="LHDP2YfW8ASP10CMHXTuFi" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="BEfnqmIS4h8LB3nqlPIzfy" Ids="LHDP2YfW8ASP10CMHXTuFi,Q3BOy7sLeqcLBMo32EjySy" IsHidden="true" />
+          <Node Bounds="342,168,72,19" Id="KkGSjToqtg9PU4ZppFH8Sa">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
+            </p:NodeReference>
+            <Pin Id="EZ2xu9cFUMVPb1LVlVGMRX" Name="Message" Kind="InputPin" />
+            <Pin Id="KBJZIJTEJ8tNSDl3Ybu1pi" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="Q5x6eOOeDnYO4XnPrgXEUV" Ids="Q3BOy7sLeqcLBMo32EjySy,EZ2xu9cFUMVPb1LVlVGMRX" />
+          <Link Id="Sy6KT6dtZ1jOAosazRAf3r" Ids="Rovv2c00VYIMmIVMqzldfQ,KBJZIJTEJ8tNSDl3Ybu1pi" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogWarning (Generic) ************************
+
+-->
+      <Node Name="LogWarning (Generic)" Bounds="336,282,181,111" Id="Abwp6iutHQNMlSk1tLMjh3">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="Jy9og2M2MHWOnR79GtGAgN" IsGeneric="true">
+          <Pad Id="SXRI2lSvQ30Ov1R1UYZfWQ" Comment="Category" Bounds="412,326,30,19" ShowValueBox="true" isIOBox="true" Value="Warning">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="FJKSFpiF0BjLBid5UciCo3" Bounds="356,300" />
+          <Pin Id="RxSYGuNu5d3Ph02559ACOv" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="EIh6COOgYNlL9qswTfwZvi" Ids="RxSYGuNu5d3Ph02559ACOv,FJKSFpiF0BjLBid5UciCo3" IsHidden="true" />
+          <Node Bounds="348,354,72,19" Id="IyDYWHktZF5P5M3WvfaIXE">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (Generic)" />
+            </p:NodeReference>
+            <Pin Id="RFWwlKTwXmGMMmpcd1PLWt" Name="Message" Kind="InputPin" />
+            <Pin Id="OtPGLHPjErcMthjmfT5LiR" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="HLwKAWDM525OOFGgdtsKH0" Ids="FJKSFpiF0BjLBid5UciCo3,RFWwlKTwXmGMMmpcd1PLWt" />
+          <Link Id="RDzji4oWxfxMlHfztnKo4d" Ids="SXRI2lSvQ30Ov1R1UYZfWQ,OtPGLHPjErcMthjmfT5LiR" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogError (String) ************************
+
+-->
+      <Node Name="LogError (String)" Bounds="546,96,185,119" Id="IWusYxRKMrNNKdEFPJrAoR">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="DpDdGoLm0IJOIgN9hbd3h3">
+          <Pad Id="ACusVhRaa3sOtBLVRuISGn" Comment="Category" Bounds="626,124,30,19" ShowValueBox="true" isIOBox="true" Value="Error">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="UPTx73opSFsP4GKerYewJo" Bounds="561,123" />
+          <Pin Id="KNyoeGX4vhZPr4ou4wUi7i" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="Lq8JHImGkyyNvA8M419wP4" Ids="KNyoeGX4vhZPr4ou4wUi7i,UPTx73opSFsP4GKerYewJo" IsHidden="true" />
+          <Node Bounds="558,176,72,19" Id="RHNhAc5gkhrLDskUNiUoAS">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
+            </p:NodeReference>
+            <Pin Id="Bf65lelJbgUPEjY65WP09l" Name="Message" Kind="InputPin" />
+            <Pin Id="VFuetstCrQ2K983ku5j984" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="HF9gUA8crHEObOUNTyCCgj" Ids="UPTx73opSFsP4GKerYewJo,Bf65lelJbgUPEjY65WP09l" />
+          <Link Id="Fvf9aGnzScZMqPFbpusNqC" Ids="ACusVhRaa3sOtBLVRuISGn,VFuetstCrQ2K983ku5j984" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ LogError (Generic) ************************
+
+-->
+      <Node Name="LogError (Generic)" Bounds="552,290,181,111" Id="L8Sw50BIIrzPeuh7vxP6Ng">
+        <p:NodeReference>
+          <Choice Kind="OperationDefinition" Name="Operation" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="Sld5RMNXR8jPLoVz68KCj9" IsGeneric="true">
+          <Pad Id="B10fIdSx8kuLUncF72cIbi" Comment="Category" Bounds="628,334,30,19" ShowValueBox="true" isIOBox="true" Value="Error">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pad>
+          <ControlPoint Id="KvM1nLsxePSOGX7q781qZ1" Bounds="572,308" />
+          <Pin Id="Od99fQHVRcwPPsJg5wFA9v" Name="Message" Kind="InputPin" Bounds="250,201" />
+          <Link Id="UGIUIwqKkOKM8vhWRv1U4s" Ids="Od99fQHVRcwPPsJg5wFA9v,KvM1nLsxePSOGX7q781qZ1" IsHidden="true" />
+          <Node Bounds="564,362,72,19" Id="ORIkcSDnAnXNVwO5sIoRxv">
+            <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="LogMessage (Generic)" />
+            </p:NodeReference>
+            <Pin Id="HUWnP67nQW9Md82qy4Ny5j" Name="Message" Kind="InputPin" />
+            <Pin Id="ABKBMyw02LqNbzPmtj7MWi" Name="Category" Kind="InputPin" />
+          </Node>
+          <Link Id="Rz34pbsIJ0kMt2bOrlFVqS" Ids="KvM1nLsxePSOGX7q781qZ1,HUWnP67nQW9Md82qy4Ny5j" />
+          <Link Id="SPoXNO1siLtMZEgOfI9Hy9" Ids="B10fIdSx8kuLUncF72cIbi,ABKBMyw02LqNbzPmtj7MWi" />
+        </Patch>
+      </Node>
+      <!--
+
+    ************************ GetLogMessagePrefix (Internal) ************************
+
+-->
+      <Node Name="GetLogMessagePrefix (Internal)" Bounds="635,558,81,101" Id="Brse0p00hNaLRBtMlQsNfx">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+          <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
+          <Choice Kind="OperationDefinition" Name="Operation" />
+        </p:NodeReference>
+        <Patch Id="JizR7XJYAt2PdSYjKNut8q">
+          <ControlPoint Id="M9IskhVi4JZObvRSR6ZGpq" Bounds="649,576" />
+          <Link Id="IoAUnawY2PJOrT4NJl4KEk" Ids="IOITtETILgvLetpx1w8jnN,M9IskhVi4JZObvRSR6ZGpq" IsHidden="true" />
+          <Node Bounds="657,599,45,19" Id="C5Iv4GdLdXKM0erOwyeL5W">
+            <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="+" />
+            </p:NodeReference>
+            <Pin Id="ExwgEjPHgvMObsfx27cPrt" Name="Input" Kind="InputPin" DefaultValue="[" />
+            <Pin Id="MMPTx4VZuyzL9p2Yk0OhFZ" Name="Input 2" Kind="InputPin" />
+            <Pin Id="GfC2hmryXmfMVkzzmw00ct" Name="Output" Kind="OutputPin" />
+            <Pin Id="T1iJq8qxhhyLYliDhE82qT" Name="Input 3" Kind="InputPin" DefaultValue="] " />
+          </Node>
+          <Link Id="SXs5U2FZNgGOVu2UZPzc0Y" Ids="M9IskhVi4JZObvRSR6ZGpq,MMPTx4VZuyzL9p2Yk0OhFZ" />
+          <Pin Id="IOITtETILgvLetpx1w8jnN" Name="Category" Kind="InputPin" Bounds="358,476">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+          </Pin>
+          <ControlPoint Id="RwJ2PkYJGfvNubF1BcNQYG" Bounds="661,642" />
+          <Link Id="JX83nfhs1J1QYDpyRksT5g" Ids="GfC2hmryXmfMVkzzmw00ct,RwJ2PkYJGfvNubF1BcNQYG" />
+          <Pin Id="GtJFlYwZoTRO3Lmq6lap7r" Name="Output" Kind="OutputPin" Bounds="753,511" />
+          <Link Id="Dgd87xFds8CNnlZVVJhlLI" Ids="RwJ2PkYJGfvNubF1BcNQYG,GtJFlYwZoTRO3Lmq6lap7r" IsHidden="true" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="A0zOLUaaZHcPhFibBJL3hG">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <CategoryReference Kind="Category" Name="Primitive" />
+      </p:NodeReference>
+      <Patch Id="UimmDaHnotONOremazfG3P">
+        <Canvas Id="J957DvUKdrYO4iptYwzIhP" CanvasType="Group" />
+        <Patch Id="LUVXGDa5IoCNIVZhMIRHR5" Name="Create" />
+        <Patch Id="GkYBkBxX0LbOdpOIELGquc" Name="Update" />
+        <ProcessDefinition Id="LwdN5mSZfvTNFF6tkqbc0M">
+          <Fragment Id="A5knCI5uAp0LdWKyQPMNJL" Patch="LUVXGDa5IoCNIVZhMIRHR5" Enabled="true" />
+          <Fragment Id="EqWznNjq3gkPR9LFrLvnSd" Patch="GkYBkBxX0LbOdpOIELGquc" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+</Document>

--- a/Main/vl/VVVV.Schema.Core.vl
+++ b/Main/vl/VVVV.Schema.Core.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="NavXg4rbp7DOs3twJZ1RLi" LanguageVersion="2024.6.7" Version="0.128">
-  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2024.6.7" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="NavXg4rbp7DOs3twJZ1RLi" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="Th8hpfHvBF4Lk6VOwDCc9D">
     <Canvas Id="NtZT52Xp5qNOXK0fF2H7kv" DefaultCategory="VVVV.Schema" CanvasType="FullCategory">
       <Canvas Id="ACGTwDN2TwVPdWleiRveRH" Name="Import" Position="-677,-490">
@@ -2317,6 +2317,7 @@
                 <Pin Id="JxiuVNVmghFOqbS9KHaZgo" Name="Initial Result" Kind="InputPin" />
                 <Pin Id="GOLvDq5h1H3ODeBKZ22Hyj" Name="Async Notifications" Kind="InputPin" />
                 <Pin Id="S4qkYQe7AiGM9yBq7pONGH" Name="Reset" Kind="InputPin" />
+                <Pin Id="QTLw43UWlc2OvthqgyC0Gp" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="OSwrZ9r9k9EM4KZLMQSjiN" Name="Value" Kind="OutputPin" />
                 <Pin Id="HieK53HZJleOGTyTypwkmU" Name="On Data" Kind="OutputPin" />
               </Node>
@@ -5265,7 +5266,6 @@
                                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                                 <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
                               </p:NodeReference>
-                              <Pin Id="H81L80fpgVHLFT2UZieoQH" Name="Node Context" Kind="InputPin" IsHidden="true" />
                               <Pin Id="AZuwDi5GYADOicca1lXLpA" Name="Default Output" Kind="InputPin" />
                               <Pin Id="CcAOTgt7LJ9MU1yZaKZkEp" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
                               <Pin Id="BbKciPrAbKYNoQPFYsHZ7u" Name="Result" Kind="OutputPin" />
@@ -5499,13 +5499,13 @@
     ************************ RegisterSourceColorBlocks ************************
 
 -->
-            <Node Name="RegisterSourceColorBlocks" Bounds="591,142,385,278" Id="KF5osJJtjLGOwsxU8KK7yU">
+            <Node Name="RegisterSourceColorBlocks" Bounds="591,139,388,281" Id="KF5osJJtjLGOwsxU8KK7yU">
               <p:NodeReference>
                 <Choice Kind="OperationDefinition" Name="Operation" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
               <Patch Id="RCJSul3fKgEO5YYczQEaFx">
-                <Node Bounds="665,215,109,94" Id="REaEwhwbg82M3btzjt1roP">
+                <Node Bounds="665,215,110,94" Id="REaEwhwbg82M3btzjt1roP">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5517,7 +5517,7 @@
                   <Patch Id="LwkHbb54kdENgQK0AHnVVB" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="BAlRVfa4TZwO8HovjcMs73" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="FsXdGoLSBpxOJpInQvLmFt" Bounds="669,300" />
-                    <Node Bounds="681,238,81,13" Id="RKd540K57vbMRIBEprWLMo">
+                    <Node Bounds="681,238,82,26" Id="RKd540K57vbMRIBEprWLMo">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Color.GlobalColorSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5544,7 +5544,7 @@
                 <Link Id="DJDfW9jpgfDMpogr1M2ueC" Ids="QCFrP4ma00LPbSgU5DeKRd,RVKUWCMGA3tNeEvAleyCvw" />
                 <Pin Id="IhK39MwqWpVPssF8AK0YUF" Name="Output" Kind="OutputPin" Bounds="645,358" />
                 <Link Id="HtFLkj98GuBOeSFm7CLqwi" Ids="Vud8MAVyTNcO2RssSNbMDd,IhK39MwqWpVPssF8AK0YUF" IsHidden="true" />
-                <Node Bounds="661,342" Id="T47gstSGpidPxkH4gC03hV">
+                <Node Bounds="661,342,158,19" Id="T47gstSGpidPxkH4gC03hV">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.Registry.Source" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="RegisterSourceColorPixelBlocks" />
@@ -5560,13 +5560,13 @@
     ************************ RegisterSourcePositionBlocks ************************
 
 -->
-            <Node Name="RegisterSourcePositionBlocks" Bounds="1160,864,467,403" Id="LC2mrxpf7uFQTyv8oQbbiR">
+            <Node Name="RegisterSourcePositionBlocks" Bounds="1160,861,469,406" Id="LC2mrxpf7uFQTyv8oQbbiR">
               <p:NodeReference>
                 <Choice Kind="OperationDefinition" Name="Operation" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
               <Patch Id="Pew4LkDznolMyVB6KavWA6">
-                <Node Bounds="1234,937,108,94" Id="OQ8be6fwTLaPahuQ8r8xwp">
+                <Node Bounds="1233,937,109,94" Id="OQ8be6fwTLaPahuQ8r8xwp">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5578,7 +5578,7 @@
                   <Patch Id="C6CDv6xOghjQYf0VIUvBwR" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="VAw6ZbPhLFdP70nwDFBIP9" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="LXQxXVGqWNSOCAGRiuWkZ0" Bounds="1237,1022" />
-                    <Node Bounds="1249,960,81,22" Id="SoqdahTozj4NQ5X1ke1rRm">
+                    <Node Bounds="1249,960,81,26" Id="SoqdahTozj4NQ5X1ke1rRm">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Position.Current" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Current" />
@@ -5604,7 +5604,7 @@
                 <Link Id="J6FwDvtJUOkMyMDOrU9nid" Ids="Df2OgNRGK5XO39b5Q48V9O,SZSd7r1NLNtMtHwJLcabts" />
                 <Link Id="URwYMXXBT3eMCXZVnlM9u6" Ids="CwMJMsTbNLRO1L7lfUTjR3,Df2OgNRGK5XO39b5Q48V9O" IsHidden="true" />
                 <Link Id="Tk9ZTA4rZGGPvdJoJUHBBz" Ids="Aqxt4jXUUAFM8nfjYn3dJv,EneHZamGrxRPafyrFC9G2i" IsHidden="true" />
-                <Node Bounds="1276,1116,108,94" Id="FbsgAQ9Hkt9MmMfYx78uiC">
+                <Node Bounds="1275,1116,110,94" Id="FbsgAQ9Hkt9MmMfYx78uiC">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5616,7 +5616,7 @@
                   <Patch Id="BEnv2FUvAZUM32mNyUGIfp" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="ERiRUvO8OiwMWK8KpfyGhX" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="GMqEoe4RcnuNXWkTYgo7LF" Bounds="1279,1201" />
-                    <Node Bounds="1291,1139,81,22" Id="U1JVy6V83yfMWSuT1BmitT">
+                    <Node Bounds="1291,1139,82,26" Id="U1JVy6V83yfMWSuT1BmitT">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Position.XYZPositionSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5644,13 +5644,13 @@
     ************************ RegisterSourceValueBlocks ************************
 
 -->
-            <Node Name="RegisterSourceValueBlocks" Bounds="1058,70,422,545" Id="I2sZ5bTToLGLkQUMq6I3Dr">
+            <Node Name="RegisterSourceValueBlocks" Bounds="1058,68,425,547" Id="I2sZ5bTToLGLkQUMq6I3Dr">
               <p:NodeReference>
                 <Choice Kind="OperationDefinition" Name="Operation" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:NodeReference>
               <Patch Id="C9KEHiD2dkgPjWAevJ2Rtw">
-                <Node Bounds="1132,144,108,94" Id="SnEfrSUwrLqL9yAduusqBo">
+                <Node Bounds="1131,144,109,94" Id="SnEfrSUwrLqL9yAduusqBo">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5662,7 +5662,7 @@
                   <Patch Id="RYREp8O8e11QA79RIiRPkJ" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="NLxqFAoZD21Li5e9yTW52f" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="Sq4huTS13R2QdBrk6JmCJG" Bounds="1135,229" />
-                    <Node Bounds="1147,167,81,22" Id="Acu2SZc5xp2M6MOVkIPHA1">
+                    <Node Bounds="1147,167,81,26" Id="Acu2SZc5xp2M6MOVkIPHA1">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.Global" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="Category" Name="Global" />
@@ -5691,7 +5691,7 @@
                 <Link Id="KajSFGLus5JLMp3AW5AwzT" Ids="B3n6X68NcpNK9VzifmVBfR,Mnr6pAVeF8JMJ0GXk7rqUn" />
                 <Link Id="TYIeD8TwK2WMCq4NEiPnX1" Ids="GOMwBF24dz8LVJbVM28Nqh,B3n6X68NcpNK9VzifmVBfR" IsHidden="true" />
                 <Link Id="AGykepBunwHLUMwFiUyMYr" Ids="VcLbiwnO5J7Qc98ii9A2Au,JB4v3CQ5YfxOmPQMnmUWwF" IsHidden="true" />
-                <Node Bounds="1132,275,108,94" Id="E1lxRqbbHUDQVdiU0h4hqS">
+                <Node Bounds="1132,275,109,94" Id="E1lxRqbbHUDQVdiU0h4hqS">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5703,7 +5703,7 @@
                   <Patch Id="Ktg2B4ffRkNOFQeiFWEjtR" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="IFQPW1K5jnVPZ2YcTWQYdO" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="S2pXc6P9efFLKotchaYdz4" Bounds="1136,360" />
-                    <Node Bounds="1148,298,81,22" Id="CoO52jthITqMVRmAYEYL47">
+                    <Node Bounds="1148,298,81,26" Id="CoO52jthITqMVRmAYEYL47">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.Expression" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Expression" />
@@ -5723,7 +5723,7 @@
                 <Link Id="FQ6LXlFfPMtLyrdWCSMZrZ" Ids="GuzpplHryqVNQGNuXliVT5,S2pXc6P9efFLKotchaYdz4" />
                 <Link Id="Ggtrd4eNwBUNut13uBUV8t" Ids="FUpjQLrTVkIMm07zQGpGDG,A0G6WIJGYpYOxCQrsEZDgI" />
                 <Link Id="T5zMbCghlNXOaFXxLo7kRG" Ids="NBkwYWoaDRpNIDdf4k1nJb,DucvP1oNGWlNZu98I3QJ58" />
-                <Node Bounds="1133,408,109,94" Id="DG9G1uplLyaLYGtLlFHqe3">
+                <Node Bounds="1133,408,114,94" Id="DG9G1uplLyaLYGtLlFHqe3">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5735,7 +5735,7 @@
                   <Patch Id="RYfFmRStUN0Pul43Jp6mug" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="BQCEr7jAqMvLWb5n1Hf3wU" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="FSBbdWOkKioLIUM28xPMaf" Bounds="1137,493" />
-                    <Node Bounds="1149,431,81,22" Id="SjGu8XiCK9lQKHIy5mSz7u">
+                    <Node Bounds="1149,431,86,26" Id="SjGu8XiCK9lQKHIy5mSz7u">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.TriggerValueSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5756,7 +5756,7 @@
                 <Link Id="KjaebawhtlqMJ2XdqLxwcq" Ids="JtxE6d7fzL5PHFV5Q62RqG,LWZl6H7xhatLW1vwFi2beE" />
                 <Link Id="PDioLkhB2ApPY02XiWNZoS" Ids="L8XICEHj8Y0NkOWlhsmDSh,ExmTSVGdCSHO7i2QCOWaQw" />
                 <Link Id="LnspMdfD70RNflann9oczp" Ids="EOo9lv12oM9Mx6GmsRw9kA,DPw8Q9hajM7NTsnBumlTLi" />
-                <Node Bounds="1135,542" Id="CnodDznbWOaLROYDh3f28K">
+                <Node Bounds="1135,542,164,19" Id="CnodDznbWOaLROYDh3f28K">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.Registry.Source" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="RegisterSourceValueAudioBlocks" />
@@ -5772,12 +5772,12 @@
     ************************ RegisterSourceColorPixelBlocks (Internal) ************************
 
 -->
-            <Node Name="RegisterSourceColorPixelBlocks (Internal)" Bounds="585,594,410,630" Id="J0OTCmxHiLCNGFzStwyK6D">
+            <Node Name="RegisterSourceColorPixelBlocks (Internal)" Bounds="585,594,417,630" Id="J0OTCmxHiLCNGFzStwyK6D">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="IDKU4d1BMnBNhhdXPg7R96">
-                <Node Bounds="654,657,109,94" Id="S5CAoc9B6Q4NECHa3RvaHL">
+                <Node Bounds="654,657,136,94" Id="S5CAoc9B6Q4NECHa3RvaHL">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5789,7 +5789,7 @@
                   <Patch Id="FAR7ZSwKDtpMIeYY2VP56r" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="MzlBEJKzxVENkgSQ6i9Jxs" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="GGJE73FYdOCO5197MiyiQv" Bounds="658,742" />
-                    <Node Bounds="670,680,81,13" Id="IBMuyArVXJ5M4Tui1tRYd7">
+                    <Node Bounds="670,680,108,26" Id="IBMuyArVXJ5M4Tui1tRYd7">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Color.Pixel.PointDistanceColorSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5805,7 +5805,7 @@
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="654,777,109,94" Id="Q0ws3cFR1J6Mzn6bsNhJq2">
+                <Node Bounds="654,777,134,94" Id="Q0ws3cFR1J6Mzn6bsNhJq2">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5817,7 +5817,7 @@
                   <Patch Id="SGXlkqWUoPFMSGMlcAMW7p" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="CqMyqiLtU7fO58LSa45tOo" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="QNTOIfcYh8hQFj0zOB4xVP" Bounds="658,862" />
-                    <Node Bounds="670,800,81,22" Id="LCF93coZu2FMhAYKAzo57f">
+                    <Node Bounds="670,800,106,26" Id="LCF93coZu2FMhAYKAzo57f">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Color.Pixel.AxisDistanceColorSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5859,7 +5859,7 @@
                   <Patch Id="NvHOIKfb10LMoRwDk4miPR" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="FJcIu1NV53CPjexCo2rPFu" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="NY1qCt2hveXMhGv5RU4P3b" Bounds="658,984" />
-                    <Node Bounds="670,922,81,22" Id="Aclg66NkQ2BMMwv2GSjVOx">
+                    <Node Bounds="670,922,81,26" Id="Aclg66NkQ2BMMwv2GSjVOx">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Color.Pixel.Segment" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5879,7 +5879,7 @@
                 <Link Id="EMB5MDpFAHIOxXcfcGjBWC" Ids="U8ehd6tRYddL65SMoYZiHw,NY1qCt2hveXMhGv5RU4P3b" />
                 <Link Id="TDi7QqHDGXBPy1nvpMToJs" Ids="Hzp16RGq77nOLv8uDzPwlT,Txr1Ons3vBsNopE4MpOGT5" />
                 <Link Id="Shqa0yFFqkDOKU8hPlJQod" Ids="Ku1jvK4Sgs0OYJLDHyxOWg,BJBjE2MPgsSOEjlA86GhkP" />
-                <Node Bounds="660,1044,109,94" Id="RQFeMYcBRJdPlRRU0ttUsw">
+                <Node Bounds="660,1044,137,94" Id="RQFeMYcBRJdPlRRU0ttUsw">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5891,7 +5891,7 @@
                   <Patch Id="JzqUnPZsXYHNFVrx2VJQXW" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="FjKZTK5oNoPOzxNaQlmzNu" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="U8fyBqepDnsOeckhzdTIHR" Bounds="664,1129" />
-                    <Node Bounds="676,1067,81,26" Id="NIo1Mko76oCL1huSRfgyoc">
+                    <Node Bounds="676,1067,109,26" Id="NIo1Mko76oCL1huSRfgyoc">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Color.Pixel.PlaneDistanceColorSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5919,7 +5919,7 @@
     ************************ RegisterSourceSpeedBlocks (Internal) ************************
 
 -->
-            <Node Name="RegisterSourceSpeedBlocks (Internal)" Bounds="291,1332,409,205" Id="FJFYbZdQFuaMaytUG73jHE">
+            <Node Name="RegisterSourceSpeedBlocks (Internal)" Bounds="291,1331,412,206" Id="FJFYbZdQFuaMaytUG73jHE">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
@@ -5936,7 +5936,7 @@
                   <Patch Id="G0BWSItD6yQMun8NSV6Nzv" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="KKYBiQPSJf6LqHKqR6pBQP" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="Qxp928Ew6p3NhFKl28xlrI" Bounds="369,1479" />
-                    <Node Bounds="381,1417,81,13" Id="DsqZylkC4T7Oy4omT1o9jr">
+                    <Node Bounds="381,1417,81,26" Id="DsqZylkC4T7Oy4omT1o9jr">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Speed.Constant" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5972,7 +5972,7 @@
     ************************ RegisterSourceDurationBlocks (Internal) ************************
 
 -->
-            <Node Name="RegisterSourceDurationBlocks (Internal)" Bounds="761,1428,409,205" Id="AhTfWOezshXOWBY0eDOZxi">
+            <Node Name="RegisterSourceDurationBlocks (Internal)" Bounds="761,1427,412,206" Id="AhTfWOezshXOWBY0eDOZxi">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
@@ -5989,7 +5989,7 @@
                   <Patch Id="CLU9yyb0UNCMIHa00hDzzn" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="VFuWCNXl220MD4qBL0ObTe" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="KsAE5DQW3JONiG69SHTqgG" Bounds="839,1575" />
-                    <Node Bounds="851,1513,81,13" Id="G3JO6rUw1v3MkTvPxtctG0">
+                    <Node Bounds="851,1513,81,26" Id="G3JO6rUw1v3MkTvPxtctG0">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Duration.Constant" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -6025,12 +6025,12 @@
     ************************ RegisterSourceValueAudioBlocks (Internal) ************************
 
 -->
-            <Node Name="RegisterSourceValueAudioBlocks (Internal)" Bounds="1590,-67,421,378" Id="BPAfRuAHQZ2NdxI5m5Qt4H">
+            <Node Name="RegisterSourceValueAudioBlocks (Internal)" Bounds="1590,-68,425,379" Id="BPAfRuAHQZ2NdxI5m5Qt4H">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
               <Patch Id="EtHtrwFFkR0Pu83Usq9yVD">
-                <Node Bounds="1664,-18,108,94" Id="TEKr9OqXjLrNIo5CKTzlCb">
+                <Node Bounds="1664,-18,109,94" Id="TEKr9OqXjLrNIo5CKTzlCb">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -6042,7 +6042,7 @@
                   <Patch Id="TYidVuTvddaPGMUr9ejNMQ" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="ApkGMRIVVmOMny9wGxQAXt" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="QsGIVW6zE8rPxL5x9pD5Oc" Bounds="1668,67" />
-                    <Node Bounds="1680,5,81,22" Id="GG9E53ieNnZLw2dxwjYr9r">
+                    <Node Bounds="1680,5,81,26" Id="GG9E53ieNnZLw2dxwjYr9r">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.Beat" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Beat" />
@@ -6080,7 +6080,7 @@
                   <Patch Id="N1wkv4ZqTlCMtw0fYGGuvU" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="DKu8HBjSKYRPpnCfn0WfkS" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="E6B42prPUFrOoY8ZrJhUVI" Bounds="1669,219" />
-                    <Node Bounds="1681,157,81,13" Id="JwubcILfvJePeN8rfq6Uli">
+                    <Node Bounds="1681,157,81,26" Id="JwubcILfvJePeN8rfq6Uli">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.Audio.Level" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Level" />
@@ -6108,7 +6108,7 @@
     ************************ RegisterSourceLayerBlocks ************************
 
 -->
-            <Node Name="RegisterSourceLayerBlocks" Bounds="575,-147,421,205" Id="NgFqNspioKDLBhXX1ABMB4">
+            <Node Name="RegisterSourceLayerBlocks" Bounds="575,-148,424,206" Id="NgFqNspioKDLBhXX1ABMB4">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
@@ -6125,7 +6125,7 @@
                   <Patch Id="Em2pQEKnL4qQPGSFEQUCBm" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="SxBtveMeo7ILAmvobjhjYE" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="HvuCKFtwZXnMEpyqOu4YIh" Bounds="653,0" />
-                    <Node Bounds="665,-62,81,22" Id="Fhw8gmul7WQOVdjkqb6IbN">
+                    <Node Bounds="665,-62,81,26" Id="Fhw8gmul7WQOVdjkqb6IbN">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Layer.Above" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="ClassType" Name="Above" />
@@ -6159,7 +6159,7 @@
     ************************ RegisterSourceTemperatureBlocks (Internal) ************************
 
 -->
-            <Node Name="RegisterSourceTemperatureBlocks (Internal)" Bounds="1180,-273,396,265" Id="EqEdeb5fa4TNqJHOM5HT0Q">
+            <Node Name="RegisterSourceTemperatureBlocks (Internal)" Bounds="1180,-274,399,266" Id="EqEdeb5fa4TNqJHOM5HT0Q">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="OperationDefinition" Name="Operation" />
               </p:NodeReference>
@@ -6176,7 +6176,7 @@
                   <Patch Id="LkP563XRePeMekXwcImkee" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="REXWucCQZNhLFJuKIFmQBH" Name="Result" Kind="OutputPin" />
                     <ControlPoint Id="KsoMLOAYGpBL3lK736CB4O" Bounds="1258,-113" />
-                    <Node Bounds="1270,-175,81,13" Id="GKS1NYRbJJCMqwS748wMwN">
+                    <Node Bounds="1270,-175,81,26" Id="GKS1NYRbJJCMqwS748wMwN">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Temperature.Constant" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="Category" Name="Temperature" />
@@ -12314,7 +12314,7 @@
             <Pin Id="JGOcSPMIsvVL98OIViYxUd" Name="Global" Kind="InputPin" />
             <Pin Id="TcjOciUAlLOLrqMpmxjWu8" Name="New State" Kind="OutputPin" />
             <Pin Id="CL5BjMZbmJLOLnErIuxCF3" Name="Node Operation" Kind="OutputPin" />
-            <Pin Id="IaQjOzMczc1PjTXYQxbZnq" Name="Properties" Kind="InputPin" />
+            <Pin Id="PlJgYR98qLjNUxAcmiDjZ8" Name="Properties" Kind="InputPin" />
           </Patch>
           <Patch Id="KaCaE3sKV3UMVtoT2k9fVI" Name="GetChildren">
             <Pin Id="C0BKrPp9iE9N5esRHhPybU" Name="Children" Kind="OutputPin" />
@@ -13007,13 +13007,13 @@
           <Link Id="C8cmZKeAfHyPP67K7WtHm5" Ids="T29DpogE4b2LdkohUTTmJ3,R6Bo59veWFeNHB6xZ8HqAl" />
           <Patch Id="QFjBE7nZ6v3QIMDO7h0tlZ" Name="Create" />
           <Patch Id="F2GiypGHcmWMNd3KKUzSEV" Name="Update">
-            <Pin Id="QsiHuHyA2uIOJJ8LAWoIoq" Name="Setup" Kind="InputPin" />
+            <Pin Id="DZ5EUykW8QnNz2nFZrPY1t" Name="Setup" Kind="InputPin" />
             <Pin Id="QXu17NLnnfXNcWxWfddTlu" Name="State" Kind="InputPin" />
             <Pin Id="R5iYxD4bMKqNYTC5XMP5wX" Name="New State" Kind="OutputPin" />
-            <Pin Id="D9Kaq3ubLOJOY2cStOsRie" Name="Previous Layer States" Kind="InputPin" />
-            <Pin Id="OYY5aTray5xPReM9zmfsOV" Name="Global" Kind="InputPin" />
-            <Pin Id="VnVUvYtiSGEN0IOfGuGZzO" Name="Properties" Kind="InputPin" />
-            <Pin Id="PPTwuEGmP1LN3otF59oYG2" Name="Node Operation" Kind="OutputPin" />
+            <Pin Id="FeMlqiqlNomNqC62dUCMWu" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="A9hG4K2DLIqQarfMDgXk5B" Name="Global" Kind="InputPin" />
+            <Pin Id="LmzJohIY8h7PZQ3fw8PgYH" Name="Properties" Kind="InputPin" />
+            <Pin Id="VD3SZD4zmtAOWONIRcSB6f" Name="Node Operation" Kind="OutputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -15457,7 +15457,7 @@
                 <Patch Id="NvjEDLP7UGELinv8irrBtN" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="OFBWjugRDsgO3PwPUA9sLg" Name="Update" ManuallySortedPins="true" />
                 <Patch Id="KSdFjajcjOMPBlacQGweGQ" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="86,359,919,349" Id="UlC8ToJ4HbNMXyIMx4kr7V">
+                <Node Bounds="86,359,919,355" Id="UlC8ToJ4HbNMXyIMx4kr7V">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -15466,7 +15466,7 @@
                   <Pin Id="UyMMWsRokxMLg2vr23wHGt" Name="Break" Kind="OutputPin" />
                   <ControlPoint Id="Cv0D4LL4a49QJplY7sbETy" Bounds="489,365" Alignment="Top" />
                   <ControlPoint Id="HF2LOdWz3FVOQVr2CVUaX1" Bounds="422,365" Alignment="Top" />
-                  <ControlPoint Id="Ev1IhkJOY98NwYHZksleHi" Bounds="422,702" Alignment="Bottom" />
+                  <ControlPoint Id="Ev1IhkJOY98NwYHZksleHi" Bounds="422,708" Alignment="Bottom" />
                   <Patch Id="HAERQd8g5oSQFJ4DBLvdq3" ManuallySortedPins="true">
                     <Patch Id="G8eTZ6y12B7MRUM2QtWghT" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="IfCpQQm2NP9LVeypIkDmwh" Name="Update" ManuallySortedPins="true" />
@@ -15492,7 +15492,7 @@
                       <Patch Id="QpnkCCIewsMLO4es8MQUU0" ManuallySortedPins="true">
                         <ControlPoint Id="T5vC5ssaaA2QMsT1EOS0Cf" Bounds="170,473" />
                         <ControlPoint Id="GhX8aIHttUuM3LLR5ltRMq" Bounds="170,627" />
-                        <Node Bounds="242,470,98,22" Id="G7oq6mdrQw3LOqnSizkVkn">
+                        <Node Bounds="242,470,98,26" Id="G7oq6mdrQw3LOqnSizkVkn">
                           <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetRGBASpread" />
@@ -15517,7 +15517,7 @@
                             <Patch Id="IluD8JnTkSjQJVeBN5EVVK" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="ATjXvKWEKo1L6UYC1C9y7s" Name="Update" ManuallySortedPins="true" />
                             <Patch Id="UUsaTW93VLuLyPIXvmKzaL" Name="Dispose" ManuallySortedPins="true" />
-                            <Node Bounds="232,559,25,13" Id="QCyjTMmDv74M0Cu36WcWoN">
+                            <Node Bounds="232,559,25,19" Id="QCyjTMmDv74M0Cu36WcWoN">
                               <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="OperationCallFlag" Name="*" />
@@ -15555,7 +15555,7 @@
                       <Patch Id="B0PASR5t1YgMpmDEeGD4sV" ManuallySortedPins="true">
                         <ControlPoint Id="Hd0gRnhX5LCP8If4ZeInR4" Bounds="440,497" />
                         <ControlPoint Id="BKLLcWQ3Jx9OEpe5yqr2WZ" Bounds="440,577" />
-                        <Node Bounds="465,541,25,13" Id="NraYKmX3ulhLKDZAoTgAvo">
+                        <Node Bounds="465,541,25,19" Id="NraYKmX3ulhLKDZAoTgAvo">
                           <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="*" />
@@ -15565,7 +15565,7 @@
                           <Pin Id="CffWcMdWDv4LuxQfbC2xzR" Name="Input 2" Kind="InputPin" />
                           <Pin Id="S0OOXEpVc8rNtb6NnRqQsn" Name="Output" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="505,501,77,22" Id="Cyozsh0GuIuOjduXjH8i5y">
+                        <Node Bounds="505,501,77,26" Id="Cyozsh0GuIuOjduXjH8i5y">
                           <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetVector3" />
@@ -15593,7 +15593,7 @@
                       <Patch Id="ErlToUNUWgALl5eCewcSC1" ManuallySortedPins="true">
                         <ControlPoint Id="UWCKA83vaecNZUxsmUiHry" Bounds="619,492" />
                         <ControlPoint Id="NOLIj87oKzQPLrwRvFUQPy" Bounds="619,572" />
-                        <Node Bounds="671,492,76,22" Id="DZl4bfQCUEqONg5OPhgTUm">
+                        <Node Bounds="671,492,76,26" Id="DZl4bfQCUEqONg5OPhgTUm">
                           <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="GetFloat32" />
@@ -15604,7 +15604,7 @@
                           <Pin Id="UBxZR1Ao3vlMbDNIJ2vUwn" Name="Output" Kind="StateOutputPin" />
                           <Pin Id="TyeZc4iNChQPMXvktwVoRO" Name="Result" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="630,535,25,13" Id="M134EGaYZoSO8Ce0H4K6JO">
+                        <Node Bounds="630,535,25,19" Id="M134EGaYZoSO8Ce0H4K6JO">
                           <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <Choice Kind="OperationCallFlag" Name="*" />
@@ -18768,7 +18768,6 @@
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
               </p:NodeReference>
-              <Pin Id="Bg4C9YMImDxNuwapaLcV49" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="HPFsx41BhmNNJjPp7OlokC" Name="Default Output" Kind="InputPin" />
               <Pin Id="S7f3CYT0q2DL4ouHgqi0Qr" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
               <Pin Id="MrREV0I4mNDQMcKBHf57Vs" Name="Result" Kind="OutputPin" />
@@ -19172,6 +19171,7 @@
                 <Patch Id="BBg4m53AdpWMt0JlAh9mum" Name="Update" />
                 <Patch Id="ICBN4YdP1TGLHdsqQkot1d" Name="Dispose" />
               </Patch>
+              <Pin Id="GY4Cwy9F8g1QA4Jbv9ilFc" Name="Warn" Kind="InputPin" />
             </Node>
             <Pad Id="GqmCZj0l4SZL5KBJdfF6WB" SlotId="AEG1pE4ARRgMlDXPIVLt1e" Bounds="-200,-962" />
             <Overlay Id="AiTf2qIp07yPnmjw7tyWDe" Name="LoadContent" Bounds="-291,-1031,449,621">
@@ -25387,7 +25387,7 @@
                       <Pin Id="NhdbMIKnTQuLqK9akC7sk0" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="NWyAGHL6OzzOnRjn4OyV4q" Name="New State" Kind="OutputPin" />
                       <Pin Id="Uhf9QBoB7GTL6BxTVEl6MB" Name="Node Operation" Kind="OutputPin" />
-                      <Pin Id="BlTjmbkf3e8NyztNHjqEF0" Name="Properties" Kind="InputPin" />
+                      <Pin Id="JeQyZaZO3eBQF8G8MLejzH" Name="Properties" Kind="InputPin" />
                     </Node>
                     <Node Bounds="743,1671,38,26" Id="Nh1waDQte6ON8nma8jYPCs">
                       <p:NodeReference LastCategoryFullName="Collections.Stack" LastDependency="VL.CoreLib.vl">
@@ -26815,7 +26815,7 @@
               <Pin Id="Mhc1yC0e0zINL4aOYrDe1b" Name="Context" Kind="InputPin" />
               <Pin Id="QiJnYN2GNUzL6Awl2QmsXI" Name="Last Content" Kind="InputPin" />
               <Pin Id="Q4uQTZo00QVLs8krCdpLqU" Name="Output" Kind="OutputPin" />
-              <Pin Id="NJXGtJO3pu8NLiC6sQ2ooy" Name="Context" Kind="OutputPin" />
+              <Pin Id="V0fwCObw5aoOkYZge5uQOk" Name="Context" Kind="OutputPin" />
               <Pin Id="G1188jU8YH2Lsp6uklbg6c" Name="Loaded Content" Kind="OutputPin" />
             </Node>
             <Pad Id="R0yxExdnrjlMov5wlHfOnX" SlotId="TMQLd4zoFKRNWhSlxdh4P1" Bounds="491,500" />
@@ -27647,7 +27647,6 @@
                       <Pin Id="Al2yassP6AZOEUlA2TT4bU" Name="Output" Kind="StateOutputPin" />
                     </Node>
                   </Patch>
-                  <Pin Id="PZ2ikE6iD6iNRIeQBf7NrK" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="KxS5FLdAtaaQF991U8amtK" Name="Default Output" Kind="InputPin" />
                   <Pin Id="IBQq1UVRKz8QFt3BUlMPRW" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
                   <Pin Id="TzhBOiIuhQYQBq72HorSql" Name="Result" Kind="OutputPin" />
@@ -42506,7 +42505,7 @@
           </Patch>
           <Patch Id="K1VSqBLP5wyOYYo0AfFzXF" Name="SetNode">
             <Pin Id="LMstxV1zpHfQTT3hpYUwX9" Name="Root Node" Kind="InputPin" />
-            <Pin Id="DY7IIcJrMigM4TWKzi8jFK" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="P1vzVDd6ObkOCslZgNID2G" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="OwQF9JVmoMEL92JMH0MFYn" Name="GetSetup">
             <Pin Id="Tzln8INOGeHOmPwLzFQhvW" Name="Setup" Kind="OutputPin" />
@@ -42516,18 +42515,18 @@
           </Patch>
           <Patch Id="RxSENQUOIIoP64lLKDwsat" Name="GetNode">
             <Pin Id="ASjxsVfwoSDOS5uqP61sin" Name="Root Node" Kind="OutputPin" />
-            <Pin Id="SKGiEWYQKQBLRUvs9lk5xh" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="CDMM6ngEtdPOqMNTObIrvl" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="PcAC7AUwhyjK9sWKKGJCRe" Name="GetType">
             <Pin Id="FEw9ono9mi3MWfJ6PhxkY2" Name="Type" Kind="OutputPin" />
           </Patch>
           <Patch Id="FtOtBZ5oyz1NEmsVxOqr43" Name="SetLastAssigned">
             <Pin Id="IhkYiFkpKunO3Z5MuR2Gqn" MergeId="700333" Name="LastAssigned" Kind="InputPin" />
-            <Pin Id="HdVtQpNFt34NUUGeYasVz2" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="FsQQwMttbIIMe49jIaxVWZ" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="Ue6LShoqEuAOXmFq1poOPv" Name="GetLastAssigned">
             <Pin Id="DXUFfe4BTlVLAhqUyZCHWI" MergeId="709913" Name="LastAssigned" Kind="OutputPin" />
-            <Pin Id="SNBL7CBDDd3NqWHCcKXBIN" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="EMU2w6XDd0oMJjmR1dKAYQ" Name="Layer Index" Kind="InputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -51910,7 +51909,6 @@
                           <Pin Id="MocSDw5f4lhP2C3643C8mK" Name="Output" Kind="StateOutputPin" />
                         </Node>
                       </Patch>
-                      <Pin Id="MQVU4Nv20cKP5Ibu5n1Hjb" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="ERQj7kI6hR1OvlTGp6dzJP" Name="Default Output" Kind="InputPin" />
                       <Pin Id="Q4WpTdr82QaOxJ0KfqkqYe" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
                       <Pin Id="VIQH5pqr2raN77tDvb0PJu" Name="Result" Kind="OutputPin" />
@@ -62911,7 +62909,7 @@
     </Node>
   </Patch>
   <NugetDependency Id="GrC8xaUMwn4MZwjSBKGsTz" Location="Csv" Version="2.0.93" />
-  <NugetDependency Id="L6BoZEdIC1fPpiehk66FpI" Location="VL.IO.Midi" Version="1.1.1" />
+  <NugetDependency Id="L6BoZEdIC1fPpiehk66FpI" Location="VL.IO.Midi" Version="2.0.4" />
   <PlatformDependency Id="O7rdP89oF1UPNoubLT4KKV" Location="System.Diagnostics.Debug" />
   <NugetDependency Id="C4Yl2tAKeLRNU3XegdjoNf" Location="ncalc" Version="1.3.8" />
   <DocumentDependency Id="M2pvWdXTRcKM73Wor3khLk" Location="./VL.LinearSpread.vl" />

--- a/Main/vl/VVVV.Schema.Core.vl
+++ b/Main/vl/VVVV.Schema.Core.vl
@@ -5644,7 +5644,7 @@
     ************************ RegisterSourceValueBlocks ************************
 
 -->
-            <Node Name="RegisterSourceValueBlocks" Bounds="1058,68,425,547" Id="I2sZ5bTToLGLkQUMq6I3Dr">
+            <Node Name="RegisterSourceValueBlocks" Bounds="1062,68,389,483" Id="I2sZ5bTToLGLkQUMq6I3Dr">
               <p:NodeReference>
                 <Choice Kind="OperationDefinition" Name="Operation" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -5683,7 +5683,7 @@
                 </Pad>
                 <ControlPoint Id="B3n6X68NcpNK9VzifmVBfR" Bounds="1111,86" />
                 <Pin Id="GOMwBF24dz8LVJbVM28Nqh" Name="Input" Kind="InputPin" Bounds="645,157" />
-                <ControlPoint Id="VcLbiwnO5J7Qc98ii9A2Au" Bounds="1137,596" />
+                <ControlPoint Id="VcLbiwnO5J7Qc98ii9A2Au" Bounds="1137,534" />
                 <Pin Id="JB4v3CQ5YfxOmPQMnmUWwF" Name="Output" Kind="OutputPin" Bounds="645,358" />
                 <Link Id="HmBtPHwCSoGMtS1pJ0xtYO" Ids="Sq4huTS13R2QdBrk6JmCJG,NLxqFAoZD21Li5e9yTW52f" IsHidden="true" />
                 <Link Id="VmiBrLkDrjZMls5u7K5JOD" Ids="JNH7UolgYhWLrq0MOCipk5,Sq4huTS13R2QdBrk6JmCJG" />
@@ -5691,39 +5691,7 @@
                 <Link Id="KajSFGLus5JLMp3AW5AwzT" Ids="B3n6X68NcpNK9VzifmVBfR,Mnr6pAVeF8JMJ0GXk7rqUn" />
                 <Link Id="TYIeD8TwK2WMCq4NEiPnX1" Ids="GOMwBF24dz8LVJbVM28Nqh,B3n6X68NcpNK9VzifmVBfR" IsHidden="true" />
                 <Link Id="AGykepBunwHLUMwFiUyMYr" Ids="VcLbiwnO5J7Qc98ii9A2Au,JB4v3CQ5YfxOmPQMnmUWwF" IsHidden="true" />
-                <Node Bounds="1132,275,109,94" Id="E1lxRqbbHUDQVdiU0h4hqS">
-                  <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
-                    <Choice Kind="OperationCallFlag" Name="RegisterBee" />
-                    <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
-                  </p:NodeReference>
-                  <Pin Id="DucvP1oNGWlNZu98I3QJ58" Name="Input" Kind="StateInputPin" />
-                  <Pin Id="A0G6WIJGYpYOxCQrsEZDgI" Name="Key" Kind="InputPin" />
-                  <Pin Id="HjdoGIO5iREMHjXSyVWA3O" Name="Log" Kind="InputPin" />
-                  <Pin Id="L8XICEHj8Y0NkOWlhsmDSh" Name="Output" Kind="StateOutputPin" />
-                  <Patch Id="Ktg2B4ffRkNOFQeiFWEjtR" Name="Constructor" ManuallySortedPins="true">
-                    <Pin Id="IFQPW1K5jnVPZ2YcTWQYdO" Name="Result" Kind="OutputPin" />
-                    <ControlPoint Id="S2pXc6P9efFLKotchaYdz4" Bounds="1136,360" />
-                    <Node Bounds="1148,298,81,26" Id="CoO52jthITqMVRmAYEYL47">
-                      <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.Expression" LastDependency="VVVV.Schema.Core.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <CategoryReference Kind="ClassType" Name="Expression" />
-                        <Choice Kind="OperationCallFlag" Name="Create" />
-                      </p:NodeReference>
-                      <Pin Id="Er705rPpoZWQFKTFgmbd1Y" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                      <Pin Id="GuzpplHryqVNQGNuXliVT5" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                  </Patch>
-                </Node>
-                <Pad Id="FUpjQLrTVkIMm07zQGpGDG" Comment="Key" Bounds="1269,240,160,20" ShowValueBox="true" isIOBox="true" Value="Create.Value.Expression">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="String" />
-                  </p:TypeAnnotation>
-                </Pad>
-                <Link Id="Eh8stLeB0bxN313R4Mh2wQ" Ids="S2pXc6P9efFLKotchaYdz4,IFQPW1K5jnVPZ2YcTWQYdO" IsHidden="true" />
-                <Link Id="FQ6LXlFfPMtLyrdWCSMZrZ" Ids="GuzpplHryqVNQGNuXliVT5,S2pXc6P9efFLKotchaYdz4" />
-                <Link Id="Ggtrd4eNwBUNut13uBUV8t" Ids="FUpjQLrTVkIMm07zQGpGDG,A0G6WIJGYpYOxCQrsEZDgI" />
-                <Link Id="T5zMbCghlNXOaFXxLo7kRG" Ids="NBkwYWoaDRpNIDdf4k1nJb,DucvP1oNGWlNZu98I3QJ58" />
-                <Node Bounds="1133,408,114,94" Id="DG9G1uplLyaLYGtLlFHqe3">
+                <Node Bounds="1133,346,114,94" Id="DG9G1uplLyaLYGtLlFHqe3">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.BeeRegistry" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="OperationCallFlag" Name="RegisterBee" />
                     <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -5734,8 +5702,8 @@
                   <Pin Id="EOo9lv12oM9Mx6GmsRw9kA" Name="Output" Kind="StateOutputPin" />
                   <Patch Id="RYfFmRStUN0Pul43Jp6mug" Name="Constructor" ManuallySortedPins="true">
                     <Pin Id="BQCEr7jAqMvLWb5n1Hf3wU" Name="Result" Kind="OutputPin" />
-                    <ControlPoint Id="FSBbdWOkKioLIUM28xPMaf" Bounds="1137,493" />
-                    <Node Bounds="1149,431,86,26" Id="SjGu8XiCK9lQKHIy5mSz7u">
+                    <ControlPoint Id="FSBbdWOkKioLIUM28xPMaf" Bounds="1137,431" />
+                    <Node Bounds="1149,369,86,26" Id="SjGu8XiCK9lQKHIy5mSz7u">
                       <p:NodeReference LastCategoryFullName="VVVV.Schema.Block.Behavior.Source.Value.TriggerValueSource" LastDependency="VVVV.Schema.Core.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Create" />
@@ -5746,7 +5714,7 @@
                     </Node>
                   </Patch>
                 </Node>
-                <Pad Id="JtxE6d7fzL5PHFV5Q62RqG" Comment="Key" Bounds="1282,386,150,20" ShowValueBox="true" isIOBox="true" Value="Create.Value.Trigger">
+                <Pad Id="JtxE6d7fzL5PHFV5Q62RqG" Comment="Key" Bounds="1189,289,150,20" ShowValueBox="true" isIOBox="true" Value="Create.Value.Trigger">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
@@ -5754,9 +5722,8 @@
                 <Link Id="NvpmDzrE4SfL1S3Db72iGx" Ids="FSBbdWOkKioLIUM28xPMaf,BQCEr7jAqMvLWb5n1Hf3wU" IsHidden="true" />
                 <Link Id="Aqtb3vU2y4HNXZYsoh28qI" Ids="VxJd6F4y4MoLbioE27L3SH,FSBbdWOkKioLIUM28xPMaf" />
                 <Link Id="KjaebawhtlqMJ2XdqLxwcq" Ids="JtxE6d7fzL5PHFV5Q62RqG,LWZl6H7xhatLW1vwFi2beE" />
-                <Link Id="PDioLkhB2ApPY02XiWNZoS" Ids="L8XICEHj8Y0NkOWlhsmDSh,ExmTSVGdCSHO7i2QCOWaQw" />
                 <Link Id="LnspMdfD70RNflann9oczp" Ids="EOo9lv12oM9Mx6GmsRw9kA,DPw8Q9hajM7NTsnBumlTLi" />
-                <Node Bounds="1135,542,164,19" Id="CnodDznbWOaLROYDh3f28K">
+                <Node Bounds="1135,480,164,19" Id="CnodDznbWOaLROYDh3f28K">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.Registry.Source" LastDependency="VVVV.Schema.Core.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="RegisterSourceValueAudioBlocks" />
@@ -5765,6 +5732,7 @@
                   <Pin Id="PsZENC9POoFPc7yMQcQGs6" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Link Id="LkD5cIUkSmvQAVHJvc48yg" Ids="PsZENC9POoFPc7yMQcQGs6,VcLbiwnO5J7Qc98ii9A2Au" />
+                <Link Id="B1bIRgtPHTANkVFjDQy7TS" Ids="NBkwYWoaDRpNIDdf4k1nJb,ExmTSVGdCSHO7i2QCOWaQw" />
               </Patch>
             </Node>
             <!--
@@ -12314,7 +12282,7 @@
             <Pin Id="JGOcSPMIsvVL98OIViYxUd" Name="Global" Kind="InputPin" />
             <Pin Id="TcjOciUAlLOLrqMpmxjWu8" Name="New State" Kind="OutputPin" />
             <Pin Id="CL5BjMZbmJLOLnErIuxCF3" Name="Node Operation" Kind="OutputPin" />
-            <Pin Id="PlJgYR98qLjNUxAcmiDjZ8" Name="Properties" Kind="InputPin" />
+            <Pin Id="ITdh93BfvXBLUa9VqKcssq" Name="Properties" Kind="InputPin" />
           </Patch>
           <Patch Id="KaCaE3sKV3UMVtoT2k9fVI" Name="GetChildren">
             <Pin Id="C0BKrPp9iE9N5esRHhPybU" Name="Children" Kind="OutputPin" />
@@ -13007,13 +12975,13 @@
           <Link Id="C8cmZKeAfHyPP67K7WtHm5" Ids="T29DpogE4b2LdkohUTTmJ3,R6Bo59veWFeNHB6xZ8HqAl" />
           <Patch Id="QFjBE7nZ6v3QIMDO7h0tlZ" Name="Create" />
           <Patch Id="F2GiypGHcmWMNd3KKUzSEV" Name="Update">
-            <Pin Id="DZ5EUykW8QnNz2nFZrPY1t" Name="Setup" Kind="InputPin" />
+            <Pin Id="EduJQz2OeDALRQUOOzBkfp" Name="Setup" Kind="InputPin" />
             <Pin Id="QXu17NLnnfXNcWxWfddTlu" Name="State" Kind="InputPin" />
             <Pin Id="R5iYxD4bMKqNYTC5XMP5wX" Name="New State" Kind="OutputPin" />
-            <Pin Id="FeMlqiqlNomNqC62dUCMWu" Name="Previous Layer States" Kind="InputPin" />
-            <Pin Id="A9hG4K2DLIqQarfMDgXk5B" Name="Global" Kind="InputPin" />
-            <Pin Id="LmzJohIY8h7PZQ3fw8PgYH" Name="Properties" Kind="InputPin" />
-            <Pin Id="VD3SZD4zmtAOWONIRcSB6f" Name="Node Operation" Kind="OutputPin" />
+            <Pin Id="UdEOrWvigtBN6ojBXCk1Y5" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="OIYqCP0FA4BLCzWR8r6LVe" Name="Global" Kind="InputPin" />
+            <Pin Id="TE17cjGjarJPxtDLcugfnP" Name="Properties" Kind="InputPin" />
+            <Pin Id="Exe4504WZmhPSREDYE2Ngh" Name="Node Operation" Kind="OutputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -25387,7 +25355,7 @@
                       <Pin Id="NhdbMIKnTQuLqK9akC7sk0" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="NWyAGHL6OzzOnRjn4OyV4q" Name="New State" Kind="OutputPin" />
                       <Pin Id="Uhf9QBoB7GTL6BxTVEl6MB" Name="Node Operation" Kind="OutputPin" />
-                      <Pin Id="JeQyZaZO3eBQF8G8MLejzH" Name="Properties" Kind="InputPin" />
+                      <Pin Id="CJZnxIhaxfFLYGqC2wh0dm" Name="Properties" Kind="InputPin" />
                     </Node>
                     <Node Bounds="743,1671,38,26" Id="Nh1waDQte6ON8nma8jYPCs">
                       <p:NodeReference LastCategoryFullName="Collections.Stack" LastDependency="VL.CoreLib.vl">
@@ -26815,7 +26783,7 @@
               <Pin Id="Mhc1yC0e0zINL4aOYrDe1b" Name="Context" Kind="InputPin" />
               <Pin Id="QiJnYN2GNUzL6Awl2QmsXI" Name="Last Content" Kind="InputPin" />
               <Pin Id="Q4uQTZo00QVLs8krCdpLqU" Name="Output" Kind="OutputPin" />
-              <Pin Id="V0fwCObw5aoOkYZge5uQOk" Name="Context" Kind="OutputPin" />
+              <Pin Id="FKvfZ3dqcOROWuIQHu0wov" Name="Context" Kind="OutputPin" />
               <Pin Id="G1188jU8YH2Lsp6uklbg6c" Name="Loaded Content" Kind="OutputPin" />
             </Node>
             <Pad Id="R0yxExdnrjlMov5wlHfOnX" SlotId="TMQLd4zoFKRNWhSlxdh4P1" Bounds="491,500" />
@@ -31630,7 +31598,7 @@
           <Pin Id="Uqk6PZ6gTPfLKICywZxROH" Name="Factory" Kind="InputPin" />
           <ControlPoint Id="A5Lij8EEmaGQGEFz67TII6" Bounds="-660,-823" />
           <Link Id="N4BPeuPjZwlPpxZ46UGKo0" Ids="Uqk6PZ6gTPfLKICywZxROH,A5Lij8EEmaGQGEFz67TII6" IsHidden="true" />
-          <Node Bounds="-663,-767,95,26" Id="JEKG5Hl0ue9OaDrrYl6kAH">
+          <Node Bounds="-663,-767,95,19" Id="JEKG5Hl0ue9OaDrrYl6kAH">
             <p:NodeReference LastCategoryFullName="System.Serialization" LastDependency="VL.CoreLib.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="RegisterSerializer" />
@@ -42505,7 +42473,7 @@
           </Patch>
           <Patch Id="K1VSqBLP5wyOYYo0AfFzXF" Name="SetNode">
             <Pin Id="LMstxV1zpHfQTT3hpYUwX9" Name="Root Node" Kind="InputPin" />
-            <Pin Id="P1vzVDd6ObkOCslZgNID2G" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="Fe2sB8rNwGKOyklSM8djRf" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="OwQF9JVmoMEL92JMH0MFYn" Name="GetSetup">
             <Pin Id="Tzln8INOGeHOmPwLzFQhvW" Name="Setup" Kind="OutputPin" />
@@ -42515,18 +42483,18 @@
           </Patch>
           <Patch Id="RxSENQUOIIoP64lLKDwsat" Name="GetNode">
             <Pin Id="ASjxsVfwoSDOS5uqP61sin" Name="Root Node" Kind="OutputPin" />
-            <Pin Id="CDMM6ngEtdPOqMNTObIrvl" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="DdL6q5xGTPZMcLtwGIhDIJ" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="PcAC7AUwhyjK9sWKKGJCRe" Name="GetType">
             <Pin Id="FEw9ono9mi3MWfJ6PhxkY2" Name="Type" Kind="OutputPin" />
           </Patch>
           <Patch Id="FtOtBZ5oyz1NEmsVxOqr43" Name="SetLastAssigned">
             <Pin Id="IhkYiFkpKunO3Z5MuR2Gqn" MergeId="700333" Name="LastAssigned" Kind="InputPin" />
-            <Pin Id="FsQQwMttbIIMe49jIaxVWZ" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="GtMuBWjXQdCLlvF2TslsQq" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="Ue6LShoqEuAOXmFq1poOPv" Name="GetLastAssigned">
             <Pin Id="DXUFfe4BTlVLAhqUyZCHWI" MergeId="709913" Name="LastAssigned" Kind="OutputPin" />
-            <Pin Id="EMU2w6XDd0oMJjmR1dKAYQ" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="Eel31WMwS4yMtrcAbIsWQm" Name="Layer Index" Kind="InputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -51180,7 +51148,7 @@
     ************************ Beat ************************
 
 -->
-              <Node Name="Beat" Bounds="385,254" Id="QA66pGvhmeCNrg26BwUJKM">
+              <Node Name="Beat" Bounds="93,95" Id="QA66pGvhmeCNrg26BwUJKM">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="ClassDefinition" Name="Class" />
                 </p:NodeReference>
@@ -51387,7 +51355,7 @@
     ************************ TriggerValueSource ************************
 
 -->
-              <Node Name="TriggerValueSource" Bounds="383,305" Id="Qg5fWkuTQd1MD0NfgBxi1r">
+              <Node Name="TriggerValueSource" Bounds="93,160" Id="Qg5fWkuTQd1MD0NfgBxi1r">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="ClassDefinition" Name="Class" />
                 </p:NodeReference>
@@ -51705,326 +51673,10 @@
               </Node>
               <!--
 
-    ************************ Expression ************************
-
--->
-              <Node Name="Expression" Bounds="411,350" Id="OLxLNteqTmfM8mMM20nPD8">
-                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                  <Choice Kind="ClassDefinition" Name="Class" />
-                </p:NodeReference>
-                <p:Interfaces>
-                  <TypeReference LastCategoryFullName="VVVV.Beehive" LastDependency="Schema.Model.AudioState.vl">
-                    <Choice Kind="InterfaceTypeFlag" Name="IBee" />
-                  </TypeReference>
-                </p:Interfaces>
-                <Patch Id="DhQQe9RBpb3LfTNvTdvHO8">
-                  <Canvas Id="P0MT9Ab6vceLTXxMy4KaOZ" CanvasType="Group">
-                    <ControlPoint Id="HvjaypTjaJ4QZDQh0c1wSg" Bounds="548,24" />
-                    <ControlPoint Id="SrxiHjrD5q5M9lDO0VvhLk" Bounds="620,29" />
-                    <ControlPoint Id="Ui00AH7reR0M7XcCfAoFxh" Bounds="525,768" />
-                    <ControlPoint Id="R1sc0Fh9fiPO7PnHFtPXCG" Bounds="745,40" />
-                    <ControlPoint Id="UwKPvZptcW2LRbWVKz8fp4" Bounds="834,42" />
-                    <Node Bounds="541,83,54,13" Id="Vjk26UAzrhyPE0AJo6Q1f2">
-                      <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="Merge" />
-                        <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="Kp3MV0jCLNXLizOLDIDjtM" Name="Input" Kind="InputPin" />
-                      <Pin Id="AodldrWM1tsNz7AxFqMDK3" Name="Output" Kind="OutputPin" />
-                    </Node>
-                    <ControlPoint Id="IUMNHjXDdfTPMRLaeVFdCD" Bounds="946,488" />
-                    <Node Bounds="867,212,89,13" Id="OQ8hZ3bhrU4NKSsMx2Bznk">
-                      <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="CreateDefault" />
-                        <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="PJPX1SvU5CSOmekl2Cd7L6" Name="Output" Kind="StateOutputPin" />
-                    </Node>
-                    <Node Bounds="867,431,71,22" Id="SxBLQal6tkfPRRJYUX3pFI">
-                      <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="ToImmutable" />
-                        <CategoryReference Kind="ClassType" Name="DictionaryBuilder" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="ScDOsdwipy0MzM976apL5K" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="OGPpLWdY4P9QVrf0TSG4gq" Name="Output" Kind="StateOutputPin" />
-                      <Pin Id="RlVUipHv06SOOLuXRQ9Vrs" Name="Result" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="868,253,205,13" Id="TSoh9SbGc5DMyuMzbreSuU">
-                      <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="AddString" />
-                      </p:NodeReference>
-                      <Pin Id="AnRN3RQdvmdLl7x38aqDYn" Name="Input" Kind="InputPin" />
-                      <Pin Id="IV0MNzGHIllLpxqpdJRGro" Name="Key" Kind="InputPin" />
-                      <Pin Id="GwHBSgI8UmmPzIB0SnPqDc" Name="Default" Kind="InputPin" DefaultValue="s">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="String" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="D00QfhCsf7fN4eWN96T7Lb" Name="Between Spread" Kind="InputPin" />
-                      <Pin Id="N4TOwObqoxmLeWWDwG1Ibl" Name="Children Spread" Kind="InputPin" />
-                      <Pin Id="Cx9LEY9ir3HNz9Sfp1dkw9" Name="Type" Kind="InputPin" DefaultValue="Label">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="String" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="Uocry5cwbHKNNBasxMYqRy" Name="Tooltip" Kind="InputPin" />
-                      <Pin Id="JgkUvS3Wg35LyZYBcKjfyy" Name="Properties" Kind="OutputPin" />
-                    </Node>
-                    <Pad Id="MZBnF5gjcWANFDwk198RIA" Comment="Key" Bounds="910,96,133,20" ShowValueBox="true" isIOBox="true" Value="Expression">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
-                      </p:TypeAnnotation>
-                    </Pad>
-                    <Node Bounds="783,117,76,22" Id="SsjCQzfjhFWQAp4xrU0YOE">
-                      <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="GetString" />
-                        <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="UctgSqspayKMYglLqLSgo8" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="IRp3POn96qrO35m31m4Ofz" Name="Key" Kind="InputPin" />
-                      <Pin Id="QiNIm0ySL3yP7ZlY2aN285" Name="Default" Kind="InputPin" />
-                      <Pin Id="I96Rlks8nfDMj4N0IFH7NC" Name="Output" Kind="StateOutputPin" />
-                      <Pin Id="Ql0orqvhwZKPyZ8wDNMtxd" Name="Result" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="528,702,65,13" Id="B00nUi9mKFJPI3FOkNnpav">
-                      <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="SetValue" />
-                        <CategoryReference Kind="ClassType" Name="PropertyBank" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="SKpSDq87EgSLnCvCadpvrL" Name="Input" Kind="InputPin" />
-                      <Pin Id="HJnqa54cN6DPmjNm68keN7" Name="Value" Kind="InputPin" />
-                      <Pin Id="UC5KPq8eXGgPBzP9qNU898" Name="Output" Kind="OutputPin" />
-                    </Node>
-                    <Pad Id="QJDCMqkqzgQPnQ3NPOKUgI" Bounds="246,87,269,49" ShowValueBox="true" isIOBox="true" Value="TODO expression effect, expression source with value set by another parameter">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
-                      </p:TypeAnnotation>
-                      <p:ValueBoxSettings>
-                        <p:fontsize p:Type="Int32">9</p:fontsize>
-                        <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-                      </p:ValueBoxSettings>
-                    </Pad>
-                    <Pad Id="QtBTiVjD8QALarGFRPyutP" Bounds="859,289,364,56" ShowValueBox="true" isIOBox="true" Value="TODO set time source (local, global, reset on load, etc.)">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
-                      </p:TypeAnnotation>
-                      <p:ValueBoxSettings>
-                        <p:fontsize p:Type="Int32">9</p:fontsize>
-                        <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
-                      </p:ValueBoxSettings>
-                    </Pad>
-                    <Pad Id="Hz8hCF4c23cQI0MZIg2B26" Comment="Key" Bounds="908,152,20,19" ShowValueBox="true" isIOBox="true" Value="s">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="String" />
-                      </p:TypeAnnotation>
-                    </Pad>
-                    <Pad Id="Sz2Ptx7PM2qQTUg7JiYXiP" Comment="Value" Bounds="758,411,63,19" ShowValueBox="true" isIOBox="true" Value="0.5">
-                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="TypeFlag" Name="Float32" />
-                      </p:TypeAnnotation>
-                    </Pad>
-                    <Node Bounds="610,434,183,207" Id="LoiGogA8MpMLbmTvLTMxr2">
-                      <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                        <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
-                      </p:NodeReference>
-                      <Patch Id="QTCVqRyM2HdNp9ZBAtH9wK" ManuallySortedPins="true">
-                        <Patch Id="SBPpDguJQqDQBtArbaAZ8U" Name="Create" ManuallySortedPins="true" />
-                        <Patch Id="TYPNV5tS1nhQYIgzwsfGbm" Name="Try" ParticipatingElements="HxueZeHfmoGPlc44fONo7X" ManuallySortedPins="true">
-                          <Pin Id="FtkY1cXEcLYOoTkKjIHzzy" Name="Output" Kind="OutputPin" />
-                        </Patch>
-                        <ControlPoint Id="PHXoYqzjk5NLKWGytScxyv" Bounds="613,632" />
-                        <Node Bounds="628,573,48,22" Id="AUP1XMql22jQTOkt3UMgYJ">
-                          <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="Evaluate" />
-                          </p:NodeReference>
-                          <Pin Id="MHuQ5fVYiT0P6kinyU6yA1" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="FguRTRwPs5eL1ZxPCE0FUD" Name="Output" Kind="StateOutputPin" />
-                          <Pin Id="TycpeS1zdBhOpUXQ8k7lGG" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="644,608,72,13" Id="DdHgc2BqvWwPV0qf0B5Aye">
-                          <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="ToFloat32 (Expression Result)" />
-                          </p:NodeReference>
-                          <Pin Id="SyN5GsDg4byLBeGRsLAdbl" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="OOfDBR24eS6Pc5tLjmegMG" Name="Defaultvalue" Kind="InputPin" />
-                          <Pin Id="VGP0W2Lw4nGPOhNK6t4MLX" Name="Result" Kind="OutputPin" />
-                        </Node>
-                        <Node Bounds="631,488,48,22" Id="HxueZeHfmoGPlc44fONo7X">
-                          <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <CategoryReference Kind="AssemblyCategory" Name="NCalc" />
-                            <CategoryReference Kind="AssemblyCategory" Name="Expression" />
-                            <Choice Kind="OperationCallFlag" Name="Create" />
-                            <PinReference Kind="InputPin" Name="Expression">
-                              <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="System" LastDependency="mscorlib.dll">
-                                <Choice Kind="TypeFlag" Name="String" />
-                              </p:DataTypeReference>
-                            </PinReference>
-                            <PinReference Kind="InputPin" Name="Options" />
-                          </p:NodeReference>
-                          <Pin Id="VIccR7A37FEK9uAHoInarV" Name="Expression" Kind="InputPin" />
-                          <Pin Id="NRrus8N1DjgPgitWxSeq6z" Name="Options" Kind="InputPin" DefaultValue="IgnoreCase">
-                            <p:TypeAnnotation LastCategoryFullName="NCalc" LastDependency="NCalc.dll">
-                              <Choice Kind="TypeFlag" Name="EvaluateOptions" />
-                            </p:TypeAnnotation>
-                          </Pin>
-                          <Pin Id="UYtmio0ZMhbO4y9adsOaxp" Name="Output" Kind="StateOutputPin" />
-                        </Node>
-                        <Node Bounds="630,528,75,22" Id="RdlYZ9ObkhUNoK3UqaR6GU">
-                          <p:NodeReference LastCategoryFullName="NCalc.Expression" LastDependency="NCalc.dll">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="SetParameters" />
-                            <CategoryReference Kind="AssemblyCategory" Name="Expression" NeedsToBeDirectParent="true" />
-                          </p:NodeReference>
-                          <Pin Id="M4TFWSCVk3wNmhRK3gFEdr" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="BRv8UG5P7YsP2MwHvwwDTl" Name="Value" Kind="InputPin" />
-                          <Pin Id="QqvaTpOYSyoNwM6ScdEaya" Name="Output" Kind="StateOutputPin" />
-                        </Node>
-                        <Node Bounds="695,484,75,22" Id="HxRJWttuukQNd91KVzP3dn">
-                          <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="SetItem" />
-                            <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
-                          </p:NodeReference>
-                          <Pin Id="CNB4hY7i3fNN94Vz8721Cj" Name="Input" Kind="StateInputPin" />
-                          <Pin Id="PHr1S1XOy2FNxDMZUVtVZR" Name="Key" Kind="InputPin" />
-                          <Pin Id="ElxW2hey5sKMgSOFrRCRP4" Name="Value" Kind="InputPin" />
-                          <Pin Id="MwmukJyXV8lNv8ZXddkU1e" Name="Output" Kind="StateOutputPin" />
-                        </Node>
-                        <Node Bounds="692,457,89,13" Id="RiAKrH7nsuVQaf4OvVz0N8">
-                          <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableDictionary" LastDependency="VL.CoreLib.vl">
-                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                            <Choice Kind="OperationCallFlag" Name="CreateDefault" />
-                            <CategoryReference Kind="ClassType" Name="MutableDictionary" NeedsToBeDirectParent="true" />
-                          </p:NodeReference>
-                          <Pin Id="MocSDw5f4lhP2C3643C8mK" Name="Output" Kind="StateOutputPin" />
-                        </Node>
-                      </Patch>
-                      <Pin Id="ERQj7kI6hR1OvlTGp6dzJP" Name="Default Output" Kind="InputPin" />
-                      <Pin Id="Q4WpTdr82QaOxJ0KfqkqYe" Name="Re Initialize" Kind="InputPin" IsHidden="true" />
-                      <Pin Id="VIQH5pqr2raN77tDvb0PJu" Name="Result" Kind="OutputPin" />
-                      <Pin Id="MMtRdYHEfHQQK0GNeIATwh" Name="Success" Kind="OutputPin" />
-                      <Pin Id="NuqTruQXUuSQb0o7kp3CmX" Name="Error Message" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="597,663,45,13" Id="MVGGm4xdEbFLyp6da3ChkV">
-                      <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="ProcessAppFlag" Name="S+H" />
-                        <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="DntMJ1zkeyKOEDoaWtbfcc" Name="Node Context" Kind="InputPin" IsHidden="true" />
-                      <Pin Id="KhvsIH4ImFVMt16cxs2A8E" Name="Initial Value" Kind="InputPin" />
-                      <Pin Id="ELxwj0IPI9dNSCikhC6cVV" Name="Value" Kind="InputPin" />
-                      <Pin Id="Axv0bmx0sRIP94ikBb34BU" Name="Sample" Kind="InputPin" />
-                      <Pin Id="DsnkQIG7s6BNekg1qM9cPf" Name="Value" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="752,308,96,13" Id="Ceoy3U4ttNTMt1NevObbKU">
-                      <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="CurrentFrameTime" />
-                      </p:NodeReference>
-                      <Pin Id="DpFAS7CxISSOI6O5cYU2E8" Name="Current Frame Time" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="754,337,47,22" Id="GaDUVyVsNArMC5n4KluWEY">
-                      <p:NodeReference LastCategoryFullName="Animation.Time" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="Seconds" />
-                        <CategoryReference Kind="RecordType" Name="Time" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="MvJw0I331PfNEdekYb63nY" Name="Input" Kind="StateInputPin" />
-                      <Pin Id="QMmaG5pFMFgPFXJ2pWssCf" Name="Seconds" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="753,378,72,13" Id="R9ixkgSi4gTLrZmpMUVRCY">
-                      <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="ToFloat32" />
-                      </p:NodeReference>
-                      <Pin Id="P7HuLFiHwnKQRxWMTWUk8C" Name="Input" Kind="InputPin" />
-                      <Pin Id="Ncz5gCY3fTpMUJ18CR6wFp" Name="Result" Kind="OutputPin" />
-                    </Node>
-                  </Canvas>
-                  <Patch Id="SgdmnyJJEisN0bl8n6Baj3" Name="Create" />
-                  <ProcessDefinition Id="Hj0iNcK8wc6P6IqokjKfDd" IsHidden="true">
-                    <Fragment Id="SAjT0z2MWX7LihryrCQa1D" Patch="SgdmnyJJEisN0bl8n6Baj3" Enabled="true" />
-                    <Fragment Id="GEtO5csiVOfL29HUrD64Q1" Patch="A5tPLf8XHoYMzUMk8Oqx5S" Enabled="true" />
-                    <Fragment Id="V5NF3sxt5g4PKwnmQPHmbd" Patch="U8vs16Ga6soNL2VgRmGos5" Enabled="true" />
-                    <Fragment Id="DOevIbZ6bIJLD88fzWwYsN" Patch="NWPSRvU8N7LLBwYCvBGBzf" Enabled="true" />
-                    <Fragment Id="BlIY5Oaq9CMN9C8YAghuRE" Patch="P9NGDzEk9YAMOMziZobOWS" Enabled="true" />
-                  </ProcessDefinition>
-                  <Patch Id="A5tPLf8XHoYMzUMk8Oqx5S" Name="Update">
-                    <Pin Id="EABULm1EID6P3P41gXtTkG" Name="Setup" Kind="InputPin" />
-                    <Pin Id="UwR5sI9k7dlPgnMtgDZ5aU" Name="State" Kind="InputPin" />
-                    <Pin Id="V2JkZor6QtBOMYgKROn9gk" Name="Previous Layer States" Kind="InputPin" />
-                    <Pin Id="DzLKnMJQSbsLaYhArWXZcK" Name="Global" Kind="InputPin" />
-                    <Pin Id="ASx1Qr9OmZpOzFk3ByoLCs" Name="Properties" Kind="InputPin" />
-                    <Pin Id="UifEeChqhgGPkuSPnYkp0U" Name="New State" Kind="OutputPin" />
-                    <Pin Id="Q4293tal92gLc6zxyMW7ds" Name="Node Operation" Kind="OutputPin" />
-                  </Patch>
-                  <Link Id="JG8whY1aRJdMMuwZNaFx8f" Ids="EABULm1EID6P3P41gXtTkG,HvjaypTjaJ4QZDQh0c1wSg" IsHidden="true" />
-                  <Link Id="MQwbQzXUubaMPsWbWytnj1" Ids="UwR5sI9k7dlPgnMtgDZ5aU,SrxiHjrD5q5M9lDO0VvhLk" IsHidden="true" />
-                  <Link Id="C0dXcCReD1APEfti2XTrU4" Ids="Ui00AH7reR0M7XcCfAoFxh,UifEeChqhgGPkuSPnYkp0U" IsHidden="true" />
-                  <Link Id="BtcZRY2dIpJL3HmSbmd05q" Ids="DzLKnMJQSbsLaYhArWXZcK,R1sc0Fh9fiPO7PnHFtPXCG" IsHidden="true" />
-                  <Link Id="EuAiKDncDOrQSz7FSyJMEY" Ids="ASx1Qr9OmZpOzFk3ByoLCs,UwKPvZptcW2LRbWVKz8fp4" IsHidden="true" />
-                  <Patch Id="U8vs16Ga6soNL2VgRmGos5" Name="Provides">
-                    <Pin Id="M7D2MhNHkydPPRSUFoQaT4" Name="Color" Kind="OutputPin" />
-                    <Pin Id="RGlJKFErsywP52lG5zPfsw" Name="Pick" Kind="OutputPin" />
-                    <Pin Id="CQRMDLsnA3UPh7AhO0nRFO" Name="Gate" Kind="OutputPin" />
-                    <Pin Id="RC50mNlGCmROA8kHXy0DRU" Name="Own Color" Kind="OutputPin" />
-                    <Pin Id="VZbd44SGdJxLmZ4jXHplmb" Name="Text" Kind="OutputPin" />
-                    <Pin Id="KEHuzWobhhYPeeZzi74y5z" Name="Progress" Kind="OutputPin" />
-                    <Pin Id="MsA9xPlWulULYhmQB7UKNU" Name="Levels" Kind="OutputPin" />
-                    <Pin Id="RKyEAVRxcYjPcG5jrPzjRL" Name="Active Levels" Kind="OutputPin" />
-                  </Patch>
-                  <Patch Id="NWPSRvU8N7LLBwYCvBGBzf" Name="GetPick">
-                    <Pin Id="QDRLBizKxyLP1kvQFCIlHv" Name="Index" Kind="OutputPin" />
-                  </Patch>
-                  <Link Id="JqlH46L1pJqMEWBdNT52zF" Ids="SrxiHjrD5q5M9lDO0VvhLk,Kp3MV0jCLNXLizOLDIDjtM" />
-                  <Patch Id="P9NGDzEk9YAMOMziZobOWS" Name="GetPropertyDefinitions">
-                    <Pin Id="Jmg8SDX7f2CLcgbqBXewsi" Name="Properties" Kind="OutputPin" />
-                  </Patch>
-                  <Link Id="P64fKdDtAhmLSSgIVqfl2T" Ids="RlVUipHv06SOOLuXRQ9Vrs,IUMNHjXDdfTPMRLaeVFdCD" />
-                  <Link Id="JoAKcfRR6b1MIbJqGtIWz3" Ids="MZBnF5gjcWANFDwk198RIA,IV0MNzGHIllLpxqpdJRGro" />
-                  <Link Id="MLh0TQDNg2yLk2HUVbvasu" Ids="MZBnF5gjcWANFDwk198RIA,IRp3POn96qrO35m31m4Ofz" />
-                  <Link Id="NFruPflygl3LMKGhjyFhB0" Ids="IUMNHjXDdfTPMRLaeVFdCD,Jmg8SDX7f2CLcgbqBXewsi" IsHidden="true" />
-                  <Link Id="AjG7aBN4vv9NjHPFqYN6mO" Ids="PJPX1SvU5CSOmekl2Cd7L6,AnRN3RQdvmdLl7x38aqDYn" />
-                  <Link Id="U6hh34YqMflQBFumniCDZ3" Ids="UwKPvZptcW2LRbWVKz8fp4,UctgSqspayKMYglLqLSgo8" />
-                  <Link Id="DeVua7FNcPvQVwB5ou50Uk" Ids="UC5KPq8eXGgPBzP9qNU898,Ui00AH7reR0M7XcCfAoFxh" />
-                  <Link Id="IwbD3D14LftPZ0VeJr0dtw" Ids="AodldrWM1tsNz7AxFqMDK3,SKpSDq87EgSLnCvCadpvrL" />
-                  <Link Id="FvRo260bJavL6J8WROUUux" Ids="JgkUvS3Wg35LyZYBcKjfyy,ScDOsdwipy0MzM976apL5K" />
-                  <Link Id="V7Kg8OdjVcxLvdR91nB2vp" Ids="Hz8hCF4c23cQI0MZIg2B26,GwHBSgI8UmmPzIB0SnPqDc" />
-                  <Link Id="D50FYE6AphEPIX3X1jyt5z" Ids="MocSDw5f4lhP2C3643C8mK,CNB4hY7i3fNN94Vz8721Cj" />
-                  <Link Id="CzaJVsPpz0CO4wQipdbM3Q" Ids="MwmukJyXV8lNv8ZXddkU1e,BRv8UG5P7YsP2MwHvwwDTl" />
-                  <Link Id="BSjvmmOJhYaNHXlyBiTQsu" Ids="Hz8hCF4c23cQI0MZIg2B26,PHr1S1XOy2FNxDMZUVtVZR" />
-                  <Link Id="M56AZSfpBnmM8jHkHh2z1k" Ids="Sz2Ptx7PM2qQTUg7JiYXiP,ElxW2hey5sKMgSOFrRCRP4" />
-                  <Link Id="PxIxBoJhGDyOyvHQU1kc1I" Ids="PHXoYqzjk5NLKWGytScxyv,FtkY1cXEcLYOoTkKjIHzzy" IsHidden="true" />
-                  <Link Id="EP2asNWoALWPMYOmKuh3yn" Ids="TycpeS1zdBhOpUXQ8k7lGG,SyN5GsDg4byLBeGRsLAdbl" />
-                  <Link Id="OtN2NQ8KaNCPX0yDdM9VeT" Ids="VGP0W2Lw4nGPOhNK6t4MLX,PHXoYqzjk5NLKWGytScxyv" />
-                  <Link Id="JR9YRWyB3soMi2uQw7woFc" Ids="VIQH5pqr2raN77tDvb0PJu,ELxwj0IPI9dNSCikhC6cVV" />
-                  <Link Id="I4AO8FmwyeCM5oMKAkIPem" Ids="MMtRdYHEfHQQK0GNeIATwh,Axv0bmx0sRIP94ikBb34BU" />
-                  <Link Id="OETkghhQLCwQJAjJ8Wdl5d" Ids="DsnkQIG7s6BNekg1qM9cPf,HJnqa54cN6DPmjNm68keN7" />
-                  <Link Id="LAT12TR5oTqNxNWJjSbieE" Ids="DpFAS7CxISSOI6O5cYU2E8,MvJw0I331PfNEdekYb63nY" />
-                  <Link Id="NhlR0JK3FIBPsqQEIRhW8p" Ids="QMmaG5pFMFgPFXJ2pWssCf,P7HuLFiHwnKQRxWMTWUk8C" />
-                  <Link Id="Pwp7YqfceWvOiZpMOxvBCC" Ids="Ncz5gCY3fTpMUJ18CR6wFp,Sz2Ptx7PM2qQTUg7JiYXiP" />
-                  <Link Id="UzKRXpn6Y6WMkR4mmiAcZV" Ids="UYtmio0ZMhbO4y9adsOaxp,M4TFWSCVk3wNmhRK3gFEdr" />
-                  <Link Id="NuRwnyjx12yP03C0gQkkGa" Ids="QqvaTpOYSyoNwM6ScdEaya,MHuQ5fVYiT0P6kinyU6yA1" />
-                  <Link Id="FckisNroJ7RLx8CLYospqJ" Ids="Ql0orqvhwZKPyZ8wDNMtxd,VIccR7A37FEK9uAHoInarV" />
-                </Patch>
-              </Node>
-              <!--
-
     ************************ Global ************************
 
 -->
-              <Node Name="Global" Bounds="423,398" Id="PG4RHqlQbhMObZnqDqnkVD">
+              <Node Name="Global" Bounds="93,225" Id="PG4RHqlQbhMObZnqDqnkVD">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="ClassDefinition" Name="Class" />
                 </p:NodeReference>
@@ -52165,7 +51817,7 @@
                   <Link Id="Km5mklWrarSMuy8DtPSPj5" Ids="FlGku3i43zMLLmatqkCCom,Qg8hSYIs664LVao1ETsP4D" />
                 </Patch>
               </Node>
-              <Canvas Id="H9ccOhNnCFROnJ92sWe9FT" Name="Audio" Position="447,450">
+              <Canvas Id="H9ccOhNnCFROnJ92sWe9FT" Name="Audio" Position="93,290">
                 <!--
 
     ************************ Level ************************
@@ -62911,7 +62563,6 @@
   <NugetDependency Id="GrC8xaUMwn4MZwjSBKGsTz" Location="Csv" Version="2.0.93" />
   <NugetDependency Id="L6BoZEdIC1fPpiehk66FpI" Location="VL.IO.Midi" Version="2.0.4" />
   <PlatformDependency Id="O7rdP89oF1UPNoubLT4KKV" Location="System.Diagnostics.Debug" />
-  <NugetDependency Id="C4Yl2tAKeLRNU3XegdjoNf" Location="ncalc" Version="1.3.8" />
   <DocumentDependency Id="M2pvWdXTRcKM73Wor3khLk" Location="./VL.LinearSpread.vl" />
   <NugetDependency Id="RixNdOgIlcmN9jiTafifzl" Location="VL.IO.Xbox360Controller" Version="1.0.4" />
   <DocumentDependency Id="PBxGQ2mzhwiMf7jTlCPrLi" Location="./VL.Schema.Config.vl" IsForward="true" />

--- a/Main/vl/VVVV.Schema.Core.vl
+++ b/Main/vl/VVVV.Schema.Core.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="NavXg4rbp7DOs3twJZ1RLi" LanguageVersion="2024.6.2" Version="0.128">
-  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2024.6.2" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="NavXg4rbp7DOs3twJZ1RLi" LanguageVersion="2024.6.7" Version="0.128">
+  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2024.6.7" />
   <Patch Id="Th8hpfHvBF4Lk6VOwDCc9D">
     <Canvas Id="NtZT52Xp5qNOXK0fF2H7kv" DefaultCategory="VVVV.Schema" CanvasType="FullCategory">
       <Canvas Id="ACGTwDN2TwVPdWleiRveRH" Name="Import" Position="-677,-490">
@@ -11005,6 +11005,7 @@
                             <CategoryReference Kind="RecordType" Name="KeyValuePair" NeedsToBeDirectParent="true" />
                           </p:NodeReference>
                           <Pin Id="LmW5WzCjlteOagpHCs9sWI" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="FfihujlOA4yMCP2ZffnaAN" Name="Output" Kind="OutputPin" IsHidden="true" />
                           <Pin Id="NawbmHLER3AOE6E5Q5W3Fq" Name="Value" Kind="OutputPin" />
                         </Node>
                         <Node Bounds="1538,414,225,26" Id="NNJAov9iqLOOWWPc2N1nud">
@@ -11841,6 +11842,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="Node" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="NmRoee12DYLLoyOMCToYhe" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="FEzgBgepUAgO15ZXi6h4ux" Name="Bee" Kind="InputPin" />
                   <Pin Id="NCcXZ9sVzFOP1dOkahfcAR" Name="Properties" Kind="InputPin" />
                   <Pin Id="Bqaa0OIdDecPfqPSeeStn6" Name="Name" Kind="InputPin" DefaultValue="New">
@@ -11860,6 +11862,7 @@
                     <CategoryReference Kind="ClassType" Name="PassthroughBee" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="CPBP2wBijHGQY5Ro8amphB" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="B64UwBebqPVN0ZKDEuJyfh" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 </Node>
                 <Link Id="V0DyJFBzIpgOnn3croZKk5" Ids="CPBP2wBijHGQY5Ro8amphB,FEzgBgepUAgO15ZXi6h4ux" />
                 <ControlPoint Id="N1KpshRvvW8NkeGSTyFDn5" Bounds="-520,380" />
@@ -12309,9 +12312,9 @@
             <Pin Id="MsY2qlxBj00Ok08d7fKjTc" Name="State" Kind="InputPin" />
             <Pin Id="HV76h5D8yMqPXoJ8eHX4TR" Name="Previous Layer States" Kind="InputPin" />
             <Pin Id="JGOcSPMIsvVL98OIViYxUd" Name="Global" Kind="InputPin" />
-            <Pin Id="KH9DfjpF6QwOF0JS7w8plw" Name="Properties" Kind="InputPin" />
             <Pin Id="TcjOciUAlLOLrqMpmxjWu8" Name="New State" Kind="OutputPin" />
             <Pin Id="CL5BjMZbmJLOLnErIuxCF3" Name="Node Operation" Kind="OutputPin" />
+            <Pin Id="IaQjOzMczc1PjTXYQxbZnq" Name="Properties" Kind="InputPin" />
           </Patch>
           <Patch Id="KaCaE3sKV3UMVtoT2k9fVI" Name="GetChildren">
             <Pin Id="C0BKrPp9iE9N5esRHhPybU" Name="Children" Kind="OutputPin" />
@@ -13004,13 +13007,13 @@
           <Link Id="C8cmZKeAfHyPP67K7WtHm5" Ids="T29DpogE4b2LdkohUTTmJ3,R6Bo59veWFeNHB6xZ8HqAl" />
           <Patch Id="QFjBE7nZ6v3QIMDO7h0tlZ" Name="Create" />
           <Patch Id="F2GiypGHcmWMNd3KKUzSEV" Name="Update">
-            <Pin Id="AHxWlp1eOGXPEc56njFbbK" Name="Setup" Kind="InputPin" />
+            <Pin Id="QsiHuHyA2uIOJJ8LAWoIoq" Name="Setup" Kind="InputPin" />
             <Pin Id="QXu17NLnnfXNcWxWfddTlu" Name="State" Kind="InputPin" />
-            <Pin Id="Ud7IkhC0tZpOfzZn1IswFF" Name="Previous Layer States" Kind="InputPin" />
-            <Pin Id="Q4zApwMT0ASP3UnXQSExmw" Name="Global" Kind="InputPin" />
-            <Pin Id="ScNAiGJQBOPOESBSlpwATe" Name="Properties" Kind="InputPin" />
             <Pin Id="R5iYxD4bMKqNYTC5XMP5wX" Name="New State" Kind="OutputPin" />
-            <Pin Id="MzABgESkxjQLW8dQzC9gYN" Name="Node Operation" Kind="OutputPin" />
+            <Pin Id="D9Kaq3ubLOJOY2cStOsRie" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="OYY5aTray5xPReM9zmfsOV" Name="Global" Kind="InputPin" />
+            <Pin Id="VnVUvYtiSGEN0IOfGuGZzO" Name="Properties" Kind="InputPin" />
+            <Pin Id="PPTwuEGmP1LN3otF59oYG2" Name="Node Operation" Kind="OutputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -13256,6 +13259,7 @@
                   </p:NodeReference>
                   <Pin Id="GqQ6kudYyl7MuXZ5Gayq32" Name="Input" Kind="StateInputPin" />
                   <Pin Id="BjMOMWd04k7OGNzaxGH69v" Name="Key" Kind="InputPin" />
+                  <Pin Id="VBXnG6RgZ6LM3w20E7Isgp" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="Eoc3tLC8ppVLLF98h810jp" Name="Result" Kind="OutputPin" />
                   <Pin Id="Qo4LpZ7CPkaQEvb5zA7AGP" Name="Value" Kind="OutputPin" />
                 </Node>
@@ -13296,6 +13300,7 @@
                         <Choice Kind="OperationCallFlag" Name="Create" />
                         <CategoryReference Kind="ClassType" Name="Node" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
+                      <Pin Id="J0AfzMXCWkULiBp9W7RKTc" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="M2WMeAfrWcKNrVJDH1K5lS" Name="Bee" Kind="InputPin" />
                       <Pin Id="TVd3bWgGAtNO90qwXvAQBq" Name="Properties" Kind="InputPin" />
                       <Pin Id="OujAUAM0OUfPmrLbdwvjD5" Name="Name" Kind="InputPin" />
@@ -16700,6 +16705,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="Fixture" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="UPeF6xqPDh3PmQbMkcA9wE" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="LUparBtgkNaQVfwdkQ7QNZ" Name="Name" Kind="InputPin" />
                   <Pin Id="KdS8zcsXwA6PdGfwmP1Cd0" Name="Setup" Kind="InputPin" />
                   <Pin Id="JM9XxtR78YtPFehib5MiD8" Name="State" Kind="InputPin" />
@@ -16810,6 +16816,7 @@
                     <CategoryReference Kind="ClassType" Name="PassthroughBee" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="P0UAizHZTJCPXASmbLUa8K" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="R3ZRXgZBRymMU2mhXe3uZZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 </Node>
                 <Node Bounds="130,551,105,26" Id="Cy1Ar4UDt4bQYPXvBgWUFb">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Node" LastDependency="VVVV.Schema.Core.vl">
@@ -16817,6 +16824,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="Node" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="DWzFSghavBOLitzrz6yGfy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JmdGTB77NGuPHNJTCz6tyh" Name="Bee" Kind="InputPin" />
                   <Pin Id="GUfp5FXjUrPM3lsH6m0wVT" Name="Properties" Kind="InputPin" />
                   <Pin Id="NqRlXOlJy92OrpS0tpgOks" Name="Name" Kind="InputPin" DefaultValue="New">
@@ -17165,6 +17173,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="SpreadBuilder" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="UxJzszNOg7DMNycTzqWBYH" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="BbfNaHzhp3RPc1iPnUsVUC" Name="Capacity" Kind="InputPin" />
                   <Pin Id="EXa0UVSD65xPw4RTSP49gi" Name="Output" Kind="StateOutputPin" />
                 </Node>
@@ -17858,6 +17867,7 @@
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessAppFlag" Name="RemoveNumberSuffix" />
                               </p:NodeReference>
+                              <Pin Id="HALsRdSFOGGMjkOZekWXMD" Name="Node Context" Kind="InputPin" IsHidden="true" />
                               <Pin Id="RO1wevJfk3qNlGUgFWtXN9" Name="Input" Kind="InputPin" />
                               <Pin Id="B5S8emqGHlBLnmiFxsOrdI" Name="Result" Kind="OutputPin" />
                             </Node>
@@ -17894,6 +17904,7 @@
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="ProcessAppFlag" Name="Matches" />
                             </p:NodeReference>
+                            <Pin Id="LLvcsJCAZ5cPwSUwFMuA8P" Name="Node Context" Kind="InputPin" IsHidden="true" />
                             <Pin Id="BbcHpQr9plsOENtd0ncFiQ" Name="Input" Kind="InputPin" />
                             <Pin Id="RoRZlb0YHRsN7BtMkuEtDT" Name="Pattern" Kind="InputPin" DefaultValue="^(.*?)(\.\d{3})$">
                               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -18037,6 +18048,7 @@
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessNode" Name="MakeFixtureNamesUnique" />
                       </p:NodeReference>
+                      <Pin Id="BF6cLzahMpvPE4NDApVg7k" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="B5fT7e60uIeLpOjiCwpXYZ" Name="Input" Kind="InputPin" />
                       <Pin Id="STTAafM0TRZLM2XL249AF8" Name="Output" Kind="OutputPin" />
                     </Node>
@@ -18155,6 +18167,7 @@
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="OnOpen" />
                     </p:NodeReference>
+                    <Pin Id="JmJHhvyfdX8NBU2yzUh3w1" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="Ls3dqbJe6M2P1aaAk66aHW" Name="Simulate" Kind="InputPin" />
                     <Pin Id="StnfJ1WPsnaP3Vdas8Ay3Z" Name="Output" Kind="OutputPin" />
                   </Node>
@@ -19157,6 +19170,7 @@
                 </Node>
                 <Patch Id="F9LIjYUZ2uTLmrLqohiY0x" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="BBg4m53AdpWMt0JlAh9mum" Name="Update" />
+                <Patch Id="ICBN4YdP1TGLHdsqQkot1d" Name="Dispose" />
               </Patch>
             </Node>
             <Pad Id="GqmCZj0l4SZL5KBJdfF6WB" SlotId="AEG1pE4ARRgMlDXPIVLt1e" Bounds="-200,-962" />
@@ -19208,6 +19222,7 @@
                         <Choice Kind="OperationCallFlag" Name="Value" />
                       </p:NodeReference>
                       <Pin Id="LDp9P3mLn2sMq9ivHcfudy" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="T5lU1PWoh6zL2NDo9k0DLa" Name="Output" Kind="OutputPin" IsHidden="true" />
                       <Pin Id="HEhNE3H51RTLQcygOAuCPy" Name="Value" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="-927,-111,76,19" Id="Q9iTd7IBpkZONPXNRe7Rdm">
@@ -19335,6 +19350,7 @@
                     <CategoryReference Kind="ClassType" Name="PropertyBank" />
                     <Choice Kind="OperationCallFlag" Name="Create" />
                   </p:NodeReference>
+                  <Pin Id="KKhcZEnPDKXLPJFVFW4mQL" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="T4lqK3TRzyXQdePBXBq45X" Name="Properties" Kind="InputPin" />
                   <Pin Id="RiEFwHb6eyvOB44nJc4JWL" Name="Output" Kind="StateOutputPin" />
                 </Node>
@@ -22145,7 +22161,7 @@
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <Patch Id="QgerIw3NZ7MQNhcpTs7jUu" IsGeneric="true">
-            <Node Bounds="-51,280,66,26" Id="CaebScBg9LaPGiAcEkj8Au">
+            <Node Bounds="-51,280,66,19" Id="CaebScBg9LaPGiAcEkj8Au">
               <p:NodeReference LastCategoryFullName="System.Serialization" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Deserialize" />
@@ -22155,7 +22171,7 @@
               <Pin Id="USJOVlKxUynNLb4wsfE7ef" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="ReEDNFg9E1tO1jiJ4apD3V" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="-51,248,60,26" Id="HAlxhqTGE8wMcQT0BJWVYT">
+            <Node Bounds="-51,248,60,19" Id="HAlxhqTGE8wMcQT0BJWVYT">
               <p:NodeReference LastCategoryFullName="System.Serialization" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Serialize" />
@@ -24262,48 +24278,60 @@
     ************************ DirectoryFilePath ************************
 
 -->
-        <Node Name="DirectoryFilePath" Bounds="2868,-1189,232,141" Id="Pz2loSLa82fPivyDLYfnkE">
+        <Node Name="DirectoryFilePath" Bounds="2868,-1192,237,179" Id="Pz2loSLa82fPivyDLYfnkE">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="CdTHDSPn9jmPzlai78FUfz">
-            <Node Bounds="2883,-1104,57,19" Id="T7F49bI67HhN6Gzczjrs9A">
-              <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
-              </p:NodeReference>
-              <Pin Id="OK9Ypb8HmBQMwo4KtZi6hy" Name="Directory" Kind="InputPin" />
-              <Pin Id="ChINKsALwzKLk987Ena7lj" Name="Filename" Kind="InputPin" />
-              <Pin Id="RbMR5EO88Q8NfaawBcQVMA" Name="Extension" Kind="InputPin" />
-              <Pin Id="OJzrt9clnxVPmGusUlLthd" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="2881,-1152,57,19" Id="HWzQDc83teAM1SIrRfE9QG">
-              <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="Filename (Split)" />
-              </p:NodeReference>
-              <Pin Id="SFuLpT1DcBHP1Qk3bjCOrD" Name="Input" Kind="StateInputPin" />
-              <Pin Id="DhnUAjCBgdJNsPgwksf6B6" Name="Directory" Kind="OutputPin" />
-              <Pin Id="TuEf6e09lAgOnnmeBXtfnk" Name="Filename" Kind="OutputPin" />
-              <Pin Id="JM7T512Z9v9LrjZVlTp3NQ" Name="Extension" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="GttVFQFge0sO4MPMj1vrUx" Bounds="2882,-1171" />
-            <Link Id="BY1s0PX9otXM6rldoZYSYc" Ids="GttVFQFge0sO4MPMj1vrUx,SFuLpT1DcBHP1Qk3bjCOrD" />
+            <ControlPoint Id="GttVFQFge0sO4MPMj1vrUx" Bounds="2882,-1174" />
             <Link Id="VTdxmjw3YlQLaqjFdTq7up" Ids="EaWP5MUjxQ2QBIOBticTAO,GttVFQFge0sO4MPMj1vrUx" IsHidden="true" />
-            <ControlPoint Id="BIeNZqITqiDPhNYuF8VP30" Bounds="2886,-1067" />
-            <Link Id="SVvwXUV5dlXN9XJzVb4pbZ" Ids="OJzrt9clnxVPmGusUlLthd,BIeNZqITqiDPhNYuF8VP30" />
+            <ControlPoint Id="BIeNZqITqiDPhNYuF8VP30" Bounds="2886,-1030" />
             <Link Id="PMbN2FsI8amO2FlDk5pjN1" Ids="BIeNZqITqiDPhNYuF8VP30,FaCUkGa3pKIPuhhZFi4aeU" IsHidden="true" />
-            <ControlPoint Id="JDesIeO0LO1OgmBpTt1u57" Bounds="2962,-1171" />
-            <Link Id="DF5MUEkT6uXP15ohtIdQtt" Ids="JDesIeO0LO1OgmBpTt1u57,ChINKsALwzKLk987Ena7lj" />
+            <ControlPoint Id="JDesIeO0LO1OgmBpTt1u57" Bounds="2970,-1174" />
             <Link Id="HsPuz8JPxhmNQvgUTDjl2H" Ids="PBsOXSo8wJ0P3tHxqeQELy,JDesIeO0LO1OgmBpTt1u57" IsHidden="true" />
-            <ControlPoint Id="BPaAYksfcSxNRxzZpMA6eq" Bounds="3032,-1165" />
-            <Link Id="I8eMQ9gRRdiOWP4RQXVSqM" Ids="BPaAYksfcSxNRxzZpMA6eq,RbMR5EO88Q8NfaawBcQVMA" />
+            <ControlPoint Id="BPaAYksfcSxNRxzZpMA6eq" Bounds="3037,-1174" />
             <Link Id="Hr86CY9pikENRHi4QYLCAG" Ids="KvwfAx7K6jkO0IVpwxDuHH,BPaAYksfcSxNRxzZpMA6eq" IsHidden="true" />
-            <Link Id="OUpCYjHN58uPc0iEKK76JR" Ids="DhnUAjCBgdJNsPgwksf6B6,OK9Ypb8HmBQMwo4KtZi6hy" />
             <Pin Id="EaWP5MUjxQ2QBIOBticTAO" Name="Directory Path" Kind="InputPin" Bounds="2972,-1207" />
             <Pin Id="PBsOXSo8wJ0P3tHxqeQELy" Name="Filename" Kind="InputPin" Bounds="3021,-1211" />
             <Pin Id="KvwfAx7K6jkO0IVpwxDuHH" Name="Extension" Kind="InputPin" Bounds="3091,-1205" />
             <Pin Id="FaCUkGa3pKIPuhhZFi4aeU" Name="Result" Kind="OutputPin" Bounds="2976,-1103" />
+            <Node Bounds="2936,-1108,60,19" Id="LuCmCNjCR1qPzbxQee1gK5">
+              <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="MakePath" />
+              </p:NodeReference>
+              <Pin Id="Ic8jkUZFOnyMLhW8OnPH2H" Name="Path" Kind="InputPin" IsHidden="true" />
+              <Pin Id="QoM6AscZsZMNobByqXudYI" Name="Input" Kind="InputPin" />
+              <Pin Id="OBVtgvdFsysP5gbGVyED28" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="2884,-1076,57,26" Id="NQbHTcCUd8SMHNON2PdTge">
+              <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="4026531840" Name="Path" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="IO" NeedsToBeDirectParent="true" />
+                </CategoryReference>
+                <Choice Kind="OperationCallFlag" Name="Combine" />
+              </p:NodeReference>
+              <Pin Id="D54f1vuUxeeOyJHAv4LsBc" Name="Input" Kind="StateInputPin" />
+              <Pin Id="K3pkl1D1E6ILYfQqhvHwmR" Name="Input 2" Kind="InputPin" />
+              <Pin Id="LeUgN0GE17sM0BpMqorNXM" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Link Id="Jycz6dmwDQVM0Vsvc3DPIg" Ids="GttVFQFge0sO4MPMj1vrUx,D54f1vuUxeeOyJHAv4LsBc" />
+            <Node Bounds="2936,-1136,45,19" Id="QP0mFMjoKFzNOemDIPV4qq">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="+" />
+              </p:NodeReference>
+              <Pin Id="MFNOOP0i1nxNe0s4jI7GwG" Name="Input" Kind="InputPin" />
+              <Pin Id="PUFSgdoTmaeNcwHRJzLF3l" Name="Input 2" Kind="InputPin" DefaultValue="." />
+              <Pin Id="KpJWnz9AIlENlcUky9hd2K" Name="Output" Kind="OutputPin" />
+              <Pin Id="MIvSzegjbcxNWjN1Qy1toq" Name="Input 3" Kind="InputPin" />
+            </Node>
+            <Link Id="Vhrx1OIu0SRPEjNmc7Tp1T" Ids="JDesIeO0LO1OgmBpTt1u57,MFNOOP0i1nxNe0s4jI7GwG" />
+            <Link Id="RPNyuI9EVkMPNc3CSniNou" Ids="BPaAYksfcSxNRxzZpMA6eq,MIvSzegjbcxNWjN1Qy1toq" />
+            <Link Id="EKv67cuzjuQPNiF4tQjb7z" Ids="KpJWnz9AIlENlcUky9hd2K,QoM6AscZsZMNobByqXudYI" />
+            <Link Id="MVSkg6dhMz4PQqpPxDtT6C" Ids="OBVtgvdFsysP5gbGVyED28,K3pkl1D1E6ILYfQqhvHwmR" />
+            <Link Id="Q2NzGgORcvXO5EYOra53RF" Ids="LeUgN0GE17sM0BpMqorNXM,BIeNZqITqiDPhNYuF8VP30" />
           </Patch>
         </Node>
         <!--
@@ -25356,10 +25384,10 @@
                       <Pin Id="P1EiNP6KZyWO5gTp9HykTH" Name="State" Kind="InputPin" />
                       <Pin Id="EiBbSIVP4a9Mjo6NC4oQvw" Name="Previous Layer States" Kind="InputPin" />
                       <Pin Id="NnqQn2XdKKnOAVwCgokEwF" Name="Global" Kind="InputPin" />
-                      <Pin Id="OEzsenOFydmPTv7DUtGq5n" Name="Properties" Kind="InputPin" />
                       <Pin Id="NhdbMIKnTQuLqK9akC7sk0" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="NWyAGHL6OzzOnRjn4OyV4q" Name="New State" Kind="OutputPin" />
                       <Pin Id="Uhf9QBoB7GTL6BxTVEl6MB" Name="Node Operation" Kind="OutputPin" />
+                      <Pin Id="BlTjmbkf3e8NyztNHjqEF0" Name="Properties" Kind="InputPin" />
                     </Node>
                     <Node Bounds="743,1671,38,26" Id="Nh1waDQte6ON8nma8jYPCs">
                       <p:NodeReference LastCategoryFullName="Collections.Stack" LastDependency="VL.CoreLib.vl">
@@ -26787,7 +26815,7 @@
               <Pin Id="Mhc1yC0e0zINL4aOYrDe1b" Name="Context" Kind="InputPin" />
               <Pin Id="QiJnYN2GNUzL6Awl2QmsXI" Name="Last Content" Kind="InputPin" />
               <Pin Id="Q4uQTZo00QVLs8krCdpLqU" Name="Output" Kind="OutputPin" />
-              <Pin Id="HQoiu4Un9skMq9C0RcFXuy" Name="Context" Kind="OutputPin" />
+              <Pin Id="NJXGtJO3pu8NLiC6sQ2ooy" Name="Context" Kind="OutputPin" />
               <Pin Id="G1188jU8YH2Lsp6uklbg6c" Name="Loaded Content" Kind="OutputPin" />
             </Node>
             <Pad Id="R0yxExdnrjlMov5wlHfOnX" SlotId="TMQLd4zoFKRNWhSlxdh4P1" Bounds="491,500" />
@@ -27677,6 +27705,7 @@
                         <Choice Kind="OperationCallFlag" Name="Create" />
                         <CategoryReference Kind="ArrayType" Name="MutableArray" NeedsToBeDirectParent="true" />
                       </p:NodeReference>
+                      <Pin Id="Dci1wfEp1T8QH9ksnn6Meh" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="Sce15hXdLD7PlTRlN8ky3M" Name="Length" Kind="InputPin" />
                       <Pin Id="Gq4JznBJRDhOsZvULR0f9M" Name="Result" Kind="StateOutputPin" />
                     </Node>
@@ -30007,6 +30036,7 @@
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessNode" Name="ChangedFader" />
                     </p:NodeReference>
+                    <Pin Id="NJinjIRrOEbNtlwDFTICR0" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="U6A0T86pmdZLlS4xhILZjv" Name="Input" Kind="InputPin" />
                     <Pin Id="EXds3nfu3lYMhvu6YIJtNb" Name="Target" Kind="InputPin" />
                     <Pin Id="E1g4bMywEiaNPgnPaIYB8X" Name="Period" Kind="InputPin" />
@@ -30693,7 +30723,9 @@
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="LFO" />
                     </p:NodeReference>
+                    <Pin Id="VZvMiSg7gu5QUR1JF0KmMj" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="VQC08ET8Y2DNJCGtH1oMyK" Name="Clock" Kind="InputPin" />
+                    <Pin Id="Srz6iU0TFOtLymYHObJ7hR" Name="New Clock" Kind="InputPin" IsHidden="true" />
                     <Pin Id="Qc3rotc9IGAM31tOW36YbX" Name="Period" Kind="InputPin" />
                     <Pin Id="BxyQvdjfV0JOHQxCckNWfj" Name="Pause" Kind="InputPin" />
                     <Pin Id="DliyKAjg78jMIVfzEI3jRJ" Name="Reset" Kind="ApplyPin" />
@@ -30716,6 +30748,7 @@
                       <Choice Kind="ProcessAppFlag" Name="S+H" />
                       <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
                     </p:NodeReference>
+                    <Pin Id="EulD6Rfh1j1OUzQj9cb2XU" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="Ng2AwJv4wrROxi5M9yLiXh" Name="Initial Value" Kind="InputPin" />
                     <Pin Id="PUvBdqimROtLoZGDoC5tGI" Name="Value" Kind="InputPin" />
                     <Pin Id="R8t5u8PxJyiLY5NS5BAkum" Name="Sample" Kind="InputPin" />
@@ -30757,6 +30790,7 @@
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="FrameDelay" />
                     </p:NodeReference>
+                    <Pin Id="IVCU4MMSmEMMT0dyy4V4rG" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="DvTWNVWgIAhOY8b2kcdBUE" Name="Initial Value" Kind="InputPin" />
                     <Pin Id="G1DsWxNbvqALneJq9STCzk" Name="Value" Kind="InputPin" />
                     <Pin Id="S2uO2Zam5vwPEWSnJVGa8G" Name="Value" Kind="OutputPin" />
@@ -42029,6 +42063,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="Driver" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="T8WcdVSCcJBMDLQj71wUKF" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Nk08SUQv7kdMqprpGLm3bi" Name="From" Kind="InputPin" />
                   <Pin Id="QzqZj4RxmkxNx4OE0KyIVE" Name="To" Kind="InputPin" />
                   <Pin Id="CVwC9D7FtyIPxThPZTl4l9" Name="Name" Kind="InputPin" DefaultValue="Driver">
@@ -42047,6 +42082,7 @@
                     <CategoryReference Kind="ClassType" Name="ValueConstantBee" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="MzOr8LCt4GYOlDN7Z7L3Sv" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="VDIQ3HvIDXUOWzRsl6ER46" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 </Node>
                 <Node Bounds="440,-70,105,26" Id="JS957AZij9uQdvmAeiiEIQ">
                   <p:NodeReference LastCategoryFullName="VVVV.Schema.Node" LastDependency="VVVV.Schema.Core.vl">
@@ -42054,6 +42090,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="Node" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="GvHEyqZTSTyL9xs016MItd" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QhQlk0MZFFJNRpCTUpn42J" Name="Bee" Kind="InputPin" />
                   <Pin Id="BVKuMgNiuYGPymItILeJFz" Name="Properties" Kind="InputPin" />
                   <Pin Id="M7FCWX1BxbPP6PJWGgWPrK" Name="Name" Kind="InputPin" DefaultValue="S.Value.Constant">
@@ -42073,6 +42110,7 @@
                     <Choice Kind="OperationCallFlag" Name="Create" />
                     <CategoryReference Kind="ClassType" Name="Node" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
+                  <Pin Id="Is5c2qa4UgTP7an3tXIjwZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OQCg9F0QZzsP8xWjYnrC97" Name="Bee" Kind="InputPin" />
                   <Pin Id="EKeN0qKlo1ZLdc3dN4IoxI" Name="Properties" Kind="InputPin" />
                   <Pin Id="AAH5K5NGrIoP1Ko5z5Fw89" Name="Name" Kind="InputPin" DefaultValue="Value">
@@ -42092,6 +42130,7 @@
                     <CategoryReference Kind="ClassType" Name="PassthroughBee" NeedsToBeDirectParent="true" />
                   </p:NodeReference>
                   <Pin Id="RtUduRQAlw7QMJ3DAqy2dA" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="G4IdRLFiwxMLMs2PPAvobQ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 </Node>
                 <Link Id="LytSBoXIHkBMF0SycRfZin" Ids="RtUduRQAlw7QMJ3DAqy2dA,OQCg9F0QZzsP8xWjYnrC97" />
                 <Node Bounds="469,-28,16,19" Id="NZu7bjHEN9gOqcGILpq1hZ">
@@ -42467,7 +42506,7 @@
           </Patch>
           <Patch Id="K1VSqBLP5wyOYYo0AfFzXF" Name="SetNode">
             <Pin Id="LMstxV1zpHfQTT3hpYUwX9" Name="Root Node" Kind="InputPin" />
-            <Pin Id="BuClTVVYyaHNr4pTGFwRLI" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="DY7IIcJrMigM4TWKzi8jFK" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="OwQF9JVmoMEL92JMH0MFYn" Name="GetSetup">
             <Pin Id="Tzln8INOGeHOmPwLzFQhvW" Name="Setup" Kind="OutputPin" />
@@ -42476,19 +42515,19 @@
             <Pin Id="R471o1HsFVnOCsNpbmOxhV" Name="Name" Kind="OutputPin" />
           </Patch>
           <Patch Id="RxSENQUOIIoP64lLKDwsat" Name="GetNode">
-            <Pin Id="SLuUSiK4eG6P5vdps7ALav" Name="Layer Index" Kind="InputPin" />
             <Pin Id="ASjxsVfwoSDOS5uqP61sin" Name="Root Node" Kind="OutputPin" />
+            <Pin Id="SKGiEWYQKQBLRUvs9lk5xh" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="PcAC7AUwhyjK9sWKKGJCRe" Name="GetType">
             <Pin Id="FEw9ono9mi3MWfJ6PhxkY2" Name="Type" Kind="OutputPin" />
           </Patch>
           <Patch Id="FtOtBZ5oyz1NEmsVxOqr43" Name="SetLastAssigned">
             <Pin Id="IhkYiFkpKunO3Z5MuR2Gqn" MergeId="700333" Name="LastAssigned" Kind="InputPin" />
-            <Pin Id="VdpYvorFqNxOjSioRxEhNY" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="HdVtQpNFt34NUUGeYasVz2" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="Ue6LShoqEuAOXmFq1poOPv" Name="GetLastAssigned">
-            <Pin Id="KbsfYjGoSsaMZbLCcwBND8" Name="Layer Index" Kind="InputPin" />
             <Pin Id="DXUFfe4BTlVLAhqUyZCHWI" MergeId="709913" Name="LastAssigned" Kind="OutputPin" />
+            <Pin Id="SNBL7CBDDd3NqWHCcKXBIN" Name="Layer Index" Kind="InputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -62872,7 +62911,7 @@
     </Node>
   </Patch>
   <NugetDependency Id="GrC8xaUMwn4MZwjSBKGsTz" Location="Csv" Version="2.0.93" />
-  <NugetDependency Id="L6BoZEdIC1fPpiehk66FpI" Location="VL.IO.Midi" Version="1.1.0" />
+  <NugetDependency Id="L6BoZEdIC1fPpiehk66FpI" Location="VL.IO.Midi" Version="1.1.1" />
   <PlatformDependency Id="O7rdP89oF1UPNoubLT4KKV" Location="System.Diagnostics.Debug" />
   <NugetDependency Id="C4Yl2tAKeLRNU3XegdjoNf" Location="ncalc" Version="1.3.8" />
   <DocumentDependency Id="M2pvWdXTRcKM73Wor3khLk" Location="./VL.LinearSpread.vl" />

--- a/Main/vl/VVVV.Schema.Core.vl
+++ b/Main/vl/VVVV.Schema.Core.vl
@@ -1292,14 +1292,14 @@
     ************************ StripDefinition (Split) ************************
 
 -->
-        <Node Name="StripDefinition (Split)" Bounds="348,244,507,143" Id="IyultE4BVduN4DYpgW6HJn">
+        <Node Name="StripDefinition (Split)" Bounds="347,242,509,145" Id="IyultE4BVduN4DYpgW6HJn">
           <p:NodeReference>
             <Choice Kind="OperationDefinition" Name="Operation" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <p:HideCategory p:Type="Boolean">true</p:HideCategory>
           <Patch Id="ENOx1ASKcyvNLuqnAGlczF">
-            <Node Bounds="385,294,327,22" Id="DoB358oLG44OEaERcXBMcR">
+            <Node Bounds="385,294,327,26" Id="DoB358oLG44OEaERcXBMcR">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.StripDefinition" LastDependency="VVVV.Schema.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Split" />
@@ -1526,13 +1526,13 @@
     ************************ Setup (Split) ************************
 
 -->
-        <Node Name="Setup (Split)" Bounds="354,544,114,133" Id="HgyDSmfssHYNRGRr1yfqbn">
+        <Node Name="Setup (Split)" Bounds="354,542,114,135" Id="HgyDSmfssHYNRGRr1yfqbn">
           <p:NodeReference>
             <Choice Kind="OperationDefinition" Name="Operation" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <Patch Id="RlhONetvoLqPe2cYXU9d4r">
-            <Node Bounds="391,595,46,22" Id="FpMtg4zr9g8LrsVyJUv9NG">
+            <Node Bounds="391,595,65,26" Id="FpMtg4zr9g8LrsVyJUv9NG">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.Setup" LastDependency="VVVV.Schema.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Split" />
@@ -1564,13 +1564,13 @@
     ************************ Pixel (Split) ************************
 
 -->
-        <Node Name="Pixel (Split)" Bounds="897,240,242,140" Id="Hsk2nmADb9nPspxRb84g3M">
+        <Node Name="Pixel (Split)" Bounds="897,238,243,142" Id="Hsk2nmADb9nPspxRb84g3M">
           <p:NodeReference>
             <Choice Kind="OperationDefinition" Name="Operation" />
             <FullNameCategoryReference ID="Primitive" />
           </p:NodeReference>
           <Patch Id="B9vLGvWYJivN6u660yQOoa">
-            <Node Bounds="929,288" Id="Utd7rjlp5WiOHoFdT13dGD">
+            <Node Bounds="929,288,68,26" Id="Utd7rjlp5WiOHoFdT13dGD">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.PixelDefinition" LastDependency="VVVV.Schema.Core.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Split" />
@@ -2080,17 +2080,17 @@
                 <Pin Id="IbkR53A3V9IMfPSSMyO9ve" Name="Read" Kind="InputPin" />
                 <Pin Id="HQYCstraSoVNcexTvSOCdd" Name="Output" Kind="OutputPin" />
               </Node>
-              <Pad Id="CUyMUZ1cHHnOzpcA5EYtbI" Comment="Configlist Path" Bounds="2664,234,473,20" ShowValueBox="true" isIOBox="true" Value="..\config\configlist.txt">
+              <Pad Id="CUyMUZ1cHHnOzpcA5EYtbI" Comment="Configlist Path" Bounds="2625,211,473,20" ShowValueBox="true" isIOBox="true" Value="..\config\configlist.txt">
                 <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Path" />
                 </p:TypeAnnotation>
               </Pad>
-              <Pad Id="NullclvV5RbMuTKHoAHeZs" Comment="Read" Bounds="2720,266,40,19" ShowValueBox="true" isIOBox="true" Value="True">
+              <Pad Id="NullclvV5RbMuTKHoAHeZs" Comment="Read" Bounds="2677,260,40,19" ShowValueBox="true" isIOBox="true" Value="True">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pad>
-              <Pad Id="Tr0TSRwEnpFLX1CsjPSPUV" SlotId="K1xKKToFux8O1Ml4ObtO8Z" Bounds="2614,314" />
+              <Pad Id="Tr0TSRwEnpFLX1CsjPSPUV" SlotId="K1xKKToFux8O1Ml4ObtO8Z" Bounds="2599,330" />
               <Node Bounds="2596,576,189,152" Id="KtrOpPWDUy7LUz20WKjjhK">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
@@ -2347,7 +2347,7 @@
                 </Pin>
                 <Pin Id="ClAClclgVceLe5tEZLr3j5" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <Node Bounds="2868,321,65,19" Id="CCCqgqFC3m0M9XjXOyy2Yc">
+              <Node Bounds="2875,320,65,19" Id="CCCqgqFC3m0M9XjXOyy2Yc">
                 <p:NodeReference LastCategoryFullName="System.IO.NotifyFilters" LastDependency="System.IO.FileSystem.Watcher.dll">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="AssemblyCategory" Name="NotifyFilters" />
@@ -2407,9 +2407,9 @@
                 </p:TypeAnnotation>
               </Pad>
               <Pad Id="IMCE8Vz3psdMTi0mvP8C3U" SlotId="S7rDYfVaLc4Ls0ISJIs1mA" Bounds="1965,312" />
-              <Pad Id="Vpg5kl8etL1Nn75QkeisF4" SlotId="M7MzNPlMNVzNdHm8dnrxVo" Bounds="2723,76" />
-              <ControlPoint Id="M78xGFJSpZ5MyvmkrWcgr6" Bounds="2625,20" />
-              <Node Bounds="2625,152,150,19" Id="IxRn1tIiXifOwVxBwswvr7">
+              <Pad Id="Vpg5kl8etL1Nn75QkeisF4" SlotId="M7MzNPlMNVzNdHm8dnrxVo" Bounds="2625,-89" />
+              <ControlPoint Id="M78xGFJSpZ5MyvmkrWcgr6" Bounds="2625,-130" />
+              <Node Bounds="2623,60,150,19" Id="IxRn1tIiXifOwVxBwswvr7">
                 <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetDirectoryInRegistryPath" />
@@ -2422,8 +2422,8 @@
                 </Pin>
                 <Pin Id="RlO1uHRyLaxMSkgNeecism" Name="Output" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="MLU1k397e6uLXb4PYqcQZp" Bounds="2722,108" />
-              <Node Bounds="2619,190,93,19" Id="ITwJAjoLm3VNx2beNcB232">
+              <ControlPoint Id="MLU1k397e6uLXb4PYqcQZp" Bounds="2723,31" />
+              <Node Bounds="2623,110,93,19" Id="ITwJAjoLm3VNx2beNcB232">
                 <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="DirectoryFilePath" />
@@ -2433,12 +2433,12 @@
                 <Pin Id="Qf89ADm4eleNXquEtqQaI8" Name="Extension" Kind="InputPin" />
                 <Pin Id="KAfnl6x5DanNbEdmHEGRgm" Name="Result" Kind="OutputPin" />
               </Node>
-              <Pad Id="F7r9NAzF0bpQGminBnZg16" Comment="Filename" Bounds="2815,137,20,19" ShowValueBox="true" isIOBox="true" Value="configlist">
+              <Pad Id="F7r9NAzF0bpQGminBnZg16" Comment="Filename" Bounds="2815,67,61,15" ShowValueBox="true" isIOBox="true" Value="configlist">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pad>
-              <Pad Id="Sdl9FZzhZEePoHhCm7PRw4" Comment="Extension" Bounds="2941,135,20,19" ShowValueBox="true" isIOBox="true" Value="txt">
+              <Pad Id="Sdl9FZzhZEePoHhCm7PRw4" Comment="Extension" Bounds="2941,65,37,15" ShowValueBox="true" isIOBox="true" Value="txt">
                 <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
@@ -2582,6 +2582,54 @@
                 <Pin Id="AnnF2yqWHe5Oq9aiBtcp0f" Name="Input" Kind="InputPin" DefaultValue="Registering Output: " />
                 <Pin Id="JYgQtiPN8LpMNjD662sR9t" Name="Input 2" Kind="InputPin" />
                 <Pin Id="BseImjinQdBNYUb5umHqjb" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2645,170,51,19" Id="DJIiOH7NLhyMq3bSWJTxyF">
+                <p:NodeReference LastCategoryFullName="Schema.Utilities.Logging" LastDependency="Schema.Utilities.Logging.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+                </p:NodeReference>
+                <Pin Id="RDfTaESJ71nOH8qf6VVvig" Name="Message" Kind="InputPin" />
+              </Node>
+              <Node Bounds="2645,150,48,19" Id="P0T93T3CRTsQXQPw7Ih6sQ">
+                <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Format" />
+                </p:NodeReference>
+                <Pin Id="CJqW6mdpM02NddoCIKNmWT" Name="Format" Kind="InputPin" DefaultValue="Loading Configuration list: {0}" />
+                <Pin Id="IoxPJgJKoCqQPHOudyVXxy" Name="Input" Kind="InputPin" />
+                <Pin Id="ISQFiuhKwCGO9yKH111pAp" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="2568,-50,75,82" Id="FQXnLanXhpXMMLHAK2ki2R">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="DA4IUriRHMILXBmP5tZsMl" Name="Condition" Kind="InputPin" DefaultValue="True" />
+                <Patch Id="GgbZfM4s2vnLgp0rnUqGVj" ManuallySortedPins="true">
+                  <Patch Id="E0p8Pgcl2ARNpt2uiCA09o" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="TmmGpH1kCfwLBoSYHv54bG" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="2580,-7,51,19" Id="SMUl5vq2QuVP0klZTztUWD">
+                    <p:NodeReference LastCategoryFullName="Schema.Utilities.Logging" LastDependency="Schema.Utilities.Logging.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+                    </p:NodeReference>
+                    <Pin Id="JuifiS5mBlsNoQsdXdxpw9" Name="Message" Kind="InputPin" />
+                  </Node>
+                  <Node Bounds="2580,-27,48,19" Id="UZ9MfRx1zi4N9sk11spEYK">
+                    <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                      <Choice Kind="OperationCallFlag" Name="Format" />
+                    </p:NodeReference>
+                    <Pin Id="EBUdh4Al2P3MFKITljuwGN" Name="Format" Kind="InputPin" DefaultValue="Creating State with Project Directory: {0}" />
+                    <Pin Id="V5v8N3DibqrPKU4sxi5xV8" Name="Input" Kind="InputPin" />
+                    <Pin Id="MtBik6CxBYiOjdaJT73sBj" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="TSAHIdPWF6OPv1SJP3T92s" Bounds="2609,-44" Alignment="Top" />
+                <ControlPoint Id="QZ5LoTOf2elOwbYnVh18ap" Bounds="2609,26" Alignment="Bottom" />
               </Node>
             </Canvas>
             <ProcessDefinition Id="RvGpcJiphCUOPVRMJOXD9Q" IsHidden="true">
@@ -2813,7 +2861,6 @@
             <Link Id="UBwT9O2sXcfPYnUuFjP4qF" Ids="RlO1uHRyLaxMSkgNeecism,UVpzE7RdMPqORGNiZIx9Lj" />
             <Link Id="O8Ju7r9dCg8MGDZceNt2EC" Ids="Vpg5kl8etL1Nn75QkeisF4,MLU1k397e6uLXb4PYqcQZp" />
             <Link Id="QEx6IAZ1p0pQTbl2luljNf" Ids="MLU1k397e6uLXb4PYqcQZp,Ra2U1MBoqZIN8I8Vva8UUf" IsHidden="true" />
-            <Link Id="FYzYpeWvN0OQMq0qNIEH8v" Ids="M78xGFJSpZ5MyvmkrWcgr6,PzLFWaWpPh0MELzdhWhSk3" />
             <Link Id="KBffhvAtZBmM0aM8vc0AvP" Ids="CUyMUZ1cHHnOzpcA5EYtbI,AEnqNq2E32aPNhW3e2NTZW" />
             <Link Id="E3NUuWLENb5QMnnbu6Q2TM" Ids="F7r9NAzF0bpQGminBnZg16,EJu8vPjv3HhNUJf4WQ7d1a" />
             <Link Id="LVOKroAzTcRPj0Tt7s8fk3" Ids="Sdl9FZzhZEePoHhCm7PRw4,Qf89ADm4eleNXquEtqQaI8" />
@@ -2947,6 +2994,14 @@
             <Patch Id="M6AhFjdXlRiOJIHlI1TFbJ" Name="Dispose" ParticipatingElements="NbR2oA98kwlQTIEsTiaT5n" />
             <Link Id="NZrOk83HURhPIkwe8wPTbY" Ids="LNcPAcQIZhmNRTG4heiOSr,JYgQtiPN8LpMNjD662sR9t" />
             <Link Id="I8z5nUyCtLeMcvRlZUFLf0" Ids="BseImjinQdBNYUb5umHqjb,Gym86sDX9gXLIvTIaiOnB9" />
+            <Link Id="L6HmJWOzFiyNT6I4nSdOwC" Ids="KAfnl6x5DanNbEdmHEGRgm,IoxPJgJKoCqQPHOudyVXxy" />
+            <Link Id="FxkWugbypEQPecNdXa7Q9m" Ids="ISQFiuhKwCGO9yKH111pAp,RDfTaESJ71nOH8qf6VVvig" />
+            <Link Id="MyzUJuyC0tANKEnf2JkdtL" Ids="MtBik6CxBYiOjdaJT73sBj,JuifiS5mBlsNoQsdXdxpw9" />
+            <Link Id="EGJewYMbyjfOMB1487k17t" Ids="TSAHIdPWF6OPv1SJP3T92s,QZ5LoTOf2elOwbYnVh18ap" IsFeedback="true" />
+            <Link Id="HjIhQB5iEWHLBlNg66CLJk" Ids="Vpg5kl8etL1Nn75QkeisF4,TSAHIdPWF6OPv1SJP3T92s" />
+            <Link Id="U4hizqQmaKiLbNOdkWptZC" Ids="TSAHIdPWF6OPv1SJP3T92s,V5v8N3DibqrPKU4sxi5xV8" />
+            <Link Id="PGoGLCPcKGjLPp9vqqwQjr" Ids="TSAHIdPWF6OPv1SJP3T92s,QZ5LoTOf2elOwbYnVh18ap" />
+            <Link Id="G04v7x70NYTO0H77Fwpwd9" Ids="QZ5LoTOf2elOwbYnVh18ap,PzLFWaWpPh0MELzdhWhSk3" />
           </Patch>
         </Node>
         <Canvas Id="Mkv3v49ugZbMZo7KV91SCu" Name="Registry" Position="349,91">
@@ -8758,7 +8813,7 @@
               <Pin Id="VMdGZ6mRcUlL48Lgtc8Wv4" Name="Output" Kind="OutputPin" />
               <Pin Id="T7vzVci2k5yQKyUM4mZDRv" Name="Result" Kind="StateOutputPin" />
             </Node>
-            <Node Bounds="554,372,16,19" Id="OdkM6N75xwYMZbl71B1JKb">
+            <Node Bounds="554,372,54,19" Id="OdkM6N75xwYMZbl71B1JKb">
               <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="OnOpen" />
@@ -8791,7 +8846,7 @@
                 <Choice Kind="TypeFlag" Name="Path" />
               </p:TypeAnnotation>
             </Pad>
-            <ControlPoint Id="Erpz3E6gxhoM8NrJTNGl34" Bounds="944,-408" />
+            <ControlPoint Id="Erpz3E6gxhoM8NrJTNGl34" Bounds="906,-489" />
             <Pad Id="KBL6OjpxCdUQNqAgQlHtaa" SlotId="II7Njs83TRcPecrHLXmHVO" Bounds="996,-250" />
             <Node Bounds="989,-366,150,19" Id="Gqz3zhheM5FNGoul7c3k0Q">
               <p:NodeReference LastCategoryFullName="VVVV.Schema.Tools" LastDependency="VVVV.Schema.Core.vl">
@@ -8829,6 +8884,38 @@
               <Pin Id="II48ULVF2THPUHDETzs8iW" Name="Input" Kind="StateInputPin" />
               <Pin Id="CJ8blKsrlTqPNp2dFW5wQy" Name="Output" Kind="StateOutputPin" />
             </Node>
+            <Node Bounds="856,-403,75,92" Id="PQFARH9nrwGPQcdrI0tulv">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Primitive" />
+                <Choice Kind="ApplicationStatefulRegion" Name="If" />
+              </p:NodeReference>
+              <Pin Id="CRBIR29VJShPfKngLJPn9i" Name="Condition" Kind="InputPin" DefaultValue="True" />
+              <Patch Id="T7f0zVR4R8QLXtB9P2AbzZ" ManuallySortedPins="true">
+                <Patch Id="VsorxW3ls7CMbYMWJtXHBp" Name="Create" ManuallySortedPins="true" />
+                <Patch Id="VGlUXLLYmq2OqOLh7F9ITa" Name="Then" ManuallySortedPins="true" />
+                <Node Bounds="868,-350,51,19" Id="SUKD3oleah9PmzxvkSN5i1">
+                  <p:NodeReference LastCategoryFullName="Schema.Utilities.Logging" LastDependency="Schema.Utilities.Logging.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
+                  </p:NodeReference>
+                  <Pin Id="MelAcSv9OudMqPab5A2Qdh" Name="Message" Kind="InputPin" />
+                </Node>
+                <Node Bounds="868,-380,48,19" Id="BBlxIoYmpkVOTdBidNgjVp">
+                  <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="StringType" Name="String" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Format" />
+                  </p:NodeReference>
+                  <Pin Id="KINLZP6iMTOLQgF7sPmkrX" Name="Format" Kind="InputPin" DefaultValue="Starting Runtime with project directory: {0}" />
+                  <Pin Id="Gz9BXwFmnmXN6IpthfWiMH" Name="Input" Kind="InputPin" />
+                  <Pin Id="HP6O1pAfCZRPbL0jKjFhDm" Name="Output" Kind="OutputPin" />
+                </Node>
+              </Patch>
+              <ControlPoint Id="Ak9BRlIuID4NZfHZMoqWVo" Bounds="906,-397" Alignment="Top" />
+              <ControlPoint Id="JZ5AHXsOhjVOA81hwuslJ8" Bounds="906,-317" Alignment="Bottom" />
+            </Node>
+            <Pad Id="B4C5RXBQMXWQV4JMrjd8vx" Comment="" Bounds="906,-450,35,15" ShowValueBox="true" isIOBox="true" />
           </Canvas>
           <ProcessDefinition Id="G5Pgdt6PncUQAMeY0rXCEJ">
             <Fragment Id="SQwJ6ZOeu81OPWAYyt36Ra" Patch="EgmbXKuaI6MLVixT725nps" Enabled="true" />
@@ -8886,9 +8973,7 @@
           <Link Id="Q7ifqpyCE21QItLIxyUiJN" Ids="DuCOQYBZ1I9Ne5Bvrnmosb,AUXCXVDJZ9WNN7S8oRt7Jh" IsHidden="true" />
           <Link Id="Kv6M8QkgMkmNrHoYh5qGSi" Ids="L5AZLTcnm64OLAomJdcSEQ,Erpz3E6gxhoM8NrJTNGl34" IsHidden="true" />
           <Slot Id="II7Njs83TRcPecrHLXmHVO" Name="Stacks Directory" />
-          <Link Id="HcqzBzfVNSILHjCIvazMdD" Ids="Erpz3E6gxhoM8NrJTNGl34,Nb8ZsOXaMsPMxwRO2jykFy" />
           <Link Id="L5kMUSA7OyQMwqyUmdVBzT" Ids="MOM7PQcMn58LCC8LCRReee,FojHfDEY113LjOgIefyC3s" />
-          <Link Id="O42lJ4dfc2kQSjI5arVupi" Ids="Erpz3E6gxhoM8NrJTNGl34,I40TJBEknMCMBIdTFr1tb5" />
           <Link Id="JyQmw7xbO6sPReAKBCepHs" Ids="DF297davdALNpdxjtWOIJ0,QKBDlxGGDmzNVCQlT291YF" />
           <Link Id="OWpUj2XVCWrQSrbVdGAtDB" Ids="DF297davdALNpdxjtWOIJ0,P7A8lKoAt15POLP6JF5g2b" />
           <Link Id="V7D6a7StJBPNqci7mInJ88" Ids="DF297davdALNpdxjtWOIJ0,KBL6OjpxCdUQNqAgQlHtaa" />
@@ -8901,7 +8986,7 @@
           <Patch Id="EgmbXKuaI6MLVixT725nps" Name="Create" ParticipatingElements="CZxt99MXY0uNuRjk7XHgqu,P6YZYwH2UwSPadHhQ5IXHj">
             <Pin Id="N3lpJLwjVTMPKpL0OnzuMP" Name="Initial Fixtures" Kind="InputPin" Bounds="309,450" />
             <Pin Id="B4E2RqRfe0lLdnKe5JXHh6" Name="Initial Director" Kind="InputPin" Bounds="624,152" />
-            <Pin Id="L5AZLTcnm64OLAomJdcSEQ" Name="Project Directory" Kind="InputPin" Bounds="944,-408" DefaultValue="..\\">
+            <Pin Id="L5AZLTcnm64OLAomJdcSEQ" Name="Project Directory" Kind="InputPin" Bounds="944,-408" DefaultValue="">
               <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Path" />
               </p:TypeAnnotation>
@@ -8917,6 +9002,14 @@
             <Pin Id="Qsvr1D6CImGM8mnG0bjwWT" Name="State" Kind="OutputPin" />
           </Patch>
           <Patch Id="VWhQdbgcw39Mt7JWyI22Wg" Name="Dispose" ParticipatingElements="EUXTaRLF355OLIqgucP4lk" />
+          <Link Id="EPek7JA8WE0POuDsoYVbXf" Ids="HP6O1pAfCZRPbL0jKjFhDm,MelAcSv9OudMqPab5A2Qdh" />
+          <Link Id="NouJnHhu0ayLVg1oYeOqhL" Ids="Ak9BRlIuID4NZfHZMoqWVo,JZ5AHXsOhjVOA81hwuslJ8" IsFeedback="true" />
+          <Link Id="NCHUY9n3N1rL2Z8j93YDAp" Ids="Erpz3E6gxhoM8NrJTNGl34,B4C5RXBQMXWQV4JMrjd8vx" />
+          <Link Id="NQLvQbY650DLthHPnP0p2z" Ids="Ak9BRlIuID4NZfHZMoqWVo,Gz9BXwFmnmXN6IpthfWiMH" />
+          <Link Id="UeIqUilryb9M3qkl6UEqKu" Ids="JZ5AHXsOhjVOA81hwuslJ8,Nb8ZsOXaMsPMxwRO2jykFy" />
+          <Link Id="HolMEHu6oi4QSDQLvH05FC" Ids="Ak9BRlIuID4NZfHZMoqWVo,JZ5AHXsOhjVOA81hwuslJ8" />
+          <Link Id="OvFyyEbju9uQKsuVmiyTLL" Ids="B4C5RXBQMXWQV4JMrjd8vx,Ak9BRlIuID4NZfHZMoqWVo" />
+          <Link Id="JoVTgwM4b3PNywH5aPxaIV" Ids="B4C5RXBQMXWQV4JMrjd8vx,I40TJBEknMCMBIdTFr1tb5" />
         </Patch>
       </Node>
       <!--
@@ -12282,7 +12375,7 @@
             <Pin Id="JGOcSPMIsvVL98OIViYxUd" Name="Global" Kind="InputPin" />
             <Pin Id="TcjOciUAlLOLrqMpmxjWu8" Name="New State" Kind="OutputPin" />
             <Pin Id="CL5BjMZbmJLOLnErIuxCF3" Name="Node Operation" Kind="OutputPin" />
-            <Pin Id="ITdh93BfvXBLUa9VqKcssq" Name="Properties" Kind="InputPin" />
+            <Pin Id="Jg7wJnVnKfiLeV9gxKmxXf" Name="Properties" Kind="InputPin" />
           </Patch>
           <Patch Id="KaCaE3sKV3UMVtoT2k9fVI" Name="GetChildren">
             <Pin Id="C0BKrPp9iE9N5esRHhPybU" Name="Children" Kind="OutputPin" />
@@ -12975,13 +13068,13 @@
           <Link Id="C8cmZKeAfHyPP67K7WtHm5" Ids="T29DpogE4b2LdkohUTTmJ3,R6Bo59veWFeNHB6xZ8HqAl" />
           <Patch Id="QFjBE7nZ6v3QIMDO7h0tlZ" Name="Create" />
           <Patch Id="F2GiypGHcmWMNd3KKUzSEV" Name="Update">
-            <Pin Id="EduJQz2OeDALRQUOOzBkfp" Name="Setup" Kind="InputPin" />
+            <Pin Id="F3cU7FBzvYfQV2tMygROFU" Name="Setup" Kind="InputPin" />
             <Pin Id="QXu17NLnnfXNcWxWfddTlu" Name="State" Kind="InputPin" />
             <Pin Id="R5iYxD4bMKqNYTC5XMP5wX" Name="New State" Kind="OutputPin" />
-            <Pin Id="UdEOrWvigtBN6ojBXCk1Y5" Name="Previous Layer States" Kind="InputPin" />
-            <Pin Id="OIYqCP0FA4BLCzWR8r6LVe" Name="Global" Kind="InputPin" />
-            <Pin Id="TE17cjGjarJPxtDLcugfnP" Name="Properties" Kind="InputPin" />
-            <Pin Id="Exe4504WZmhPSREDYE2Ngh" Name="Node Operation" Kind="OutputPin" />
+            <Pin Id="U4ZLcgUghc9OxojLT6hLmf" Name="Previous Layer States" Kind="InputPin" />
+            <Pin Id="RyxfhHaNPQWMtMpJxXBCVZ" Name="Global" Kind="InputPin" />
+            <Pin Id="UuDnuWhF4mSMIWnJnsWaeI" Name="Properties" Kind="InputPin" />
+            <Pin Id="N8qFzDhqIKYPtxuaiRjnZh" Name="Node Operation" Kind="OutputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -13495,6 +13588,7 @@
                     <Choice Kind="OperationCallFlag" Name="LogInfo (String)" />
                   </p:NodeReference>
                   <Pin Id="GdcdZDn9QEmLR4PZtoJuTP" Name="Message" Kind="InputPin" />
+                  <Pin Id="GkNuPcBnf8rM9cZ7Doz4Kj" Name="Apply" Kind="InputPin" DefaultValue="False" />
                 </Node>
                 <Pad Id="S89xBv7GIcALGJMk83dR8M" Comment="Message" Bounds="214,107,142,15" ShowValueBox="true" isIOBox="true" Value="```&#xD;&#xA;Registering Block: ">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -24259,47 +24353,38 @@
             <Link Id="HsPuz8JPxhmNQvgUTDjl2H" Ids="PBsOXSo8wJ0P3tHxqeQELy,JDesIeO0LO1OgmBpTt1u57" IsHidden="true" />
             <ControlPoint Id="BPaAYksfcSxNRxzZpMA6eq" Bounds="3037,-1174" />
             <Link Id="Hr86CY9pikENRHi4QYLCAG" Ids="KvwfAx7K6jkO0IVpwxDuHH,BPaAYksfcSxNRxzZpMA6eq" IsHidden="true" />
-            <Pin Id="EaWP5MUjxQ2QBIOBticTAO" Name="Directory Path" Kind="InputPin" Bounds="2972,-1207" />
+            <Pin Id="EaWP5MUjxQ2QBIOBticTAO" Name="Directory Path" Kind="InputPin" Bounds="2972,-1207">
+              <p:TypeAnnotation LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
+                <Choice Kind="TypeFlag" Name="Path" />
+                <CategoryReference Kind="Category" Name="IO" NeedsToBeDirectParent="true" />
+              </p:TypeAnnotation>
+            </Pin>
             <Pin Id="PBsOXSo8wJ0P3tHxqeQELy" Name="Filename" Kind="InputPin" Bounds="3021,-1211" />
             <Pin Id="KvwfAx7K6jkO0IVpwxDuHH" Name="Extension" Kind="InputPin" Bounds="3091,-1205" />
             <Pin Id="FaCUkGa3pKIPuhhZFi4aeU" Name="Result" Kind="OutputPin" Bounds="2976,-1103" />
-            <Node Bounds="2936,-1108,60,19" Id="LuCmCNjCR1qPzbxQee1gK5">
+            <Node Bounds="2884,-1090,57,19" Id="LMRBiWtRolqQYELLu6nGu7">
               <p:NodeReference LastCategoryFullName="IO" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="MakePath" />
+                <Choice Kind="OperationCallFlag" Name="Filename (Join)" />
               </p:NodeReference>
-              <Pin Id="Ic8jkUZFOnyMLhW8OnPH2H" Name="Path" Kind="InputPin" IsHidden="true" />
-              <Pin Id="QoM6AscZsZMNobByqXudYI" Name="Input" Kind="InputPin" />
-              <Pin Id="OBVtgvdFsysP5gbGVyED28" Name="Output" Kind="OutputPin" />
+              <Pin Id="TLAPbokja7oLNh6B0AVIZc" Name="Directory" Kind="InputPin" />
+              <Pin Id="N9xXQvwEBTqN6SMJswhdiA" Name="Filename" Kind="InputPin" />
+              <Pin Id="KCp9oep8GoTN4b6gKk0fSx" Name="Extension" Kind="InputPin" />
+              <Pin Id="IHOZ5Z3pRd8P6C2qYFVpMN" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="2884,-1076,57,26" Id="NQbHTcCUd8SMHNON2PdTge">
-              <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="VL.CoreLib.vl">
+            <Link Id="MZuSXrcBhLAOqMzlxT08uX" Ids="JDesIeO0LO1OgmBpTt1u57,N9xXQvwEBTqN6SMJswhdiA" />
+            <Link Id="AFn1pPvuCLxQSgeGF91619" Ids="BPaAYksfcSxNRxzZpMA6eq,KCp9oep8GoTN4b6gKk0fSx" />
+            <Node Bounds="2880,-1130,55,19" Id="RywuCR5uFj1P8gn4ZlEgWJ">
+              <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <CategoryReference Kind="4026531840" Name="Path" NeedsToBeDirectParent="true">
-                  <p:OuterCategoryReference Kind="Category" Name="IO" NeedsToBeDirectParent="true" />
-                </CategoryReference>
-                <Choice Kind="OperationCallFlag" Name="Combine" />
+                <Choice Kind="OperationCallFlag" Name="ToString" />
               </p:NodeReference>
-              <Pin Id="D54f1vuUxeeOyJHAv4LsBc" Name="Input" Kind="StateInputPin" />
-              <Pin Id="K3pkl1D1E6ILYfQqhvHwmR" Name="Input 2" Kind="InputPin" />
-              <Pin Id="LeUgN0GE17sM0BpMqorNXM" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="NilvNrZiQdpP2w5rRDRmEU" Name="Input" Kind="InputPin" />
+              <Pin Id="L72xg8TUemQMcpUDbPXwC3" Name="Result" Kind="OutputPin" />
             </Node>
-            <Link Id="Jycz6dmwDQVM0Vsvc3DPIg" Ids="GttVFQFge0sO4MPMj1vrUx,D54f1vuUxeeOyJHAv4LsBc" />
-            <Node Bounds="2936,-1136,45,19" Id="QP0mFMjoKFzNOemDIPV4qq">
-              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="+" />
-              </p:NodeReference>
-              <Pin Id="MFNOOP0i1nxNe0s4jI7GwG" Name="Input" Kind="InputPin" />
-              <Pin Id="PUFSgdoTmaeNcwHRJzLF3l" Name="Input 2" Kind="InputPin" DefaultValue="." />
-              <Pin Id="KpJWnz9AIlENlcUky9hd2K" Name="Output" Kind="OutputPin" />
-              <Pin Id="MIvSzegjbcxNWjN1Qy1toq" Name="Input 3" Kind="InputPin" />
-            </Node>
-            <Link Id="Vhrx1OIu0SRPEjNmc7Tp1T" Ids="JDesIeO0LO1OgmBpTt1u57,MFNOOP0i1nxNe0s4jI7GwG" />
-            <Link Id="RPNyuI9EVkMPNc3CSniNou" Ids="BPaAYksfcSxNRxzZpMA6eq,MIvSzegjbcxNWjN1Qy1toq" />
-            <Link Id="EKv67cuzjuQPNiF4tQjb7z" Ids="KpJWnz9AIlENlcUky9hd2K,QoM6AscZsZMNobByqXudYI" />
-            <Link Id="MVSkg6dhMz4PQqpPxDtT6C" Ids="OBVtgvdFsysP5gbGVyED28,K3pkl1D1E6ILYfQqhvHwmR" />
-            <Link Id="Q2NzGgORcvXO5EYOra53RF" Ids="LeUgN0GE17sM0BpMqorNXM,BIeNZqITqiDPhNYuF8VP30" />
+            <Link Id="Ndz25csweomNQwg9BfpKr6" Ids="GttVFQFge0sO4MPMj1vrUx,NilvNrZiQdpP2w5rRDRmEU" />
+            <Link Id="Qp5Go1V3WlAN67ubAQCagB" Ids="L72xg8TUemQMcpUDbPXwC3,TLAPbokja7oLNh6B0AVIZc" />
+            <Link Id="SHPYozDGOB4Nv4J30H1KMm" Ids="IHOZ5Z3pRd8P6C2qYFVpMN,BIeNZqITqiDPhNYuF8VP30" />
           </Patch>
         </Node>
         <!--
@@ -25355,7 +25440,7 @@
                       <Pin Id="NhdbMIKnTQuLqK9akC7sk0" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="NWyAGHL6OzzOnRjn4OyV4q" Name="New State" Kind="OutputPin" />
                       <Pin Id="Uhf9QBoB7GTL6BxTVEl6MB" Name="Node Operation" Kind="OutputPin" />
-                      <Pin Id="CJZnxIhaxfFLYGqC2wh0dm" Name="Properties" Kind="InputPin" />
+                      <Pin Id="HpX5jFLeGYCLVwUKVhOpnQ" Name="Properties" Kind="InputPin" />
                     </Node>
                     <Node Bounds="743,1671,38,26" Id="Nh1waDQte6ON8nma8jYPCs">
                       <p:NodeReference LastCategoryFullName="Collections.Stack" LastDependency="VL.CoreLib.vl">
@@ -26783,7 +26868,7 @@
               <Pin Id="Mhc1yC0e0zINL4aOYrDe1b" Name="Context" Kind="InputPin" />
               <Pin Id="QiJnYN2GNUzL6Awl2QmsXI" Name="Last Content" Kind="InputPin" />
               <Pin Id="Q4uQTZo00QVLs8krCdpLqU" Name="Output" Kind="OutputPin" />
-              <Pin Id="FKvfZ3dqcOROWuIQHu0wov" Name="Context" Kind="OutputPin" />
+              <Pin Id="TGBLjNUePEfQOkaHYMJIAc" Name="Context" Kind="OutputPin" />
               <Pin Id="G1188jU8YH2Lsp6uklbg6c" Name="Loaded Content" Kind="OutputPin" />
             </Node>
             <Pad Id="R0yxExdnrjlMov5wlHfOnX" SlotId="TMQLd4zoFKRNWhSlxdh4P1" Bounds="491,500" />
@@ -35204,320 +35289,6 @@
           <Link Id="NsoyGV1jcwgLrXXVzL4mth" Ids="BvLBkZkLxZmPdMRN6Da2O7,RdvGe3RE6PpOidV9Bcf96h" IsHidden="true" />
         </Patch>
       </Node>
-      <Canvas Id="VEuJaDdavcoL78vHpcEFQK" Name="Debug" Position="-677,-294">
-        <!--
-
-    ************************ LogInfo (String) ************************
-
--->
-        <Node Name="LogInfo (String)" Bounds="79,95,185,119" Id="QBMYmCFx17pQKLSMAmnLn6">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="AxOOGQe1KzGO8z5USUUaNa">
-            <Pad Id="GIQn7Nt8muDOjpErmT6v7B" Comment="Category" Bounds="159,123,30,19" ShowValueBox="true" isIOBox="true" Value="Info">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="UnUEUxtoPS6PYiaXKgOc40" Bounds="94,122" />
-            <Pin Id="SrzwpWZvamTN8gxtXwirTk" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="LcJ6e8MjfdZLsy8gxBoFaX" Ids="SrzwpWZvamTN8gxtXwirTk,UnUEUxtoPS6PYiaXKgOc40" IsHidden="true" />
-            <Node Bounds="91,175,72,19" Id="DM5MDbWxJIAMkO4qJ5san2">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
-              </p:NodeReference>
-              <Pin Id="ES1c8T8tRpjOtdghoz6fxM" Name="Message" Kind="InputPin" />
-              <Pin Id="BZkmWXMAOC5MFbg1OTa5ii" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="HmgNSezj1IrMcevHFJr2SP" Ids="UnUEUxtoPS6PYiaXKgOc40,ES1c8T8tRpjOtdghoz6fxM" />
-            <Link Id="NTa5o4ZoNZxL4oKiU1JYKr" Ids="GIQn7Nt8muDOjpErmT6v7B,BZkmWXMAOC5MFbg1OTa5ii" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogMessage (Generic) ************************
-
--->
-        <Node Name="LogMessage (Generic)" Bounds="118,561,167,118" Id="PbMZi2MxBTuOTxkxpSTMZX">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="FWbMLTXI8oXNae8UchzM4r" IsGeneric="true">
-            <ControlPoint Id="Hc5lbclA0zPNGvyWboF2XA" Bounds="132,581" />
-            <Pin Id="FMAJSVYxoqhLk8JbYqWvtB" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="MLNPT2AFR4aOQhhpi6UZ6V" Ids="FMAJSVYxoqhLk8JbYqWvtB,Hc5lbclA0zPNGvyWboF2XA" IsHidden="true" />
-            <ControlPoint Id="PkSXgEaJfaqLmb7046HpKy" Bounds="221,579" />
-            <Pin Id="HlEgbehqpUQQPQUdV6yhh7" Name="Category" Kind="InputPin" Bounds="358,476" />
-            <Link Id="Uh7b2zBAmUgQKm26RPBhwF" Ids="HlEgbehqpUQQPQUdV6yhh7,PkSXgEaJfaqLmb7046HpKy" IsHidden="true" />
-            <Node Bounds="131,603,65,19" Id="T9OkaKYLbGCNMxq878FZ1b">
-              <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="ToString" />
-              </p:NodeReference>
-              <Pin Id="HtWmroRYwCBNisIx3T8Vli" Name="Input" Kind="InputPin" />
-              <Pin Id="CmrQBOolv0fNL2lSbNqSGW" Name="Result" Kind="OutputPin" />
-            </Node>
-            <Link Id="GO3DHNS1Ng8OKnZrLQralQ" Ids="Hc5lbclA0zPNGvyWboF2XA,HtWmroRYwCBNisIx3T8Vli" />
-            <Node Bounds="131,640,72,19" Id="Ml0JOofd63HPcGWXNF3Xly">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
-              </p:NodeReference>
-              <Pin Id="NDllQn7U5bkLFtqIhtTUh7" Name="Message" Kind="InputPin" />
-              <Pin Id="Hy22892VGlaM1T6Zdh4L0Y" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="C5Y5ObtM5iSPHL76e9gXHn" Ids="CmrQBOolv0fNL2lSbNqSGW,NDllQn7U5bkLFtqIhtTUh7" />
-            <Link Id="H2LgAjZ1ECwMJSBkczjD7e" Ids="PkSXgEaJfaqLmb7046HpKy,Hy22892VGlaM1T6Zdh4L0Y" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogMessage (String) ************************
-
--->
-        <Node Name="LogMessage (String)" Bounds="343,566,170,164" Id="ICBUtgJi3PENj3eQQuBdEq">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="TgOVCWoVckHNVBAKLL6jnj" IsGeneric="true">
-            <ControlPoint Id="Hm5FhGWUc19OWrAvNcqbLh" Bounds="360,586" />
-            <Pin Id="EUisxaOFjlMMdpcQVNXkJ1" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="KzDcSCW9FznLmoflmCAFTf" Ids="EUisxaOFjlMMdpcQVNXkJ1,Hm5FhGWUc19OWrAvNcqbLh" IsHidden="true" />
-            <Node Bounds="355,684,58,26" Id="OZR8xom0tXBL5xP2moSbRA">
-              <p:NodeReference LastCategoryFullName="System.Console" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="WriteLine" />
-                <CategoryReference Kind="ClassType" Name="Console" NeedsToBeDirectParent="true" />
-              </p:NodeReference>
-              <Pin Id="ITHwGCPel3bMlUc2953aPB" Name="Value" Kind="InputPin" />
-              <Pin Id="SxMF29YHaqLLdMbhyoTIaX" Name="Apply" Kind="InputPin" DefaultValue="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                  <Choice Kind="TypeFlag" Name="Boolean" />
-                </p:TypeAnnotation>
-              </Pin>
-            </Node>
-            <ControlPoint Id="FlTggqDRSfZNERDiUpucPP" Bounds="449,584" />
-            <Pin Id="QBBi8nYvT5FLmY98Ue5Ls5" Name="Category" Kind="InputPin" Bounds="358,476" />
-            <Link Id="Bo2ZuG0OlbgONBh0MT90Tc" Ids="QBBi8nYvT5FLmY98Ue5Ls5,FlTggqDRSfZNERDiUpucPP" IsHidden="true" />
-            <Node Bounds="355,619,113,19" Id="RNPrSlBiET6QUp8HpGu2IN">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="GetLogMessagePrefix" />
-              </p:NodeReference>
-              <Pin Id="FPv9oZm39uiPhrCspI8DSn" Name="Category" Kind="InputPin" />
-              <Pin Id="GaKImWiqYFgMeT6TFQwCmE" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Link Id="QywfRXFct23LVgzpW704wH" Ids="FlTggqDRSfZNERDiUpucPP,FPv9oZm39uiPhrCspI8DSn" />
-            <Node Bounds="355,653,25,19" Id="TCVlCnEY0DWOhIE0GEUkpr">
-              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="+" />
-              </p:NodeReference>
-              <Pin Id="QehMViSY0hfN7Q5zAJsclg" Name="Input" Kind="InputPin" />
-              <Pin Id="RtEOksAATrSOPhPqFxmRBl" Name="Input 2" Kind="InputPin" />
-              <Pin Id="QDHFqJBdqryNor15UCylD3" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Link Id="C3ER6rVh63sQMj174NtJHp" Ids="GaKImWiqYFgMeT6TFQwCmE,QehMViSY0hfN7Q5zAJsclg" />
-            <Link Id="Fzsba08wKy8MUgsQOKCN3G" Ids="Hm5FhGWUc19OWrAvNcqbLh,RtEOksAATrSOPhPqFxmRBl" />
-            <Link Id="U5n9kUFAYS8Qc8FqzQaYlu" Ids="QDHFqJBdqryNor15UCylD3,ITHwGCPel3bMlUc2953aPB" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogInfo (Generic) ************************
-
--->
-        <Node Name="LogInfo (Generic)" Bounds="85,289,181,111" Id="LZ8TmR4GKUfQCoAa9iQ60K">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="Cp8qV7riNbEMN2lMhccDhY" IsGeneric="true">
-            <Pad Id="RBahqe1LkrdPcKA51gCjbk" Comment="Category" Bounds="161,333,30,19" ShowValueBox="true" isIOBox="true" Value="Info">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="KB54BQofFacMvuhjRt537W" Bounds="105,307" />
-            <Pin Id="EfVFYDSdzp7MhyrswxGNzC" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="GTAXgCHGPz5MW9ll0iItmM" Ids="EfVFYDSdzp7MhyrswxGNzC,KB54BQofFacMvuhjRt537W" IsHidden="true" />
-            <Node Bounds="97,361,72,19" Id="Jj7siXPzQMsNSNewxo4drQ">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (Generic)" />
-              </p:NodeReference>
-              <Pin Id="KEovzTK9wYgL2Bfm8YzXHF" Name="Message" Kind="InputPin" />
-              <Pin Id="TLnPfBE3wowLxIBwuj39rr" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="S8lfcNo8uxrQFV0XQJBW4n" Ids="KB54BQofFacMvuhjRt537W,KEovzTK9wYgL2Bfm8YzXHF" />
-            <Link Id="Rf8dQTgRFnsLyGiZyk2CAl" Ids="RBahqe1LkrdPcKA51gCjbk,TLnPfBE3wowLxIBwuj39rr" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogWarning (String) ************************
-
--->
-        <Node Name="LogWarning (String)" Bounds="295,103,185,119" Id="GJX10AN5oEqQXpXIXB1YqU">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="SibpHIr0D5kLGhLFLoSu7S">
-            <Pad Id="GVMkGQFyMP1QEHIfcdrfrO" Comment="Category" Bounds="375,131,30,19" ShowValueBox="true" isIOBox="true" Value="Warning">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="TnZJbQVdC4JO3vW1PBMjzT" Bounds="310,130" />
-            <Pin Id="MJs7G0qkIdpQBaFgDY3JIE" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="SsN6AAhzETtPmL5Aw1nNdM" Ids="MJs7G0qkIdpQBaFgDY3JIE,TnZJbQVdC4JO3vW1PBMjzT" IsHidden="true" />
-            <Node Bounds="307,183,72,19" Id="DPItdZ87EsILAXuMKR8PTD">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
-              </p:NodeReference>
-              <Pin Id="UTJApftXsAgQRtn1KqNiPl" Name="Message" Kind="InputPin" />
-              <Pin Id="D6h3g6zqSLxNPnaYpiQ6kM" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="TuKSfJduJRBQLyQhV4xQLI" Ids="TnZJbQVdC4JO3vW1PBMjzT,UTJApftXsAgQRtn1KqNiPl" />
-            <Link Id="BJqAUA9hTA4Mn5z0VDchvc" Ids="GVMkGQFyMP1QEHIfcdrfrO,D6h3g6zqSLxNPnaYpiQ6kM" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogWarning (Generic) ************************
-
--->
-        <Node Name="LogWarning (Generic)" Bounds="301,297,181,111" Id="LMofVW5gsdAOSEGI6HYl3L">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="RHNqb8RS7nnNdWsFi6I5PR" IsGeneric="true">
-            <Pad Id="G8t0N23YIUlQMkrLOybP9U" Comment="Category" Bounds="377,341,30,19" ShowValueBox="true" isIOBox="true" Value="Warning">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="PzvNVNldb26OvltiB0JQ9o" Bounds="321,315" />
-            <Pin Id="MkUzxpSApH5NpjbVlCoWJd" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="JvRQ5vOy58pMg33MA3LuZV" Ids="MkUzxpSApH5NpjbVlCoWJd,PzvNVNldb26OvltiB0JQ9o" IsHidden="true" />
-            <Node Bounds="313,369,72,19" Id="CHA3Uz1AcmwOi0nHDCplX3">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (Generic)" />
-              </p:NodeReference>
-              <Pin Id="R8zVflk86edMZ6RhHg3LXD" Name="Message" Kind="InputPin" />
-              <Pin Id="FeYTrbfvu2eP1nCMxInNBw" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="DDuI8C9uWHZQQ4ndUf1IoW" Ids="PzvNVNldb26OvltiB0JQ9o,R8zVflk86edMZ6RhHg3LXD" />
-            <Link Id="Fl8mHRpjoz3NayGHzNCNx0" Ids="G8t0N23YIUlQMkrLOybP9U,FeYTrbfvu2eP1nCMxInNBw" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogError (String) ************************
-
--->
-        <Node Name="LogError (String)" Bounds="511,111,185,119" Id="M2njKAgBs0BPJJIjuKFzLE">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="UO4mTRZhtF0MA9jkZIUv5R">
-            <Pad Id="H3OSMSSnflqQEZkQk2vIy4" Comment="Category" Bounds="591,139,30,19" ShowValueBox="true" isIOBox="true" Value="Error">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="TeRmbegJIKCMVIyGgM9ryf" Bounds="526,138" />
-            <Pin Id="UCf2ZAXwjOnPTItITUtu5z" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="OSQeYFNjtjHMVdToSkIonI" Ids="UCf2ZAXwjOnPTItITUtu5z,TeRmbegJIKCMVIyGgM9ryf" IsHidden="true" />
-            <Node Bounds="523,191,72,19" Id="RNzbhTOAEEEL9cZxCc8pML">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (String)" />
-              </p:NodeReference>
-              <Pin Id="Mh5GnCmwcGFM9cKPFgQuQO" Name="Message" Kind="InputPin" />
-              <Pin Id="SSYDwIjotyKLudNs7cEJV3" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="CaTZVgJGpGWPdGWelyiuAX" Ids="TeRmbegJIKCMVIyGgM9ryf,Mh5GnCmwcGFM9cKPFgQuQO" />
-            <Link Id="EwPJyTcQORXMCgLrQoOLSW" Ids="H3OSMSSnflqQEZkQk2vIy4,SSYDwIjotyKLudNs7cEJV3" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ LogError (Generic) ************************
-
--->
-        <Node Name="LogError (Generic)" Bounds="517,305,181,111" Id="HCHcVLyd4BRO7CaC4NUAJ9">
-          <p:NodeReference>
-            <Choice Kind="OperationDefinition" Name="Operation" />
-            <FullNameCategoryReference ID="Primitive" />
-          </p:NodeReference>
-          <Patch Id="F2va7P2cFDVPC28O9dByop" IsGeneric="true">
-            <Pad Id="RBgqPjwKmnmNtm69bYRqOs" Comment="Category" Bounds="593,349,30,19" ShowValueBox="true" isIOBox="true" Value="Error">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pad>
-            <ControlPoint Id="JYxyrTcxWNxPrGhxJQ0xWq" Bounds="537,323" />
-            <Pin Id="GPpH2RFwmACPVJ34IA6FO6" Name="Message" Kind="InputPin" Bounds="250,201" />
-            <Link Id="Txo891H4GcVOa1ubH4uL2r" Ids="GPpH2RFwmACPVJ34IA6FO6,JYxyrTcxWNxPrGhxJQ0xWq" IsHidden="true" />
-            <Node Bounds="529,377,72,19" Id="B7lv7Ceyce8QE64sze0hJ6">
-              <p:NodeReference LastCategoryFullName="VVVV.Schema.Debug" LastDependency="VVVV.Schema.Core.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="LogMessage (Generic)" />
-              </p:NodeReference>
-              <Pin Id="FjwxxgQ3F2QOxZsdjwiajA" Name="Message" Kind="InputPin" />
-              <Pin Id="GlHF6OnwrB0P3mzG6zYTWY" Name="Category" Kind="InputPin" />
-            </Node>
-            <Link Id="K4eM4AQZXf0MaFMy9avbF1" Ids="JYxyrTcxWNxPrGhxJQ0xWq,FjwxxgQ3F2QOxZsdjwiajA" />
-            <Link Id="E3HeoyMcE8NLUQigpkkNMI" Ids="RBgqPjwKmnmNtm69bYRqOs,GlHF6OnwrB0P3mzG6zYTWY" />
-          </Patch>
-        </Node>
-        <!--
-
-    ************************ GetLogMessagePrefix (Internal) ************************
-
--->
-        <Node Name="GetLogMessagePrefix (Internal)" Bounds="600,573,81,101" Id="Iv5iwaz0KYFMvEd0H5G4z4">
-          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-            <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
-            <Choice Kind="OperationDefinition" Name="Operation" />
-          </p:NodeReference>
-          <Patch Id="PEhzQ2qGXHLLTYzPedXklj">
-            <ControlPoint Id="LTusvdcI0P2NpGtgL8gOvR" Bounds="614,591" />
-            <Link Id="PS185MFaMw1L68MITgxBxn" Ids="Q9qjhheUubmNeGsQEXAHxK,LTusvdcI0P2NpGtgL8gOvR" IsHidden="true" />
-            <Node Bounds="622,614,45,19" Id="TvWBWOw1RWUPzRLbmzGeQO">
-              <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="+" />
-              </p:NodeReference>
-              <Pin Id="O8hhGto4OQSPSSamnHLTGd" Name="Input" Kind="InputPin" DefaultValue="[" />
-              <Pin Id="MdawwohueRTP0de8K2jBz3" Name="Input 2" Kind="InputPin" />
-              <Pin Id="CKrbkeSgWxxMQMMmoGv9yC" Name="Output" Kind="OutputPin" />
-              <Pin Id="UJI3L3H31uyOjzQAlPZx04" Name="Input 3" Kind="InputPin" DefaultValue="] " />
-            </Node>
-            <Link Id="TZqv0hMWt2ULo4czYliatI" Ids="LTusvdcI0P2NpGtgL8gOvR,MdawwohueRTP0de8K2jBz3" />
-            <Pin Id="Q9qjhheUubmNeGsQEXAHxK" Name="Category" Kind="InputPin" Bounds="358,476">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                <Choice Kind="TypeFlag" Name="String" />
-              </p:TypeAnnotation>
-            </Pin>
-            <ControlPoint Id="HJlCCXM5bNhLpRfaC9DKGY" Bounds="626,657" />
-            <Link Id="U5BYfjEjWSNMm48Ljwinba" Ids="CKrbkeSgWxxMQMMmoGv9yC,HJlCCXM5bNhLpRfaC9DKGY" />
-            <Pin Id="IqRwZk1zMbWNUOzqtHzwRk" Name="Output" Kind="OutputPin" Bounds="753,511" />
-            <Link Id="KA6PFKCSrGaNUtSo7xAzqv" Ids="HJlCCXM5bNhLpRfaC9DKGY,IqRwZk1zMbWNUOzqtHzwRk" IsHidden="true" />
-          </Patch>
-        </Node>
-      </Canvas>
       <!--
 
     ************************ AudioPowerPickBee ************************
@@ -42473,7 +42244,7 @@
           </Patch>
           <Patch Id="K1VSqBLP5wyOYYo0AfFzXF" Name="SetNode">
             <Pin Id="LMstxV1zpHfQTT3hpYUwX9" Name="Root Node" Kind="InputPin" />
-            <Pin Id="Fe2sB8rNwGKOyklSM8djRf" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="SXCsvlcww2WNwtRICw06Ay" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="OwQF9JVmoMEL92JMH0MFYn" Name="GetSetup">
             <Pin Id="Tzln8INOGeHOmPwLzFQhvW" Name="Setup" Kind="OutputPin" />
@@ -42483,18 +42254,18 @@
           </Patch>
           <Patch Id="RxSENQUOIIoP64lLKDwsat" Name="GetNode">
             <Pin Id="ASjxsVfwoSDOS5uqP61sin" Name="Root Node" Kind="OutputPin" />
-            <Pin Id="DdL6q5xGTPZMcLtwGIhDIJ" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="OatOXuSig0iM9xobEaiNHl" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="PcAC7AUwhyjK9sWKKGJCRe" Name="GetType">
             <Pin Id="FEw9ono9mi3MWfJ6PhxkY2" Name="Type" Kind="OutputPin" />
           </Patch>
           <Patch Id="FtOtBZ5oyz1NEmsVxOqr43" Name="SetLastAssigned">
             <Pin Id="IhkYiFkpKunO3Z5MuR2Gqn" MergeId="700333" Name="LastAssigned" Kind="InputPin" />
-            <Pin Id="GtMuBWjXQdCLlvF2TslsQq" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="FykkqHX7UDKLgySv3v5AiA" Name="Layer Index" Kind="InputPin" />
           </Patch>
           <Patch Id="Ue6LShoqEuAOXmFq1poOPv" Name="GetLastAssigned">
             <Pin Id="DXUFfe4BTlVLAhqUyZCHWI" MergeId="709913" Name="LastAssigned" Kind="OutputPin" />
-            <Pin Id="Eel31WMwS4yMtrcAbIsWQm" Name="Layer Index" Kind="InputPin" />
+            <Pin Id="FVv5r5xWE0dLDmPJSmYTZc" Name="Layer Index" Kind="InputPin" />
           </Patch>
         </Patch>
       </Node>
@@ -50093,10 +49864,10 @@
                   </p:Interfaces>
                   <Patch Id="SFSq5DsAuUbMqeCdw5SIAc">
                     <Canvas Id="UiHd8OYiCY9OENmMh5hY3f" CanvasType="Group">
-                      <ControlPoint Id="Qk1O3UBhpWANZuxpnF4IVh" Bounds="456,-202" />
-                      <ControlPoint Id="LzpCSM6pb73N318uEpsyo7" Bounds="528,-197" />
-                      <ControlPoint Id="IyyncWUSjusPnVeVRJuekl" Bounds="453,704" />
-                      <Node Bounds="512,-146,74,13" Id="KUvE7mxNjQ4NZyqqkjMfsn">
+                      <ControlPoint Id="Qk1O3UBhpWANZuxpnF4IVh" Bounds="114,31" />
+                      <ControlPoint Id="LzpCSM6pb73N318uEpsyo7" Bounds="214,31" />
+                      <ControlPoint Id="IyyncWUSjusPnVeVRJuekl" Bounds="153,971" />
+                      <Node Bounds="212,121,74,19" Id="KUvE7mxNjQ4NZyqqkjMfsn">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Merge" />
@@ -50105,14 +49876,14 @@
                         <Pin Id="Ipc9Unb9CYAL8rb8AIK9BT" Name="Input" Kind="StateInputPin" />
                         <Pin Id="PmF6rxE7TxVLC6t9HZYx1s" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <ControlPoint Id="KLH3JO9mTJrLZ2Cx6xHeWN" Bounds="653,-186" />
-                      <ControlPoint Id="K6g8lm4SIoLN81euaeI2sK" Bounds="983,-206" />
-                      <Pad Id="S8MuytqvtOjMOjAVXc4FM9" Comment="Key" Bounds="1022,187,133,20" ShowValueBox="true" isIOBox="true" Value="Radius">
+                      <ControlPoint Id="KLH3JO9mTJrLZ2Cx6xHeWN" Bounds="358,31" />
+                      <ControlPoint Id="K6g8lm4SIoLN81euaeI2sK" Bounds="701,31" />
+                      <Pad Id="S8MuytqvtOjMOjAVXc4FM9" Comment="Key" Bounds="722,454,133,20" ShowValueBox="true" isIOBox="true" Value="Radius">
                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
-                      <Node Bounds="696,143,78,22" Id="TQKO6YxjTe9N1y0rwxIpWS">
+                      <Node Bounds="396,410,78,26" Id="TQKO6YxjTe9N1y0rwxIpWS">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetFloat32" />
@@ -50123,8 +49894,8 @@
                         <Pin Id="TGFPWTgYncFL1GDZsSvCy8" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="SRxst3c1tIpLCCCux0y73S" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <ControlPoint Id="T2ofnyzW1QRQKuaXj32z4o" Bounds="1021,621" />
-                      <Node Bounds="947,251,89,13" Id="VRHBw6bTVGtPq0VJRDsfgR">
+                      <ControlPoint Id="T2ofnyzW1QRQKuaXj32z4o" Bounds="718,842" />
+                      <Node Bounds="644,580,89,19" Id="VRHBw6bTVGtPq0VJRDsfgR">
                         <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="CreateDefault" />
@@ -50132,7 +49903,7 @@
                         </p:NodeReference>
                         <Pin Id="OIrdw2jyO8kMwPHpcnRcM9" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="952,578,77,26" Id="OKG8NBdVFDwLoptsuX5HBA">
+                      <Node Bounds="644,792,77,26" Id="OKG8NBdVFDwLoptsuX5HBA">
                         <p:NodeReference LastCategoryFullName="Collections.Builder.DictionaryBuilder" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ToImmutable" />
@@ -50142,7 +49913,7 @@
                         <Pin Id="NABKvFdTsNTN1vbTdNQJlb" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="QSVc0mmvdXaMtUpOjYLvrJ" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="947,284,205,13" Id="AhLBuydeophQK5PfYRVMP2">
+                      <Node Bounds="644,612,205,19" Id="AhLBuydeophQK5PfYRVMP2">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AddFloat32" />
@@ -50168,7 +49939,7 @@
                         <Pin Id="NQOmrPUNyLWNrqYhrg7nnb" Name="Unit" Kind="InputPin" />
                         <Pin Id="RcDly9XyU0aNTD8FmG6aBe" Name="Properties" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="659,-108,79,22" Id="UMv8R9IH3jOK97bquuQTi6">
+                      <Node Bounds="359,159,79,26" Id="UMv8R9IH3jOK97bquuQTi6">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixtures" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetFixtures" />
@@ -50178,7 +49949,7 @@
                         <Pin Id="IZAlKqO49m4N8YbTAHhDI1" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="GdcsiihRiUfNO6CAYTMIdC" Name="Fixtures" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="656,-141,79,13" Id="MimmG1kUa7aQXeRUIJyuGr">
+                      <Node Bounds="356,126,79,19" Id="MimmG1kUa7aQXeRUIJyuGr">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.Model.PropertyBank" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetFixtures" />
@@ -50188,7 +49959,7 @@
                         <Pin Id="MZa0bDe7DcSOE7SRfzHISR" Name="Output" Kind="OutputPin" />
                         <Pin Id="PofYZl1KeAxLrMh8Yel0s8" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="948,424,114,13" Id="VHJEKYfQc5YNcbmJvimpZg">
+                      <Node Bounds="644,682,114,19" Id="VHJEKYfQc5YNcbmJvimpZg">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AddFixtureSelector" />
@@ -50196,7 +49967,7 @@
                         <Pin Id="KpaoXmCEisWNKU672Ma0gN" Name="Input" Kind="InputPin" />
                         <Pin Id="ELXyUmgQ1TdLUjvFoYBIkk" Name="Properties" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="786,-88,136,96" Id="LprVwujHO3DORrjV7ypH1T">
+                      <Node Bounds="485,177,137,105" Id="LprVwujHO3DORrjV7ypH1T">
                         <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="OperationCallFlag" Name="Where" />
                           <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -50208,10 +49979,10 @@
                           <Pin Id="H9luPzjMYsSLHB1OcqDOZY" Name="Arg 1" Kind="InputPin" />
                           <Pin Id="G8IBp2eVdbUOnz0RfikhlN" Name="Arg 2" Kind="InputPin" />
                           <Pin Id="Kp8nKTGFjDoPL7oe2kVRy3" Name="Result" Kind="OutputPin" />
-                          <ControlPoint Id="Af98tS6OiS6OU5rgGlYydL" Bounds="789,-82" />
-                          <ControlPoint Id="KjUbRHvwtBCNuPEhhrKQWq" Bounds="849,-82" />
-                          <ControlPoint Id="CxYNK3IVksTNqggeBLN6XJ" Bounds="789,-2" />
-                          <Node Bounds="799,-53,68,22" Id="TLevHr8OcblM62pK09X8zh">
+                          <ControlPoint Id="Af98tS6OiS6OU5rgGlYydL" Bounds="489,185" />
+                          <ControlPoint Id="KjUbRHvwtBCNuPEhhrKQWq" Bounds="549,185" />
+                          <ControlPoint Id="CxYNK3IVksTNqggeBLN6XJ" Bounds="489,265" />
+                          <Node Bounds="499,214,68,26" Id="TLevHr8OcblM62pK09X8zh">
                             <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetName" />
@@ -50223,7 +49994,7 @@
                             <Pin Id="BwN9srPpZ2ILcE98XakqMa" Name="Output" Kind="StateOutputPin" />
                             <Pin Id="CPoWEJimvToPBV6S1zenRC" Name="Name" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="885,-24,25,13" Id="P7Dc9AEVtDIL7PmvoGd86r">
+                          <Node Bounds="585,243,25,19" Id="P7Dc9AEVtDIL7PmvoGd86r">
                             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="=" />
@@ -50234,7 +50005,7 @@
                           </Node>
                         </Patch>
                       </Node>
-                      <Node Bounds="999,-144,69,22" Id="TXohSOAEIISPlTxuSNjaOL">
+                      <Node Bounds="699,123,69,26" Id="TXohSOAEIISPlTxuSNjaOL">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetString" />
@@ -50250,7 +50021,7 @@
                         <Pin Id="REHrAxgQvr6M4xeUfbMOOw" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="CNjkojPXuwSM4thBbKjcC9" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="780,24,46,22" Id="Uw4xeewDUPtOgf4NpDgqjn">
+                      <Node Bounds="480,291,52,19" Id="Uw4xeewDUPtOgf4NpDgqjn">
                         <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -50261,7 +50032,7 @@
                         <Pin Id="FsrkEaVYiB4Nc4Rf27T4Da" Name="Index" Kind="InputPin" />
                         <Pin Id="P92P0XgdKedPksOxXebKJ3" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="773,66,67,13" Id="Fhl1YHcMWMBMRXBZS4FNNq">
+                      <Node Bounds="473,333,67,19" Id="Fhl1YHcMWMBMRXBZS4FNNq">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetState (Fixture)" />
@@ -50270,7 +50041,7 @@
                         <Pin Id="K4IKwijeK6aPYUMxqweoit" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="JUZVqdPN8BuLtakLAAYOye" Name="State" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="768,94,78,13" Id="Rq7P49VIsG2MQSAx6Vij9x">
+                      <Node Bounds="468,361,78,19" Id="Rq7P49VIsG2MQSAx6Vij9x">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetPosition" />
@@ -50281,7 +50052,7 @@
                         <Pin Id="NrnqT22JvaoPCUvahBBGBf" Name="Output" Kind="OutputPin" />
                         <Pin Id="PT9Elz6k75yL8Aa8oGHH65" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="453,642,69,19" Id="Pv8ewk533IfLjqejVuFFCD">
+                      <Node Bounds="153,909,69,19" Id="Pv8ewk533IfLjqejVuFFCD">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="SetColors" />
@@ -50290,7 +50061,7 @@
                         <Pin Id="P8p8vO6TljzNbmOMZSz8Ji" Name="Value" Kind="InputPin" />
                         <Pin Id="DuoOcHz8EcEOrNE6P2OhO5" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="867,55" Id="GPOJzZQdymNMZwyrBnrtwo">
+                      <Node Bounds="567,322,57,19" Id="GPOJzZQdymNMZwyrBnrtwo">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.Fixture" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetSetup (Fixture)" />
@@ -50299,7 +50070,7 @@
                         <Pin Id="K6XO2VljAEwQPh0lQIjAQA" Name="Output" Kind="OutputPin" />
                         <Pin Id="EusZ4J9gAtwLxpeJI4OV4y" Name="Setup" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="914,87,78,13" Id="UICpLgSn6VgMutERSTztlE">
+                      <Node Bounds="614,354,78,19" Id="UICpLgSn6VgMutERSTztlE">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetPosition" />
@@ -50310,7 +50081,7 @@
                         <Pin Id="DJgAYGfXFPYMJ3didE5Vwb" Name="Output" Kind="OutputPin" />
                         <Pin Id="VZp1dFa4CZwPTdhkFNkPbg" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="957,336,165,13" Id="U4xbw1QyqulMn9OkU2m50U">
+                      <Node Bounds="644,652,165,19" Id="U4xbw1QyqulMn9OkU2m50U">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AddBoolean" />
@@ -50328,7 +50099,7 @@
                         <Pin Id="AYcdZL1FIfXLlo8SDnEK5J" Name="Tooltip" Kind="InputPin" />
                         <Pin Id="VdP3b3sRBPOLpSKatap87H" Name="Properties" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="412,-61,94,19" Id="KhhcHSlZM6ILmUHZ5tRAK1">
+                      <Node Bounds="112,206,94,19" Id="KhhcHSlZM6ILmUHZ5tRAK1">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetPixelPositions" />
@@ -50338,20 +50109,20 @@
                         <Pin Id="Gt8NVCH9b02MrMWCo2RMdf" Name="Output" Kind="OutputPin" />
                         <Pin Id="CKlk4vVk5EjP1lcZs0JzZ5" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="434,-20,149,554" Id="ITY3cIPePW7LNmaHz4Wjac">
+                      <Node Bounds="134,247,149,554" Id="ITY3cIPePW7LNmaHz4Wjac">
                         <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                           <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                           <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                           <CategoryReference Kind="Category" Name="Primitive" />
                         </p:NodeReference>
-                        <ControlPoint Id="MElnZs9epnMQH8SafSVR5i" Bounds="466,-13" Alignment="Top" />
+                        <ControlPoint Id="MElnZs9epnMQH8SafSVR5i" Bounds="166,253" Alignment="Top" />
                         <Pin Id="Nu5lJfndCDePgpypm1gcUk" Name="Break" Kind="OutputPin" />
-                        <ControlPoint Id="VObpsAEj64kNt9p5lUCARV" Bounds="504,528" Alignment="Bottom" />
+                        <ControlPoint Id="VObpsAEj64kNt9p5lUCARV" Bounds="204,795" Alignment="Bottom" />
                         <Patch Id="CLR2m7np7APMEEejItkB0C" ManuallySortedPins="true">
                           <Patch Id="PtiDUjFJojFP4x3emjVcaf" Name="Create" ManuallySortedPins="true" />
                           <Patch Id="SbmATKCREyGPf69rQPQOk6" Name="Update" ManuallySortedPins="true" />
                           <Patch Id="Tm5cTFoQ1mkNBbtQCPWu5I" Name="Dispose" ManuallySortedPins="true" />
-                          <Node Bounds="499,494,65,19" Id="SGhU0ZI5hqHMlqJbVNBGdB">
+                          <Node Bounds="199,761,65,19" Id="SGhU0ZI5hqHMlqJbVNBGdB">
                             <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="FromHSL" />
@@ -50366,7 +50137,7 @@
                             <Pin Id="MVYZiNdvLemO77B4G8DYuU" Name="Alpha" Kind="InputPin" />
                             <Pin Id="RZh3ycyzYgiLRo9qI9hkG6" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="506,201,65,19" Id="VTItIhyIiKWODwWasgNFmY">
+                          <Node Bounds="206,468,65,19" Id="VTItIhyIiKWODwWasgNFmY">
                             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Distance" />
@@ -50375,7 +50146,7 @@
                             <Pin Id="RJ07Fehj2zdLmgdZ6dlt4v" Name="Input 2" Kind="InputPin" />
                             <Pin Id="IDzSDtuUavdPJykynrc4WV" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="484,241,85,19" Id="NoknQJ9gGpPQT5Vpa6Cblt">
+                          <Node Bounds="184,508,85,19" Id="NoknQJ9gGpPQT5Vpa6Cblt">
                             <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="MapClamp" />
@@ -50392,7 +50163,7 @@
                             <Pin Id="AejtFCgg2kwNq2WHROoRj5" Name="Output Maximum" Kind="InputPin" />
                             <Pin Id="KjYBanSlnzyLwSkNpMbZYz" Name="Output" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="505,60,52,19" Id="CF4uVK0FNhAOWnhJZXEdPc">
+                          <Node Bounds="205,327,52,19" Id="CF4uVK0FNhAOWnhJZXEdPc">
                             <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -50402,19 +50173,19 @@
                             <Pin Id="MnrGfon9aKyLFuCtxHAN8U" Name="Index" Kind="InputPin" />
                             <Pin Id="KZSMn7xs4mrPSCCoXksm82" Name="Result" Kind="OutputPin" />
                           </Node>
-                          <Node Bounds="457,320,99,140" Id="URL36eSpHZKPit1kKwT686">
+                          <Node Bounds="157,587,99,140" Id="URL36eSpHZKPit1kKwT686">
                             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                               <Choice Kind="ApplicationStatefulRegion" Name="If" />
                               <CategoryReference Kind="Category" Name="Primitive" />
                             </p:NodeReference>
                             <Pin Id="BROFc3zSfz5OzBf29hkEa3" Name="Condition" Kind="InputPin" />
-                            <ControlPoint Id="POY11HrtChbL7vBqaVz6cR" Bounds="514,454" Alignment="Bottom" />
-                            <ControlPoint Id="BomnoL64Wo8Nl4axrrlCjD" Bounds="514,327" Alignment="Top" />
+                            <ControlPoint Id="POY11HrtChbL7vBqaVz6cR" Bounds="214,721" Alignment="Bottom" />
+                            <ControlPoint Id="BomnoL64Wo8Nl4axrrlCjD" Bounds="214,593" Alignment="Top" />
                             <Patch Id="HKHJqgNFjU9QYTm3bcLgeM" ManuallySortedPins="true">
                               <Patch Id="RNparp3OuQQPlaCIjhlty8" Name="Create" ManuallySortedPins="true" />
                               <Patch Id="EmaVrwsDBaPOfE2Oh2aXM6" Name="Then" ManuallySortedPins="true" />
-                              <Node Bounds="469,374,45,19" Id="T4aKVbPnfqCLuiZcGaEOUV">
+                              <Node Bounds="169,641,45,19" Id="T4aKVbPnfqCLuiZcGaEOUV">
                                 <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationNode" Name="Switch (Boolean)" />
@@ -50425,7 +50196,7 @@
                                 <Pin Id="EVnrBlu25U6OFyaqkINI5s" Name="Input 2" Kind="InputPin" />
                                 <Pin Id="J0HizHh2BtXLm3aucv9Z6Z" Name="Output" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="488,344,25,19" Id="Tmermhkd5uLLNugVFWrROZ">
+                              <Node Bounds="188,611,25,19" Id="Tmermhkd5uLLNugVFWrROZ">
                                 <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -50435,7 +50206,7 @@
                                 <Pin Id="AKGwqDi7fBmL6VKpKnYWK3" Name="Input 2" Kind="InputPin" />
                                 <Pin Id="O6axdV3y5zDQD09BaDrHQw" Name="Result" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="519,345,25,19" Id="UIyDzLojLPsPJSpEk8N1N4">
+                              <Node Bounds="219,612,25,19" Id="UIyDzLojLPsPJSpEk8N1N4">
                                 <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationCallFlag" Name="&lt;" />
@@ -50445,7 +50216,7 @@
                                 <Pin Id="EZ0JY2ugRBeOtym5cG6OtV" Name="Input 2" Kind="InputPin" />
                                 <Pin Id="Upiy75bfoyzOyVq61WegyE" Name="Result" Kind="OutputPin" />
                               </Node>
-                              <Node Bounds="488,421,45,19" Id="NXpbrPEs6VPQVvMZLAdgF6">
+                              <Node Bounds="188,688,45,19" Id="NXpbrPEs6VPQVvMZLAdgF6">
                                 <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                   <Choice Kind="OperationNode" Name="Switch (Boolean)" />
@@ -50462,7 +50233,7 @@
                               </Node>
                             </Patch>
                           </Node>
-                          <Node Bounds="505,10,64,19" Id="EnEkC0ETX2yPz8pnXR2WeP">
+                          <Node Bounds="205,277,64,19" Id="EnEkC0ETX2yPz8pnXR2WeP">
                             <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="Transform" />
@@ -50472,7 +50243,7 @@
                             <Pin Id="BBsvPeKeP9TL88lLJebVJu" Name="Transform" Kind="InputPin" />
                             <Pin Id="EO8GsxSV2MvM9HkWYj4TCi" Name="Output" Kind="StateOutputPin" />
                           </Node>
-                          <Node Bounds="535,470,25,19" Id="Rz3gXrR04CYOUWBcouCb3F">
+                          <Node Bounds="235,737,25,19" Id="Rz3gXrR04CYOUWBcouCb3F">
                             <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                               <Choice Kind="OperationCallFlag" Name="*" />
@@ -50483,7 +50254,7 @@
                           </Node>
                         </Patch>
                       </Node>
-                      <Node Bounds="801,204,78,22" Id="TT2ZV4XBer3MTna3EOODFC">
+                      <Node Bounds="501,471,78,26" Id="TT2ZV4XBer3MTna3EOODFC">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetBoolean" />
@@ -50494,12 +50265,12 @@
                         <Pin Id="Jf0KiUuMxlJNTQJoD68MHL" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="DVJvgdrMR03NSX9dDqQQ9X" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Pad Id="SnzFegyDEyZOJYUX0UZbLv" Comment="Key" Bounds="1070,219,70,19" ShowValueBox="true" isIOBox="true" Value="Target/Local">
+                      <Pad Id="SnzFegyDEyZOJYUX0UZbLv" Comment="Key" Bounds="770,486,70,19" ShowValueBox="true" isIOBox="true" Value="Target/Local">
                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
-                      <Node Bounds="758,268" Id="S6gNJKHVY4LLaHNSnr8dVK">
+                      <Node Bounds="458,535,45,19" Id="S6gNJKHVY4LLaHNSnr8dVK">
                         <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationNode" Name="Switch (Boolean)" />
@@ -50510,7 +50281,7 @@
                         <Pin Id="HkL29o8GcMhO0sdMpkc7ye" Name="Input 2" Kind="InputPin" />
                         <Pin Id="IgQEmFvuju4LxcLPQ0GKqg" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="795,127,72,13" Id="PhppIloKaX3NwOca8bw4T7">
+                      <Node Bounds="495,394,72,19" Id="PhppIloKaX3NwOca8bw4T7">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetRadius" />
@@ -50525,7 +50296,7 @@
                         <Pin Id="T4g3dC1GntmLbhVRtIuQJm" Name="Output" Kind="OutputPin" />
                         <Pin Id="NFnLmpji9aKQdRvz349JlK" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="792,329,86,22" Id="Uta6EHMTNLiP6du1UIe2p7">
+                      <Node Bounds="492,596,86,26" Id="Uta6EHMTNLiP6du1UIe2p7">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetInteger32" />
@@ -50536,14 +50307,14 @@
                         <Pin Id="HDVDtbxRCeRNRtZOrKBmA0" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="CcN5WTKQUVfLQV1lkiauZq" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="1043,114" Id="MVSsIDwfmQmOmFSGI8IkrD">
+                      <Node Bounds="743,381,52,19" Id="MVSsIDwfmQmOmFSGI8IkrD">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AxisKey" />
                         </p:NodeReference>
                         <Pin Id="Jq1eKp7Hg1YMe8I7jeQrIn" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="645,323,52,19" Id="FWEEjDGH8LnPti3FCdOudE">
+                      <Node Bounds="345,590,52,19" Id="FWEEjDGH8LnPti3FCdOudE">
                         <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -50553,7 +50324,7 @@
                         <Pin Id="OvmUGrdjNmNLPmQWXaZo65" Name="Index" Kind="InputPin" />
                         <Pin Id="Ash6ipDQ7BUQLTJiwR47Dx" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="950,479" Id="F9CrdlXgslUMS7OakpgCMA">
+                      <Node Bounds="644,712,165,19" Id="F9CrdlXgslUMS7OakpgCMA">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AddEnum" />
@@ -50573,7 +50344,7 @@
                         <Pin Id="M9GdkYaOLm9NcU3mGDil0A" Name="Unit" Kind="InputPin" />
                         <Pin Id="LSZwPJLNPp3O86KbRd3YVZ" Name="Properties" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="651,-3,86,22" Id="D6wePt80Fk7PiikhLFkROB">
+                      <Node Bounds="351,264,86,26" Id="D6wePt80Fk7PiikhLFkROB">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetInteger32" />
@@ -50584,12 +50355,12 @@
                         <Pin Id="TspKg61r8KyLviX83oBeD1" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="Vl5Pge0ZjfHOrV7aAEMa03" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Pad Id="VXEWAKzr7cCOH6qfRc4Fky" Comment="Key" Bounds="1071,-164,20,19" ShowValueBox="true" isIOBox="true" Value="Direction">
+                      <Pad Id="VXEWAKzr7cCOH6qfRc4Fky" Comment="Key" Bounds="743,60,20,19" ShowValueBox="true" isIOBox="true" Value="Direction">
                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
-                      <Node Bounds="661,50,25,13" Id="L53nG7jDkQfPUgZw30B6Rq">
+                      <Node Bounds="361,317,25,19" Id="L53nG7jDkQfPUgZw30B6Rq">
                         <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -50599,7 +50370,7 @@
                         <Pin Id="Scg9sm3QfZJOx62nAt1xhK" Name="Input 2" Kind="InputPin" />
                         <Pin Id="MNmMNtpKjgcOOBq4X5DMhH" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="705,55,25,13" Id="UIyQHbloMfiQSted9ra1s3">
+                      <Node Bounds="405,322,25,19" Id="UIyQHbloMfiQSted9ra1s3">
                         <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="=" />
@@ -50612,7 +50383,7 @@
                         </Pin>
                         <Pin Id="MxFF2okbXe9QUG7wZzw4h0" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="794,157,70,19" Id="JuVX7fCCgy0PT97jMtxEOY">
+                      <Node Bounds="494,424,70,19" Id="JuVX7fCCgy0PT97jMtxEOY">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetRotation" />
@@ -50622,7 +50393,7 @@
                         <Pin Id="J4vahymLgkGNYe1lEcf059" Name="Output" Kind="OutputPin" />
                         <Pin Id="EUUvHf15rPPL7rQ3q6wMhl" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="597,68,45,19" Id="UWLTzSZOfG0LYDnogRXZSa">
+                      <Node Bounds="297,335,45,19" Id="UWLTzSZOfG0LYDnogRXZSa">
                         <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Rotate" />
@@ -50634,7 +50405,7 @@
                         <Pin Id="Lj8YSqHwEc6QFAUq2ckJTA" Name="Rotation" Kind="InputPin" />
                         <Pin Id="NhmreNBKdTcNkqLpvd7lwf" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="598,41,58,19" Id="LO6OOk2PqkCO042bkI0LKe">
+                      <Node Bounds="298,308,58,19" Id="LO6OOk2PqkCO042bkI0LKe">
                         <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Translate" />
@@ -50646,7 +50417,7 @@
                         <Pin Id="BAb6jXRoU2vOQUOoNVqlTR" Name="Translation" Kind="InputPin" />
                         <Pin Id="URCBAlWHEEyPnko4W6ZbL1" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="596,94,42,19" Id="E4vBpqsWAXeOnv6A6HKY8m">
+                      <Node Bounds="296,361,42,19" Id="E4vBpqsWAXeOnv6A6HKY8m">
                         <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Invert" />
@@ -50655,7 +50426,7 @@
                         <Pin Id="SnHhqOhak6wP7deX6RUi8r" Name="Input" Kind="StateInputPin" />
                         <Pin Id="JydxXr6Yj51QNAh2bTUWXv" Name="Output" Kind="StateOutputPin" />
                       </Node>
-                      <Node Bounds="644,400,61,19" Id="C1B1w0kb7QNO0yMK978hme">
+                      <Node Bounds="344,667,61,19" Id="C1B1w0kb7QNO0yMK978hme">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetColors" />
@@ -50664,7 +50435,7 @@
                         <Pin Id="TohBVQ211MUN9Jkw4Jbf7E" Name="Output" Kind="OutputPin" />
                         <Pin Id="CLnb5h95ZyZLghqFsIaN7D" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="701,439,52,26" Id="P8RYP8ngAbMOMDbxOK2ZvM">
+                      <Node Bounds="401,706,52,19" Id="P8RYP8ngAbMOMDbxOK2ZvM">
                         <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -50679,7 +50450,7 @@
                         <Pin Id="IswrUk61RxyLe0gubmfDMZ" Name="Index" Kind="InputPin" />
                         <Pin Id="KG91DeArS1IOvXntf8yR2u" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="757,400,61,19" Id="M8rUbBQYE7PNQmvLqH6Di3">
+                      <Node Bounds="457,667,61,19" Id="M8rUbBQYE7PNQmvLqH6Di3">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetColors" />
@@ -50688,7 +50459,7 @@
                         <Pin Id="QLhnjYoyR5JLlhB1CLeDIP" Name="Output" Kind="OutputPin" />
                         <Pin Id="IHNpBGeJwD7Mesjcfdv2sT" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="814,439,52,26" Id="T7FpmCmJG3JLNyZw3EqYXt">
+                      <Node Bounds="514,706,52,19" Id="T7FpmCmJG3JLNyZw3EqYXt">
                         <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetSlice" />
@@ -50703,7 +50474,7 @@
                         <Pin Id="Gy24QEJabfePxcbKiS5W0V" Name="Index" Kind="InputPin" />
                         <Pin Id="UEapQhQD0RNNctqSmY91Q1" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="914,133,70,19" Id="IAS3Ek0FkXGLDTnRNYMZDf">
+                      <Node Bounds="614,400,70,19" Id="IAS3Ek0FkXGLDTnRNYMZDf">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetRotation" />
@@ -50713,7 +50484,7 @@
                         <Pin Id="SyMvNG1jBU3LqExH5iDi1R" Name="Output" Kind="OutputPin" />
                         <Pin Id="A7cBfpG94stLQNg0qwuVG1" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="720,513,45,19" Id="EloeDsNz6pBQHybcuRjClR">
+                      <Node Bounds="420,780,45,19" Id="EloeDsNz6pBQHybcuRjClR">
                         <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="Switch" />
@@ -50724,7 +50495,7 @@
                         <Pin Id="CCT95afIma0OlwruZoYAtJ" Name="Input 2" Kind="InputPin" />
                         <Pin Id="MVeu4AECCdLNW6KHYzGEP9" Name="Output" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="976,524,165,13" Id="Pv9n15axW2nNgf7ALhasT3">
+                      <Node Bounds="644,752,165,19" Id="Pv9n15axW2nNgf7ALhasT3">
                         <p:NodeReference LastCategoryFullName="VVVV.Schema.PropertyDefinition" LastDependency="VVVV.Schema.Core.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="AddBoolean" />
@@ -50738,12 +50509,12 @@
                         <Pin Id="SWBBvi3gLsJM6NNB3kDKid" Name="Tooltip" Kind="InputPin" />
                         <Pin Id="NRd3HAEJxqbM3QbTKMObR6" Name="Properties" Kind="OutputPin" />
                       </Node>
-                      <Pad Id="CbxTy8Roa34QDuQP5BB401" Comment="Key" Bounds="1130,112,35,15" ShowValueBox="true" isIOBox="true" Value="Color From Target">
+                      <Pad Id="CbxTy8Roa34QDuQP5BB401" Comment="Key" Bounds="830,379,35,15" ShowValueBox="true" isIOBox="true" Value="Color From Target">
                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </p:TypeAnnotation>
                       </Pad>
-                      <Node Bounds="841,240,78,22" Id="GsSTk0dNjFkMLRZDue99jw">
+                      <Node Bounds="541,507,78,26" Id="GsSTk0dNjFkMLRZDue99jw">
                         <p:NodeReference LastCategoryFullName="Schema.Model.PropertyBank" LastDependency="Schema.Model.PropertyBank.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="GetBoolean" />
@@ -50754,7 +50525,7 @@
                         <Pin Id="UY4DfMwGrUwMK1YcEyVvpb" Name="Output" Kind="StateOutputPin" />
                         <Pin Id="T5temGdWbIQO5wgry9Z7IX" Name="Result" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="721,542,65,19" Id="QfiIQ2ee9RDQK7Shv8667G">
+                      <Node Bounds="421,809,65,19" Id="QfiIQ2ee9RDQK7Shv8667G">
                         <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ToHSL" />
@@ -50765,7 +50536,7 @@
                         <Pin Id="Rd9oUjADXenPiZrDCBu3aD" Name="Lightness" Kind="OutputPin" />
                         <Pin Id="SsORWyDB7STPYyDkf6xDh2" Name="Alpha" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="800,543,65,19" Id="VABI5JAa16VL81dcmkY6lR">
+                      <Node Bounds="500,810,65,19" Id="VABI5JAa16VL81dcmkY6lR">
                         <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="ToHSV" />
@@ -50776,7 +50547,7 @@
                         <Pin Id="DssYfNB0xH8O9YcsxNOiO5" Name="Value" Kind="OutputPin" />
                         <Pin Id="BACLHxquVK9OVIR2tIsFqy" Name="Alpha" Kind="OutputPin" />
                       </Node>
-                      <Pad Id="AsVkE4wQRvbP6U7NanqdNw" Comment="Index" Bounds="700,301,35,15" ShowValueBox="true" isIOBox="true" Value="2">
+                      <Pad Id="AsVkE4wQRvbP6U7NanqdNw" Comment="Index" Bounds="400,568,35,15" ShowValueBox="true" isIOBox="true" Value="2">
                         <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                           <Choice Kind="TypeFlag" Name="Integer32" />
                         </p:TypeAnnotation>
@@ -62574,4 +62345,5 @@
   <DocumentDependency Id="FVLsjTQR5fJMI8hviFW1IT" Location="./Extensions/Audio/Schema.Extensions.Audio.vl" IsForward="true" />
   <DocumentDependency Id="PdMjoGV3bvoOFB71Cq7DKl" Location="./Model/Schema.Model.AudioState.vl" IsForward="true" />
   <PlatformDependency Id="G8QCO1q3OVxNmqw9BHCY3W" Location="../lib/FileUtils.dll" />
+  <DocumentDependency Id="NBd2McXpGnaMUSPe4sMXqR" Location="./Utilities/Schema.Utilities.Logging.vl" IsForward="true" />
 </Document>


### PR DESCRIPTION
## Overview
This PR consolidates a broad optimization pass across app startup/runtime flow, build/export configuration, plugin output performance, and VL document/version alignment.

Compared to `dev`, the branch is **12 commits ahead** and includes targeted cleanup commits followed by feature-level improvements.

## Commit history reviewed
- `0034fb4` chore: version bumps  
- `4eeff91` chore: version bumps  
- `b147be9` chore: version bump in dependencies script  
- `de9c0e6` chore: patch cleanup  
- `2c58615` feat: patch cleanups, cache floorplan layer  
- `7dedd68` feat: optimize DirectoryFilePath node  
- `e7d5379` chore: update to latest vvvv, fix generic settings  
- `3fec4d2` feat: resolve schema lite build for linux  
- `62b6f3c` chore: update document versions  
- `715b2d0` feat: refactor logging, fix project paths on linux  
- `49ae75d` feat: Blocks: add rainbow node (channel-order debugging)  
- `f0ff60d` feat: Plugins: ArtNet output optimization, draft channel offset support

## What changed

### 1) Build/export and platform targeting
- Updated `.props` for app variants to improve export behavior and runtime determinism:
  - `VLAssetBehavior` switched to `RelativeToOutput` where needed.
  - Added explicit runtime identifiers (e.g. `linux-arm64`, `win-x64`).
  - Added explicit compile/unhandled-exception behavior flags.
- Fixed Schema Lite Linux build/export flow (`Main/gamma/Schema_Lite.props`, related app changes).

### 2) VL / document version modernization
- Upgraded multiple VL documents and package references to newer `2025.7.x` versions.
- Updated dependency versions and document metadata for consistency across app, UI, and core documents.

### 3) App startup/runtime flow refactor
- Simplified entry/runtime orchestration:
  - `Schema_Studio.vl` moved from older project selector flow toward `Schema.App.Studio` usage.
  - Added `Main/vl/App/Schema.App.Studio.vl`.
  - Runtime/editor patches were cleaned and restructured for safer flow and clearer state handling.
- Improved runtime resilience and keep-alive/error-path behavior in affected patches.

### 4) Logging refactor
- Introduced `Main/vl/Utilities/Schema.Utilities.Logging.vl` with reusable info/warning/error logging helpers (string + generic variants).
- Refactored runtime/editor call sites to use cleaner logging paths and prefixes.

### 5) Blocks and plugin improvements
- Added debug-oriented source blocks (including Rainbow/channel-order tooling and expression/value sources).
- Added/expanded Surfaces plugin building blocks and output pipeline files.
- Optimized ArtNet output path and introduced draft support for channel offsets.
- Additional plugin cleanups/compatibility updates across DMX/OpenDMX/OSC/XBox/MovingHeads/Sequences touch points.

### 6) Core/UI/model cleanup and performance-oriented edits
- Significant updates in `VVVV.Schema.Core.vl`, `Schema.UI.vl`, plugin selector, and project/model files to remove obsolete wiring, reduce complexity, and align with the updated runtime/app architecture.

## File impact snapshot
- **40 files changed**
- Notable large additions:
  - `Main/gamma/sketches/ImguiWidget/Schema.Embed.ImGui.vl`
  - `Main/vl/Utilities/Schema.Utilities.Logging.vl`
  - `Main/vl/App/Schema.App.Studio.vl`
  - Surfaces plugin/blocks extension files

## Notes
- This PR mixes structural refactors, version migration, and runtime/plugin optimization in one branch.
- ArtNet/channel-offset behavior is marked draft-level in commit intent and may benefit from focused follow-up validation/tuning.