### PR TITLE
Schéma CI: run from dev and PR source refs

### DIFF
--- a/.github/workflows/schema-build.yml
+++ b/.github/workflows/schema-build.yml
@@ -1,8 +1,13 @@
-name: Schema build
+name: Schéma build
 
 on:
   workflow_dispatch:
     inputs:
+      source_ref:
+        description: 'Git ref to build from (branch, tag, or SHA)'
+        required: false
+        type: string
+        default: dev
       offline_url:
         description: 'Optional TeamCity offline installer URL override'
         required: false
@@ -15,219 +20,19 @@ on:
         description: 'Optional Schema_Lite patch path override relative to repo root'
         required: false
         type: string
+  pull_request:
+    branches: [dev]
   push:
-    branches: [main]
+    branches: [dev]
 
 jobs:
   export:
-    runs-on: windows-latest
-    timeout-minutes: 75
-    env:
-      VVVV_OFFLINE_URL_DEFAULT: https://teamcity.vvvv.org/guestAuth/app/rest/builds/id:39385/artifacts/content/vvvv_gamma_7.0-win-x64_setup_offline.exe
-      VVVV_INSTALLER: ${{ github.workspace }}\vvvv_setup_offline.exe
-      EXPORT_ROOT: ${{ github.workspace }}\dist
-      STUDIO_PATCH_PATH_DEFAULT: ${{ github.workspace }}\Main\gamma\Schema_Studio.vl
-      LITE_PATCH_PATH_DEFAULT: ${{ github.workspace }}\Main\gamma\Schema_Lite.vl
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Resolve inputs
-        id: resolve
-        shell: pwsh
-        run: |
-          function Resolve-PatchPath([string]$inputValue, [string]$defaultValue) {
-            if ([string]::IsNullOrWhiteSpace($inputValue)) {
-              return $defaultValue
-            }
-            return (Join-Path $env:GITHUB_WORKSPACE $inputValue)
-          }
-
-          $offlineUrl = '${{ inputs.offline_url }}'
-          if ([string]::IsNullOrWhiteSpace($offlineUrl)) {
-            $offlineUrl = $env:VVVV_OFFLINE_URL_DEFAULT
-          }
-
-          $studioPatch = Resolve-PatchPath '${{ inputs.studio_patch_path }}' $env:STUDIO_PATCH_PATH_DEFAULT
-          $litePatch = Resolve-PatchPath '${{ inputs.lite_patch_path }}' $env:LITE_PATCH_PATH_DEFAULT
-
-          foreach ($path in @($studioPatch, $litePatch)) {
-            if (-not (Test-Path $path)) {
-              throw "Patch path does not exist: $path"
-            }
-          }
-
-          "offline_url=$offlineUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "studio_patch=$studioPatch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "lite_patch=$litePatch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Download offline installer
-        id: download
-        shell: pwsh
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          $duration = (Measure-Command {
-            Invoke-WebRequest -Uri '${{ steps.resolve.outputs.offline_url }}' -OutFile $env:VVVV_INSTALLER
-          }).TotalSeconds
-          Get-Item $env:VVVV_INSTALLER | Format-List FullName,Length,LastWriteTime
-          "seconds=$([math]::Round($duration, 2))" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Install vvvv gamma silently
-        id: install
-        shell: pwsh
-        run: |
-          $duration = (Measure-Command {
-            $script:p = Start-Process -FilePath $env:VVVV_INSTALLER -ArgumentList '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART' -Wait -PassThru
-          }).TotalSeconds
-          $p = $script:p
-          if ($p.ExitCode -ne 0) {
-            throw "Installer failed with exit code $($p.ExitCode)"
-          }
-          Write-Host "Installer exit code: $($p.ExitCode)"
-          "seconds=$([math]::Round($duration, 2))" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Locate vvvvc.exe
-        id: locate
-        shell: pwsh
-        run: |
-          $candidates = @(
-            'C:\Program Files\vvvv\vvvv_gamma_7.0-win-x64\vvvvc.exe',
-            'C:\Program Files\vvvv\vvvv gamma\vvvvc.exe',
-            'C:\Program Files\vvvv\vvvv\vvvvc.exe',
-            'C:\Program Files\vvvv gamma\vvvvc.exe',
-            'C:\Program Files (x86)\vvvv\vvvv gamma\vvvvc.exe',
-            'C:\Program Files (x86)\vvvv\vvvv\vvvvc.exe',
-            'C:\Program Files (x86)\vvvv gamma\vvvvc.exe'
-          )
-
-          if (Test-Path 'C:\Program Files\vvvv') {
-            $candidates += Get-ChildItem 'C:\Program Files\vvvv' -Directory -ErrorAction SilentlyContinue |
-              Where-Object { $_.Name -like 'vvvv_gamma_*' } |
-              ForEach-Object { Join-Path $_.FullName 'vvvvc.exe' }
-          }
-
-          $found = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $found) {
-            $searchRoots = @(
-              'C:\Program Files',
-              'C:\Program Files (x86)',
-              "$env:LOCALAPPDATA\Programs"
-            ) | Where-Object { Test-Path $_ }
-
-            foreach ($root in $searchRoots) {
-              $found = Get-ChildItem $root -Filter vvvvc.exe -File -Recurse -ErrorAction SilentlyContinue |
-                Select-Object -ExpandProperty FullName -First 1
-              if ($found) { break }
-            }
-          }
-
-          if (-not $found) {
-            throw 'vvvvc.exe not found after install'
-          }
-
-          Write-Host "Found vvvvc.exe at: $found"
-          "vvvvc=$found" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Export Schema variants
-        shell: pwsh
-        run: |
-          function Set-MsBuildPropertyValue([string]$propsPath, [string]$propertyName, [string]$value) {
-            $content = Get-Content -LiteralPath $propsPath -Raw
-            $pattern = "(<$propertyName>)(.*?)(</$propertyName>)"
-            $updated = [regex]::Replace($content, $pattern, "`${1}$value`${3}")
-            if ($updated -eq $content) {
-              throw "Could not update property '$propertyName' in $propsPath"
-            }
-            Set-Content -LiteralPath $propsPath -Value $updated
-          }
-
-          function Remove-BuildOnlyFolders([string]$outputDir) {
-            $srcPath = Join-Path $outputDir 'src'
-            if (Test-Path $srcPath) {
-              Remove-Item -LiteralPath $srcPath -Recurse -Force
-            }
-          }
-
-          function Invoke-Export([string]$label, [string]$patch, [string]$rid, [string]$outputType, [string]$outputDir) {
-            $common = @(
-              '--verbosity', 'Information',
-              '--output-directory', $outputDir,
-              '--output-type', $outputType,
-              '--rid', $rid,
-              '--clean', 'true'
-            )
-
-            & '${{ steps.locate.outputs.vvvvc }}' @common $patch
-            if ($LASTEXITCODE -ne 0) {
-              Write-Host "First attempt failed for $label; retrying with patch path first."
-              & '${{ steps.locate.outputs.vvvvc }}' $patch @common
-            }
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "vvvvc export failed for $label with exit code $LASTEXITCODE"
-            }
-          }
-
-          function Export-Variant(
-            [string]$label,
-            [string]$patch,
-            [string]$rid,
-            [string]$outputType,
-            [string]$outputDir,
-            [string]$propsPath,
-            [hashtable]$propsOverrides
-          ) {
-            New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
-
-            if ($propsPath -and $propsOverrides.Count -gt 0) {
-              $backup = "$propsPath.bak"
-              Copy-Item -LiteralPath $propsPath -Destination $backup -Force
-              try {
-                foreach ($entry in $propsOverrides.GetEnumerator()) {
-                  Set-MsBuildPropertyValue -propsPath $propsPath -propertyName $entry.Key -value $entry.Value
-                }
-                Invoke-Export -label $label -patch $patch -rid $rid -outputType $outputType -outputDir $outputDir
-              }
-              finally {
-                Move-Item -LiteralPath $backup -Destination $propsPath -Force
-              }
-            }
-            else {
-              Invoke-Export -label $label -patch $patch -rid $rid -outputType $outputType -outputDir $outputDir
-            }
-
-            Remove-BuildOnlyFolders -outputDir $outputDir
-          }
-
-          $studioPatch = '${{ steps.resolve.outputs.studio_patch }}'
-          $litePatch = '${{ steps.resolve.outputs.lite_patch }}'
-          $liteProps = [System.IO.Path]::ChangeExtension($litePatch, '.props')
-
-          Export-Variant -label 'Schema_Studio win-x64' -patch $studioPatch -rid 'win-x64' -outputType 'WinExe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-studio-win-x64') -propsPath '' -propsOverrides @{}
-          Export-Variant -label 'Schema_Lite win-x64' -patch $litePatch -rid 'win-x64' -outputType 'Exe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-lite-win-x64') -propsPath $liteProps -propsOverrides @{ VLTargetOS = 'Windows' }
-          Export-Variant -label 'Schema_Lite linux-arm64' -patch $litePatch -rid 'linux-arm64' -outputType 'Exe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-lite-linux-arm64') -propsPath '' -propsOverrides @{}
-
-      - name: Show export directory
-        shell: pwsh
-        run: |
-          Get-ChildItem $env:EXPORT_ROOT -Recurse | Select-Object FullName,Length
-
-      - name: Upload export artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: schema-exports
-          path: |
-            dist/**
-            !dist/**/src/**
-
-      - name: Timing summary
-        shell: pwsh
-        run: |
-          @"
-          ### vvvv CI timing
-          - Download installer: ${{ steps.download.outputs.seconds }}s
-          - Silent install: ${{ steps.install.outputs.seconds }}s
-          - Exports: Schema_Studio win-x64, Schema_Lite win-x64, Schema_Lite linux-arm64
-          "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-
+    uses: ./.github/workflows/schema-shared-export.yml
+    with:
+      source_ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.source_ref || 'dev') || github.event_name == 'pull_request' && github.head_ref || github.ref_name || 'dev' }}
+      offline_url: ${{ github.event_name == 'workflow_dispatch' && inputs.offline_url || '' }}
+      studio_patch_path: ${{ github.event_name == 'workflow_dispatch' && inputs.studio_patch_path || 'Main/gamma/Schema_Studio.vl' }}
+      lite_patch_path: ${{ github.event_name == 'workflow_dispatch' && inputs.lite_patch_path || 'Main/gamma/Schema_Lite.vl' }}
+      ci_artifact_name: schema-exports
+      timeout_minutes: 75
+      create_release: false

--- a/.github/workflows/schema-release.yml
+++ b/.github/workflows/schema-release.yml
@@ -1,4 +1,4 @@
-name: Schema release
+name: Schéma release
 
 on:
   push:
@@ -10,6 +10,11 @@ on:
         description: 'Tag to release (for example: v1.2.3)'
         required: true
         type: string
+      source_ref:
+        description: 'Git ref to build from (branch, tag, or SHA)'
+        required: false
+        type: string
+        default: dev
       offline_url:
         description: 'Optional TeamCity offline installer URL override'
         required: false
@@ -28,242 +33,14 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: windows-latest
-    timeout-minutes: 90
-    env:
-      VVVV_OFFLINE_URL_DEFAULT: https://teamcity.vvvv.org/guestAuth/app/rest/builds/id:39385/artifacts/content/vvvv_gamma_7.0-win-x64_setup_offline.exe
-      VVVV_INSTALLER: ${{ github.workspace }}\vvvv_setup_offline.exe
-      EXPORT_ROOT: ${{ github.workspace }}\dist
-      STUDIO_PATCH_PATH_DEFAULT: ${{ github.workspace }}\Main\gamma\Schema_Studio.vl
-      LITE_PATCH_PATH_DEFAULT: ${{ github.workspace }}\Main\gamma\Schema_Lite.vl
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Resolve inputs
-        id: resolve
-        shell: pwsh
-        run: |
-          function Resolve-PatchPath([string]$inputValue, [string]$defaultValue) {
-            if ([string]::IsNullOrWhiteSpace($inputValue)) {
-              return $defaultValue
-            }
-            return (Join-Path $env:GITHUB_WORKSPACE $inputValue)
-          }
-
-          $offlineUrl = '${{ inputs.offline_url }}'
-          if ([string]::IsNullOrWhiteSpace($offlineUrl)) {
-            $offlineUrl = $env:VVVV_OFFLINE_URL_DEFAULT
-          }
-
-          $studioPatch = Resolve-PatchPath '${{ inputs.studio_patch_path }}' $env:STUDIO_PATCH_PATH_DEFAULT
-          $litePatch = Resolve-PatchPath '${{ inputs.lite_patch_path }}' $env:LITE_PATCH_PATH_DEFAULT
-
-          foreach ($path in @($studioPatch, $litePatch)) {
-            if (-not (Test-Path $path)) {
-              throw "Patch path does not exist: $path"
-            }
-          }
-
-          "offline_url=$offlineUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "studio_patch=$studioPatch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "lite_patch=$litePatch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Download offline installer
-        shell: pwsh
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri '${{ steps.resolve.outputs.offline_url }}' -OutFile $env:VVVV_INSTALLER
-          Get-Item $env:VVVV_INSTALLER | Format-List FullName,Length,LastWriteTime
-
-      - name: Install vvvv gamma silently
-        shell: pwsh
-        run: |
-          $p = Start-Process -FilePath $env:VVVV_INSTALLER -ArgumentList '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART' -Wait -PassThru
-          if ($p.ExitCode -ne 0) {
-            throw "Installer failed with exit code $($p.ExitCode)"
-          }
-
-      - name: Locate vvvvc.exe
-        id: locate
-        shell: pwsh
-        run: |
-          $candidates = @(
-            'C:\Program Files\vvvv\vvvv_gamma_7.0-win-x64\vvvvc.exe',
-            'C:\Program Files\vvvv\vvvv gamma\vvvvc.exe',
-            'C:\Program Files\vvvv\vvvv\vvvvc.exe',
-            'C:\Program Files\vvvv gamma\vvvvc.exe',
-            'C:\Program Files (x86)\vvvv\vvvv gamma\vvvvc.exe',
-            'C:\Program Files (x86)\vvvv\vvvv\vvvvc.exe',
-            'C:\Program Files (x86)\vvvv gamma\vvvvc.exe'
-          )
-
-          if (Test-Path 'C:\Program Files\vvvv') {
-            $candidates += Get-ChildItem 'C:\Program Files\vvvv' -Directory -ErrorAction SilentlyContinue |
-              Where-Object { $_.Name -like 'vvvv_gamma_*' } |
-              ForEach-Object { Join-Path $_.FullName 'vvvvc.exe' }
-          }
-
-          $found = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $found) {
-            $searchRoots = @(
-              'C:\Program Files',
-              'C:\Program Files (x86)',
-              "$env:LOCALAPPDATA\Programs"
-            ) | Where-Object { Test-Path $_ }
-
-            foreach ($root in $searchRoots) {
-              $found = Get-ChildItem $root -Filter vvvvc.exe -File -Recurse -ErrorAction SilentlyContinue |
-                Select-Object -ExpandProperty FullName -First 1
-              if ($found) { break }
-            }
-          }
-
-          if (-not $found) {
-            throw 'vvvvc.exe not found after install'
-          }
-
-          "vvvvc=$found" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Export Schema variants
-        shell: pwsh
-        run: |
-          function Set-MsBuildPropertyValue([string]$propsPath, [string]$propertyName, [string]$value) {
-            $content = Get-Content -LiteralPath $propsPath -Raw
-            $pattern = "(<$propertyName>)(.*?)(</$propertyName>)"
-            $updated = [regex]::Replace($content, $pattern, "`${1}$value`${3}")
-            if ($updated -eq $content) {
-              throw "Could not update property '$propertyName' in $propsPath"
-            }
-            Set-Content -LiteralPath $propsPath -Value $updated
-          }
-
-          function Remove-BuildOnlyFolders([string]$outputDir) {
-            $srcPath = Join-Path $outputDir 'src'
-            if (Test-Path $srcPath) {
-              Remove-Item -LiteralPath $srcPath -Recurse -Force
-            }
-          }
-
-          function Invoke-Export([string]$label, [string]$patch, [string]$rid, [string]$outputType, [string]$outputDir) {
-            $common = @(
-              '--verbosity', 'Information',
-              '--output-directory', $outputDir,
-              '--output-type', $outputType,
-              '--rid', $rid,
-              '--clean', 'true'
-            )
-
-            & '${{ steps.locate.outputs.vvvvc }}' @common $patch
-            if ($LASTEXITCODE -ne 0) {
-              Write-Host "First attempt failed for $label; retrying with patch path first."
-              & '${{ steps.locate.outputs.vvvvc }}' $patch @common
-            }
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "vvvvc export failed for $label with exit code $LASTEXITCODE"
-            }
-          }
-
-          function Export-Variant(
-            [string]$label,
-            [string]$patch,
-            [string]$rid,
-            [string]$outputType,
-            [string]$outputDir,
-            [string]$propsPath,
-            [hashtable]$propsOverrides
-          ) {
-            New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
-
-            if ($propsPath -and $propsOverrides.Count -gt 0) {
-              $backup = "$propsPath.bak"
-              Copy-Item -LiteralPath $propsPath -Destination $backup -Force
-              try {
-                foreach ($entry in $propsOverrides.GetEnumerator()) {
-                  Set-MsBuildPropertyValue -propsPath $propsPath -propertyName $entry.Key -value $entry.Value
-                }
-                Invoke-Export -label $label -patch $patch -rid $rid -outputType $outputType -outputDir $outputDir
-              }
-              finally {
-                Move-Item -LiteralPath $backup -Destination $propsPath -Force
-              }
-            }
-            else {
-              Invoke-Export -label $label -patch $patch -rid $rid -outputType $outputType -outputDir $outputDir
-            }
-
-            Remove-BuildOnlyFolders -outputDir $outputDir
-          }
-
-          $studioPatch = '${{ steps.resolve.outputs.studio_patch }}'
-          $litePatch = '${{ steps.resolve.outputs.lite_patch }}'
-          $liteProps = [System.IO.Path]::ChangeExtension($litePatch, '.props')
-
-          Export-Variant -label 'Schema_Studio win-x64' -patch $studioPatch -rid 'win-x64' -outputType 'WinExe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-studio-win-x64') -propsPath '' -propsOverrides @{}
-          Export-Variant -label 'Schema_Lite win-x64' -patch $litePatch -rid 'win-x64' -outputType 'Exe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-lite-win-x64') -propsPath $liteProps -propsOverrides @{ VLTargetOS = 'Windows' }
-          Export-Variant -label 'Schema_Lite linux-arm64' -patch $litePatch -rid 'linux-arm64' -outputType 'Exe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-lite-linux-arm64') -propsPath '' -propsOverrides @{}
-
-      - name: Package release zips
-        id: package
-        shell: pwsh
-        run: |
-          $tag = '${{ github.ref_name }}'
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and -not [string]::IsNullOrWhiteSpace('${{ inputs.tag }}')) {
-            $tag = '${{ inputs.tag }}'
-          }
-
-          if ([string]::IsNullOrWhiteSpace($tag)) {
-            throw 'Could not resolve tag name for release.'
-          }
-
-          $packages = @(
-            @{ Name = "schema-studio-$tag-win-x64.zip"; Source = Join-Path $env:EXPORT_ROOT 'schema-studio-win-x64' },
-            @{ Name = "schema-lite-$tag-win-x64.zip"; Source = Join-Path $env:EXPORT_ROOT 'schema-lite-win-x64' },
-            @{ Name = "schema-lite-$tag-linux-arm64.zip"; Source = Join-Path $env:EXPORT_ROOT 'schema-lite-linux-arm64' }
-          )
-
-          $zipPaths = @()
-          foreach ($package in $packages) {
-            $zipPath = Join-Path $env:GITHUB_WORKSPACE $package.Name
-            if (Test-Path $zipPath) {
-              Remove-Item -LiteralPath $zipPath -Force
-            }
-            Compress-Archive -Path (Join-Path $package.Source '*') -DestinationPath $zipPath
-            $zipPaths += $zipPath
-          }
-
-          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          $zipPathsJson = $zipPaths | ConvertTo-Json -Compress
-          "zip_paths_json=$zipPathsJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
-      - name: Create or update GitHub release
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          $tag = '${{ steps.package.outputs.tag }}'
-          $zipPaths = ConvertFrom-Json @'
-          ${{ steps.package.outputs.zip_paths_json }}
-          '@
-          if ($zipPaths -isnot [System.Array]) {
-            $zipPaths = @($zipPaths)
-          }
-
-          $exists = gh release view $tag --repo $env:GITHUB_REPOSITORY 2>$null
-          if ($LASTEXITCODE -eq 0) {
-            gh release upload $tag @zipPaths --repo $env:GITHUB_REPOSITORY --clobber
-          }
-          else {
-            gh release create $tag @zipPaths --repo $env:GITHUB_REPOSITORY --title $tag --generate-notes
-          }
-
-      - name: Upload release build artifact (CI)
-        uses: actions/upload-artifact@v6
-        with:
-          name: schema-release-builds
-          path: |
-            dist/**
-            !dist/**/src/**
-
+    uses: ./.github/workflows/schema-shared-export.yml
+    secrets: inherit
+    with:
+      source_ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.source_ref || 'dev') || github.ref_name || 'dev' }}
+      offline_url: ${{ github.event_name == 'workflow_dispatch' && inputs.offline_url || '' }}
+      studio_patch_path: ${{ github.event_name == 'workflow_dispatch' && inputs.studio_patch_path || 'Main/gamma/Schema_Studio.vl' }}
+      lite_patch_path: ${{ github.event_name == 'workflow_dispatch' && inputs.lite_patch_path || 'Main/gamma/Schema_Lite.vl' }}
+      ci_artifact_name: schema-release-builds
+      timeout_minutes: 90
+      create_release: true
+      release_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}

--- a/.github/workflows/schema-shared-export.yml
+++ b/.github/workflows/schema-shared-export.yml
@@ -1,0 +1,330 @@
+name: Schéma shared export
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Git ref to build from (branch, tag, or SHA)
+        required: false
+        default: dev
+        type: string
+      offline_url:
+        description: Optional TeamCity offline installer URL override
+        required: false
+        default: ""
+        type: string
+      studio_patch_path:
+        description: Schema_Studio patch path relative to repo root
+        required: false
+        default: Main/gamma/Schema_Studio.vl
+        type: string
+      lite_patch_path:
+        description: Schema_Lite patch path relative to repo root
+        required: false
+        default: Main/gamma/Schema_Lite.vl
+        type: string
+      ci_artifact_name:
+        description: Name for uploaded CI artifact
+        required: false
+        default: schema-exports
+        type: string
+      timeout_minutes:
+        description: Workflow timeout in minutes
+        required: false
+        default: 75
+        type: number
+      create_release:
+        description: Whether to package and publish a GitHub release
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: Tag name for release upload/create
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  export:
+    runs-on: windows-latest
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    env:
+      VVVV_OFFLINE_URL_DEFAULT: https://teamcity.vvvv.org/guestAuth/app/rest/builds/id:39385/artifacts/content/vvvv_gamma_7.0-win-x64_setup_offline.exe
+      VVVV_INSTALLER: ${{ github.workspace }}\vvvv_setup_offline.exe
+      EXPORT_ROOT: ${{ github.workspace }}\dist
+      SOURCE_ROOT: ${{ github.workspace }}\source
+
+    steps:
+      - name: Checkout workflow repository
+        uses: actions/checkout@v5
+
+      - name: Checkout source ref
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_ref }}
+          path: source
+
+      - name: Resolve inputs
+        id: resolve
+        shell: pwsh
+        run: |
+          function Resolve-PatchPath([string]$inputValue, [string]$defaultValue) {
+            if ([string]::IsNullOrWhiteSpace($inputValue)) {
+              return (Join-Path $env:SOURCE_ROOT $defaultValue)
+            }
+            return (Join-Path $env:SOURCE_ROOT $inputValue)
+          }
+
+          $offlineUrl = '${{ inputs.offline_url }}'
+          if ([string]::IsNullOrWhiteSpace($offlineUrl)) {
+            $offlineUrl = $env:VVVV_OFFLINE_URL_DEFAULT
+          }
+
+          $studioPatch = Resolve-PatchPath '${{ inputs.studio_patch_path }}' 'Main\gamma\Schema_Studio.vl'
+          $litePatch = Resolve-PatchPath '${{ inputs.lite_patch_path }}' 'Main\gamma\Schema_Lite.vl'
+
+          foreach ($path in @($studioPatch, $litePatch)) {
+            if (-not (Test-Path $path)) {
+              throw "Patch path does not exist: $path"
+            }
+          }
+
+          "offline_url=$offlineUrl" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "studio_patch=$studioPatch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "lite_patch=$litePatch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Download offline installer
+        id: download
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          $duration = (Measure-Command {
+            Invoke-WebRequest -Uri '${{ steps.resolve.outputs.offline_url }}' -OutFile $env:VVVV_INSTALLER
+          }).TotalSeconds
+          Get-Item $env:VVVV_INSTALLER | Format-List FullName,Length,LastWriteTime
+          "seconds=$([math]::Round($duration, 2))" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Install vvvv gamma silently
+        id: install
+        shell: pwsh
+        run: |
+          $duration = (Measure-Command {
+            $script:p = Start-Process -FilePath $env:VVVV_INSTALLER -ArgumentList '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART' -Wait -PassThru
+          }).TotalSeconds
+          $p = $script:p
+          if ($p.ExitCode -ne 0) {
+            throw "Installer failed with exit code $($p.ExitCode)"
+          }
+          Write-Host "Installer exit code: $($p.ExitCode)"
+          "seconds=$([math]::Round($duration, 2))" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Locate vvvvc.exe
+        id: locate
+        shell: pwsh
+        run: |
+          $candidates = @(
+            'C:\Program Files\vvvv\vvvv_gamma_7.0-win-x64\vvvvc.exe',
+            'C:\Program Files\vvvv\vvvv gamma\vvvvc.exe',
+            'C:\Program Files\vvvv\vvvv\vvvvc.exe',
+            'C:\Program Files\vvvv gamma\vvvvc.exe',
+            'C:\Program Files (x86)\vvvv\vvvv gamma\vvvvc.exe',
+            'C:\Program Files (x86)\vvvv\vvvv\vvvvc.exe',
+            'C:\Program Files (x86)\vvvv gamma\vvvvc.exe'
+          )
+
+          if (Test-Path 'C:\Program Files\vvvv') {
+            $candidates += Get-ChildItem 'C:\Program Files\vvvv' -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.Name -like 'vvvv_gamma_*' } |
+              ForEach-Object { Join-Path $_.FullName 'vvvvc.exe' }
+          }
+
+          $found = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $found) {
+            $searchRoots = @(
+              'C:\Program Files',
+              'C:\Program Files (x86)',
+              "$env:LOCALAPPDATA\Programs"
+            ) | Where-Object { Test-Path $_ }
+
+            foreach ($root in $searchRoots) {
+              $found = Get-ChildItem $root -Filter vvvvc.exe -File -Recurse -ErrorAction SilentlyContinue |
+                Select-Object -ExpandProperty FullName -First 1
+              if ($found) { break }
+            }
+          }
+
+          if (-not $found) {
+            throw 'vvvvc.exe not found after install'
+          }
+
+          Write-Host "Found vvvvc.exe at: $found"
+          "vvvvc=$found" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Install VL dependencies
+        shell: pwsh
+        run: |
+          $nugetPath = Join-Path (Split-Path -Parent '${{ steps.locate.outputs.vvvvc }}') 'tools\NuGet.exe'
+          if (Test-Path -LiteralPath $nugetPath) {
+            $env:VVVV_NUGET_PATH = $nugetPath
+            Write-Host "Using workflow-resolved NuGet path: $nugetPath"
+          }
+          else {
+            Write-Host "NuGet.exe not found next to vvvvc.exe, falling back to automatic discovery."
+          }
+
+          & "$env:GITHUB_WORKSPACE\Main\installDependencies.ps1" -SearchRoot "$env:SOURCE_ROOT\Main"
+
+      - name: Export Schéma variants
+        id: export
+        shell: pwsh
+        run: |
+          function Set-MsBuildPropertyValue([string]$propsPath, [string]$propertyName, [string]$value) {
+            $content = Get-Content -LiteralPath $propsPath -Raw
+            $pattern = "(<$propertyName>)(.*?)(</$propertyName>)"
+            $updated = [regex]::Replace($content, $pattern, "`${1}$value`${3}")
+            if ($updated -eq $content) {
+              throw "Could not update property '$propertyName' in $propsPath"
+            }
+            Set-Content -LiteralPath $propsPath -Value $updated
+          }
+
+          function Remove-BuildOnlyFolders([string]$outputDir) {
+            $srcPath = Join-Path $outputDir 'src'
+            if (Test-Path $srcPath) {
+              Remove-Item -LiteralPath $srcPath -Recurse -Force
+            }
+          }
+
+          function Invoke-Export([string]$label, [string]$patch, [string]$rid, [string]$outputType, [string]$outputDir) {
+            $common = @(
+              '--verbosity', 'Information',
+              '--output-directory', $outputDir,
+              '--output-type', $outputType,
+              '--rid', $rid,
+              '--clean', 'true'
+            )
+
+            & '${{ steps.locate.outputs.vvvvc }}' @common $patch
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "First attempt failed for $label; retrying with patch path first."
+              & '${{ steps.locate.outputs.vvvvc }}' $patch @common
+            }
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "vvvvc export failed for $label with exit code $LASTEXITCODE"
+            }
+          }
+
+          function Export-Variant(
+            [string]$label,
+            [string]$patch,
+            [string]$rid,
+            [string]$outputType,
+            [string]$outputDir,
+            [string]$propsPath,
+            [hashtable]$propsOverrides
+          ) {
+            New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+
+            if ($propsPath -and $propsOverrides.Count -gt 0) {
+              $backup = "$propsPath.bak"
+              Copy-Item -LiteralPath $propsPath -Destination $backup -Force
+              try {
+                foreach ($entry in $propsOverrides.GetEnumerator()) {
+                  Set-MsBuildPropertyValue -propsPath $propsPath -propertyName $entry.Key -value $entry.Value
+                }
+                Invoke-Export -label $label -patch $patch -rid $rid -outputType $outputType -outputDir $outputDir
+              }
+              finally {
+                Move-Item -LiteralPath $backup -Destination $propsPath -Force
+              }
+            }
+            else {
+              Invoke-Export -label $label -patch $patch -rid $rid -outputType $outputType -outputDir $outputDir
+            }
+
+            Remove-BuildOnlyFolders -outputDir $outputDir
+          }
+
+          $studioPatch = '${{ steps.resolve.outputs.studio_patch }}'
+          $litePatch = '${{ steps.resolve.outputs.lite_patch }}'
+          $liteProps = [System.IO.Path]::ChangeExtension($litePatch, '.props')
+          Export-Variant -label 'Schema_Studio win-x64' -patch $studioPatch -rid 'win-x64' -outputType 'WinExe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-studio-win-x64') -propsPath '' -propsOverrides @{}
+          Export-Variant -label 'Schema_Lite win-x64' -patch $litePatch -rid 'win-x64' -outputType 'Exe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-lite-win-x64') -propsPath $liteProps -propsOverrides @{ VLTargetOS = 'Windows'; TargetFramework = 'net8.0-windows7.0' }
+          Export-Variant -label 'Schema_Lite linux-arm64' -patch $litePatch -rid 'linux-arm64' -outputType 'Exe' -outputDir (Join-Path $env:EXPORT_ROOT 'schema-lite-linux-arm64') -propsPath '' -propsOverrides @{}
+
+      - name: Package release zips
+        if: ${{ inputs.create_release }}
+        id: package
+        shell: pwsh
+        run: |
+          $tag = '${{ inputs.release_tag }}'
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw 'Could not resolve tag name for release.'
+          }
+
+          $packages = @(
+            @{ Name = "schema-studio-$tag-win-x64.zip"; Source = Join-Path $env:EXPORT_ROOT 'schema-studio-win-x64' },
+            @{ Name = "schema-lite-$tag-win-x64.zip"; Source = Join-Path $env:EXPORT_ROOT 'schema-lite-win-x64' },
+            @{ Name = "schema-lite-$tag-linux-arm64.zip"; Source = Join-Path $env:EXPORT_ROOT 'schema-lite-linux-arm64' }
+          )
+
+          $zipPaths = @()
+          foreach ($package in $packages) {
+            $zipPath = Join-Path $env:GITHUB_WORKSPACE $package.Name
+            if (Test-Path $zipPath) {
+              Remove-Item -LiteralPath $zipPath -Force
+            }
+            Compress-Archive -Path (Join-Path $package.Source '*') -DestinationPath $zipPath
+            $zipPaths += $zipPath
+          }
+
+          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $zipPathsJson = $zipPaths | ConvertTo-Json -Compress
+          "zip_paths_json=$zipPathsJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Create or update GitHub release
+        if: ${{ inputs.create_release }}
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = '${{ steps.package.outputs.tag }}'
+          $zipPaths = ConvertFrom-Json @'
+          ${{ steps.package.outputs.zip_paths_json }}
+          '@
+          if ($zipPaths -isnot [System.Array]) {
+            $zipPaths = @($zipPaths)
+          }
+
+          $exists = gh release view $tag --repo $env:GITHUB_REPOSITORY 2>$null
+          if ($LASTEXITCODE -eq 0) {
+            gh release upload $tag @zipPaths --repo $env:GITHUB_REPOSITORY --clobber
+          }
+          else {
+            gh release create $tag @zipPaths --repo $env:GITHUB_REPOSITORY --title $tag --generate-notes
+          }
+
+      - name: Show export directory
+        shell: pwsh
+        run: |
+          Get-ChildItem $env:EXPORT_ROOT -Recurse | Select-Object FullName,Length
+
+      - name: Upload export artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs.ci_artifact_name }}
+          path: |
+            dist/**
+            !dist/**/src/**
+
+      - name: Timing summary
+        shell: pwsh
+        run: |
+          @"
+          ### vvvv CI timing
+          - Download installer: ${{ steps.download.outputs.seconds }}s
+          - Silent install: ${{ steps.install.outputs.seconds }}s
+          - Source ref: ${{ inputs.source_ref }}
+          - Exports: Schema_Studio win-x64, Schema_Lite win-x64, Schema_Lite linux-arm64
+          "@ | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/Main/installDependencies.ps1
+++ b/Main/installDependencies.ps1
@@ -1,3 +1,16 @@
+param(
+    [string]$SearchRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$NugetDirectory = (Join-Path -Path $env:USERPROFILE -ChildPath "AppData\Local\vvvv\gamma\nugets"),
+    [string]$NugetPath = "",
+    [string[]]$Sources = @(
+        "https://teamcity.vvvv.org/guestAuth/app/nuget/v1/FeedService.svc/",
+        "https://api.nuget.org/v3/index.json"
+    )
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
 # Define the list of locations to ignore
 $ignoreList = @(
     "SharpDX.Mathematics",
@@ -19,64 +32,101 @@ $ignoreList = @(
     "VL.Video.MediaFoundation"
 )
 
-# The NuGet commands directory
-$nugetDirectory = Join-Path -Path $env:USERPROFILE -ChildPath "AppData\Local\vvvv\gamma\nugets"
+function Get-VvvvNugetPath {
+    param([string]$PreferredPath)
 
-# NuGet executable path
-$nugetPath = "C:\Program Files\vvvv\vvvv_gamma_6.7\tools\NuGet.exe"
+    if (-not [string]::IsNullOrWhiteSpace($PreferredPath) -and (Test-Path -LiteralPath $PreferredPath)) {
+        return (Resolve-Path -LiteralPath $PreferredPath).Path
+    }
 
-# Ensure NuGet executable exists
-if (-not (Test-Path -Path $nugetPath)) {
-    Write-Error "NuGet executable not found at $nugetPath. Please ensure it is installed correctly."
-    exit
+    if (-not [string]::IsNullOrWhiteSpace($env:VVVV_NUGET_PATH) -and (Test-Path -LiteralPath $env:VVVV_NUGET_PATH)) {
+        return (Resolve-Path -LiteralPath $env:VVVV_NUGET_PATH).Path
+    }
+
+    $candidates = @()
+    foreach ($root in @('C:\Program Files\vvvv', 'C:\Program Files (x86)\vvvv')) {
+        if (Test-Path -LiteralPath $root) {
+            $candidates += Get-ChildItem -LiteralPath $root -Filter NuGet.exe -File -Recurse -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match '\\tools\\NuGet\.exe$' }
+        }
+    }
+
+    $best = $candidates |
+        Sort-Object -Property LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+
+    if ($best) {
+        return $best.FullName
+    }
+
+    throw "NuGet executable not found. Set -NugetPath or VVVV_NUGET_PATH."
 }
 
-# Initialize a hashtable to hold the highest version for each package
-$highestVersions = @{}
-
 # Function to parse and return a comparable version object
-function Parse-Version($versionString) {
-    $match = [regex]::Match($versionString, '^\d+(\.\d+){0,3}')
+function Parse-Version {
+    param([string]$VersionString)
+    $match = [regex]::Match($VersionString, '^\d+(\.\d+){0,3}')
     if ($match.Success) {
         try {
             return [System.Version]$match.Value
-        } catch {
+        }
+        catch {
             return $null
         }
     }
     return $null
 }
 
-# Find all .vl files in the current directory and subdirectories
-$files = Get-ChildItem -Path . -Filter *.vl -Recurse
+$nugetPathResolved = Get-VvvvNugetPath -PreferredPath $NugetPath
+Write-Host "Using NuGet: $nugetPathResolved"
+Write-Host "Dependency scan root: $SearchRoot"
+Write-Host "NuGet output directory: $NugetDirectory"
+Write-Host "NuGet sources: $($Sources -join '; ')"
+
+New-Item -ItemType Directory -Force -Path $NugetDirectory | Out-Null
+
+# Initialize a hashtable to hold the highest version for each package
+$highestVersions = @{}
+
+# Find all .vl files in the requested directory and subdirectories
+$files = Get-ChildItem -Path $SearchRoot -Filter *.vl -Recurse -File
 
 foreach ($file in $files) {
-    # Read the contents of the file
-    $content = Get-Content $file.FullName
-    
-    # Find lines that match the NugetDependency pattern
-    $dependencies = $content | Select-String -Pattern '<NugetDependency Id=".*" Location="(?<Location>.*)" Version="(?<Version>.*)" />' -AllMatches
-    
-    foreach ($dependency in $dependencies.Matches) {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    $dependencies = [regex]::Matches($content, '<NugetDependency Id=".*?" Location="(?<Location>.*?)" Version="(?<Version>.*?)" />')
+
+    foreach ($dependency in $dependencies) {
         $location = $dependency.Groups["Location"].Value
         $versionString = $dependency.Groups["Version"].Value
-        $version = Parse-Version $versionString
-        
+        $version = Parse-Version -VersionString $versionString
+
         # Skip if version could not be parsed
         if ($null -eq $version) { continue }
-        
+
         # Check if the location is in the ignore list
         if ($location -notin $ignoreList) {
             # Update the hashtable with the highest version found for each package
-            if (-not $highestVersions.ContainsKey($location) -or (Parse-Version $highestVersions[$location]) -lt $version) {
+            if (-not $highestVersions.ContainsKey($location) -or (Parse-Version -VersionString $highestVersions[$location]) -lt $version) {
                 $highestVersions[$location] = $versionString
             }
         }
     }
 }
 
+Write-Host "Resolved package count: $($highestVersions.Count)"
+
 # Install the highest version found for each package
-foreach ($package in $highestVersions.GetEnumerator()) {
-    $nugetCommand = "& `"$nugetPath`" install $($package.Name) -Version $($package.Value) -OutputDirectory `"$nugetDirectory`""
-    Invoke-Expression $nugetCommand
+$failedPackages = @()
+foreach ($package in $highestVersions.GetEnumerator() | Sort-Object Name) {
+    Write-Host "Installing $($package.Name) $($package.Value)"
+    & $nugetPathResolved install $package.Name -Version $package.Value -OutputDirectory $NugetDirectory -Source ($Sources -join ';') -Prerelease -NonInteractive
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "NuGet install failed for $($package.Name) $($package.Value) with exit code $LASTEXITCODE. Continuing."
+        $failedPackages += "$($package.Name) $($package.Value)"
+    }
+}
+
+if ($failedPackages.Count -gt 0) {
+    Write-Warning "Some packages could not be pre-installed:"
+    $failedPackages | ForEach-Object { Write-Warning " - $_" }
 }


### PR DESCRIPTION
## Summary
This PR consolidates and modernizes Schéma CI/release workflows compared to current `dev`, and updates dependency restore to make CI builds reproducible across Schéma variants.

## What changed (since `dev`)
### Workflows
- Replaced duplicated workflow logic with a shared reusable workflow:
  - Added `.github/workflows/schema-shared-export.yml` as the common implementation.
  - Kept thin entry workflows:
    - `.github/workflows/schema-build.yml`
    - `.github/workflows/schema-release.yml`
- Standardized workflow naming to Schéma.
- Added/kept multi-target export coverage in CI:
  - `Schema_Studio` for `win-x64`
  - `Schema_Lite` for `win-x64`
  - `Schema_Lite` for `linux-arm64`
- Ensured Linux export is required (not optional) and release packaging includes the linux-arm64 artifact.

### Trigger/ref behavior
- Removed fixed source-branch coupling to `feat/optimizations`.
- Updated defaults to `dev` for manual dispatch.
- Updated build checks to validate feature-branch PRs targeting `dev`.
- Source ref resolution now uses:
  - PR head ref for `pull_request`
  - `github.ref_name` for push/tag flows
  - `dev` as fallback/default for dispatch

### Dependency restore
- Updated `Main/installDependencies.ps1` to better support CI restore with current vvvv/NuGet behavior:
  - support for vvvv feed configuration and prerelease restore where needed
  - improved package source handling/discovery for CI environments
  - more resilient install flow for dependency preinstall edge cases

## Why
- Existing workflow files had large overlap and were harder to maintain.
- Fixed branch assumptions caused stale or incorrect sources to be built after merges.
- CI needed to validate the actual code under review for feature-branch PRs.
- Recent vvvv versions required dependency-restore adjustments to keep exports reliable.

## Important implementation details
- The reusable workflow performs separate checkout for workflow repo and `source_ref` under `source/`.
- Export logic updates/uses patch props for target-specific Lite build settings.
- Release workflow reuses the same export implementation and packages all expected artifacts.

## Validation
- Manual Schéma build dispatch succeeded after these updates: run `24799464157`.
- Prior runs on this branch validated end-to-end export behavior while iterating dependency and workflow fixes.

This PR was written using [Vibe Kanban](https://vibekanban.com)